### PR TITLE
nginx: remove OPTIONS requests from logs.

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -29,6 +29,11 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
+    map "$request:$status:$body_bytes_sent" $loggable {
+        "OPTIONS / HTTP/1.0:200:0" 0;
+        default 1;
+    }
+
     # Standard log format
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
@@ -42,7 +47,7 @@ http {
                  '$msec $request_time '
                  '$upstream_http_x_session_id $upstream_http_x_user_id';
 
-    access_log  /var/log/nginx/access.log  trace;
+    access_log  /var/log/nginx/access.log  main if=$loggable;
 
     sendfile        on;
     tcp_nopush      on;


### PR DESCRIPTION
* Avoids log OPTIONS requests in access logs.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>