### PR TITLE
documents: import specific collections

### DIFF
--- a/sonar/config.py
+++ b/sonar/config.py
@@ -370,13 +370,15 @@ RECORDS_REST_ENDPOINTS = {
 
 RECORDS_REST_FACETS = {
     'documents':
-    dict(aggs=dict(institution=dict(terms=dict(field='institution.pid')),
-                   language=dict(terms=dict(field='language.value')),
-                   author__en=dict(terms=dict(field='facet_authors_en')),
-                   author__fr=dict(terms=dict(field='facet_authors_fr')),
-                   author__de=dict(terms=dict(field='facet_authors_de')),
-                   author__it=dict(terms=dict(field='facet_authors_it')),
-                   subject=dict(terms=dict(field='facet_subjects'))),
+    dict(aggs=dict(
+        institution=dict(terms=dict(field='institution.pid')),
+        language=dict(terms=dict(field='language.value')),
+        author__en=dict(terms=dict(field='facet_authors_en')),
+        author__fr=dict(terms=dict(field='facet_authors_fr')),
+        author__de=dict(terms=dict(field='facet_authors_de')),
+        author__it=dict(terms=dict(field='facet_authors_it')),
+        subject=dict(terms=dict(field='facet_subjects')),
+        specific_collections=dict(terms=dict(field='specificCollections'))),
          filters={
              _('institution'): terms_filter('institution.pid'),
              _('language'): terms_filter('language.value'),
@@ -385,6 +387,7 @@ RECORDS_REST_FACETS = {
              _('author__de'): terms_filter('facet_authors_de'),
              _('author__it'): terms_filter('facet_authors_it'),
              _('subject'): terms_filter('facet_subjects'),
+             _('specific_collections'): terms_filter('specificCollections'),
          }),
     'deposits':
     dict(aggs=dict(status=dict(terms=dict(field='status')),

--- a/sonar/modules/documents/dojson/contrib/marc21tojson/model.py
+++ b/sonar/modules/documents/dojson/contrib/marc21tojson/model.py
@@ -867,3 +867,11 @@ def marc21_to_other_edition(self, key, value):
         },
         'publicNote': public_note
     }
+
+
+@marc21tojson.over('specificCollections', '^982..')
+@utils.for_each_value
+@utils.ignore_value
+def marc21_to_specific_collection(self, key, value):
+    """Extract collection for record."""
+    return value.get('a')

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -1015,7 +1015,11 @@
             "title": "Type",
             "description": "Type of the file",
             "type": "string",
-            "enum": ["file", "fulltext", "thumbnail"],
+            "enum": [
+              "file",
+              "fulltext",
+              "thumbnail"
+            ],
             "default": "file",
             "minLength": 1
           },
@@ -1110,7 +1114,10 @@
             "minItems": 1,
             "items": {
               "type": "object",
-              "required": ["value", "language"],
+              "required": [
+                "value",
+                "language"
+              ],
               "additionalProperties": false,
               "properties": {
                 "value": {
@@ -1133,7 +1140,10 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["value", "language"],
+              "required": [
+                "value",
+                "language"
+              ],
               "additionalProperties": false,
               "properties": {
                 "value": {
@@ -1494,7 +1504,10 @@
       "items": {
         "title": "Abstract item",
         "type": "object",
-        "required": ["value", "language"],
+        "required": [
+          "value",
+          "language"
+        ],
         "additionalProperties": false,
         "properties": {
           "value": {
@@ -1670,13 +1683,18 @@
       "minItems": 1,
       "items": {
         "type": "object",
-        "required": ["document", "publicNote"],
+        "required": [
+          "document",
+          "publicNote"
+        ],
         "additionalProperties": false,
         "properties": {
           "document": {
             "title": "Document",
             "type": "object",
-            "required": ["electronicLocator"],
+            "required": [
+              "electronicLocator"
+            ],
             "additionalProperties": false,
             "properties": {
               "electronicLocator": {
@@ -1692,6 +1710,15 @@
             "minLength": 1
           }
         }
+      }
+    },
+    "specificCollections": {
+      "title": "Collection",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
       }
     }
   }

--- a/sonar/modules/documents/mappings/v6/documents/document-v1.0.0.json
+++ b/sonar/modules/documents/mappings/v6/documents/document-v1.0.0.json
@@ -26,7 +26,9 @@
   "mappings": {
     "document-v1.0.0": {
       "_source": {
-        "excludes": ["fulltext"]
+        "excludes": [
+          "fulltext"
+        ]
       },
       "date_detection": false,
       "numeric_detection": false,
@@ -378,6 +380,9 @@
               "type": "text"
             }
           }
+        },
+        "specificCollections": {
+          "type": "keyword"
         }
       }
     }

--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -60,6 +60,11 @@
 <section class="mt-3">
   <article class="">
     <dl class="row mb-0">
+      <!-- COLLECTION SPECIFIQUE -->
+      {% if record.specificCollections %}
+      {{ dl_list(_('Specific collections'), record.specificCollections) }}
+      {% endif %}
+
       <!-- AUTHORS -->
       {% if record.authors %}
       {{ dl(_('Authors'), record.pid|authors_format(current_i18n.language, viewcode)) }}

--- a/tests/ui/documents/test_marc21tojson.py
+++ b/tests/ui/documents/test_marc21tojson.py
@@ -2426,3 +2426,54 @@ def test_marc21_to_other_edition():
     marc21json = create_record(marc21xml)
     data = marc21tojson.do(marc21json)
     assert not data.get('otherEdition')
+
+
+def test_marc21_to_specific_collection():
+    """Test extracting collection from file 982."""
+    # Extract collection OK
+    marc21xml = """
+    <record>
+        <datafield tag="982" ind1=" " ind2=" ">
+            <subfield code="a">Treize étoiles</subfield>
+        </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21tojson.do(marc21json)
+    assert data.get('specificCollections') == ['Treize étoiles']
+
+    # Multiple collections
+    marc21xml = """
+    <record>
+        <datafield tag="982" ind1=" " ind2=" ">
+            <subfield code="a">Collection 1</subfield>
+        </datafield>
+        <datafield tag="982" ind1=" " ind2=" ">
+            <subfield code="a">Collection 2</subfield>
+        </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21tojson.do(marc21json)
+    assert data.get('specificCollections') == ['Collection 1', 'Collection 2']
+
+    # No code a
+    marc21xml = """
+    <record>
+        <datafield tag="982" ind1=" " ind2=" ">
+            <subfield code="b">Treize étoiles</subfield>
+        </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21tojson.do(marc21json)
+    assert not data.get('specificCollections')
+
+    # Not field 982
+    marc21xml = """
+    <record>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21tojson.do(marc21json)
+    assert not data.get('specificCollections')


### PR DESCRIPTION
* Extracts and imports collections from field 982 and store them in a "specificCollections" property.
* Shows facets for collections.
* Displays collections in detailed view.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>