### PR TITLE
documents: update subjects

### DIFF
--- a/sonar/modules/documents/dojson/contrib/marc21tojson/model.py
+++ b/sonar/modules/documents/dojson/contrib/marc21tojson/model.py
@@ -791,19 +791,32 @@ def marc21_to_is_part_of(self, key, value):
         return not_repetitive(marc21tojson.bib_id, key, value, 't')
 
 
-@marc21tojson.over('subjects', '^695..')
+@marc21tojson.over('subjects', '^600..|695..')
 @utils.for_each_value
 @utils.ignore_value
 def marc21_to_subjects(self, key, value):
-    """Get subjects.
+    """Get subjects."""
+    subjects = {
+        'label': {
+            'value': value.get('a').split(' ; ')
+        }
+    }
 
-    subjects: 6xx [duplicates could exist between several vocabularies,
-        if possible deduplicate]
-    """
-    if not value.get('9'):
-        return None
+    # If field is 695 and no language is available
+    if key == '695__':
+        if not value.get('9'):
+            return None
 
-    return dict(language=value.get('9'), value=value.get('a').split(' ; '))
+        subjects['label']['language'] = value.get('9')
+
+    # If field is 600 and no source is available
+    if key == '600__':
+        if not value.get('2'):
+            return None
+
+        subjects['source'] = value.get('2')
+
+    return subjects
 
 
 @marc21tojson.over('files', '^856..')

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -1611,34 +1611,42 @@
     },
     "subjects": {
       "title": "Subject",
-      "description": "Subject of the resource.",
       "type": "array",
-      "additionalProperties": false,
       "items": {
         "type": "object",
+        "required": ["label"],
         "additionalProperties": false,
-        "required": [
-          "language",
-          "value"
-        ],
         "properties": {
-          "language": {
-            "title": "Subject language",
-            "description": "Language of subject.",
-            "type": "string",
-            "$ref": "#/definitions/language",
-            "minLength": 1
-          },
-          "value": {
-            "title": "Subjects list",
-            "description": "A list of subjects.",
-            "type": "array",
-            "minLength": 1,
-            "items": {
-              "type": "string",
-              "title": "Subject",
-              "minLength": 1
+          "label": {
+            "title": "Label",
+            "type": "object",
+            "required": ["value"],
+            "additionalProperties": false,
+            "properties": {
+              "language": {
+                "title": "Language",
+                "$ref": "#/definitions/language",
+                "type": "string",
+                "minLength": 1
+              },
+              "value": {
+                "title": "Value",
+                "description": "A list of keywords.",
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "title": "Subject",
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
             }
+          },
+          "source": {
+            "title": "Source",
+            "description": "Source of heading or term.",
+            "type": "string",
+            "minLength": 1
           }
         }
       }

--- a/sonar/modules/documents/mappings/v6/documents/document-v1.0.0.json
+++ b/sonar/modules/documents/mappings/v6/documents/document-v1.0.0.json
@@ -347,9 +347,20 @@
         "subjects": {
           "type": "object",
           "properties": {
-            "value": {
-              "type": "text",
-              "copy_to": "facet_subjects"
+            "label": {
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "text",
+                  "copy_to": "facet_subjects"
+                },
+                "language": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "source": {
+              "type": "keyword"
             }
           }
         },

--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -114,7 +114,21 @@
 
       <!-- SUBJECTS -->
       {% if record.subjects|length > 0 %}
-      {{ dl(_('Subjects'), record.subjects|subjects_format|nl2br) }}
+      <dt class="col-sm-2">
+        {{ _('Subjects') }}:
+      </dt>
+      <dd class="col-sm-10">
+        <ul class="list-unstyled mb-0">
+          {% for subject in record.subjects|subjects_format(current_i18n.language) %}
+          <li>
+            {{ subject.value }}
+            {% if subject.source %}
+            <small class="badge badge-secondary text-uppercase text-light">{{ subject.source }}</small>
+            {% endif %}
+          </li>
+          {% endfor %}
+        </ul>
+      </dd>
       {% endif %}
 
       <!-- NOTES -->

--- a/sonar/modules/documents/views.py
+++ b/sonar/modules/documents/views.py
@@ -185,12 +185,31 @@ def abstracts_format(abstracts):
 
 
 @blueprint.app_template_filter()
-def subjects_format(subjects):
-    """Format subjects for template."""
-    output = []
+def subjects_format(subjects, language):
+    """Format subjects for template.
+
+    :param subjects: Subject object list.
+    :param language: Current language of the interface.
+    """
+    language = get_bibliographic_code_from_language(language)
+
+    items = []
     for subject in subjects:
-        output.append(' ; '.join(subject['value']))
-    return '\n'.join(str(x) for x in output)
+        item = {}
+
+        # Has source
+        if subject.get('source'):
+            item['source'] = subject['source']
+
+        # Add only subjects for current language or subjects without language
+        if not subject['label'].get(
+                'language') or subject['label']['language'] == language:
+            item['value'] = ' ; '.join(subject['label']['value'])
+
+        if item:
+            items.append(item)
+
+    return items
 
 
 @blueprint.app_template_filter()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -293,8 +293,11 @@ def document_json_fixture(app, db, organization_fixture):
             'value': 'Abstract of the document'
         }],
         'subjects': [{
-            'language': 'eng',
-            'value': ['Time series models', 'GARCH models']
+            'label': {
+                'language': 'eng',
+                'value': ['Time series models', 'GARCH models']
+            },
+            'source': 'RERO'
         }],
         'provisionActivity': [{
             'type':

--- a/tests/ui/documents/test_documents_views.py
+++ b/tests/ui/documents/test_documents_views.py
@@ -134,8 +134,35 @@ def test_abstracts_format():
 
 def test_subjects_format(document_fixture):
     """Test subjects format."""
-    assert views.subjects_format(
-        document_fixture['subjects']) == 'Time series models ; GARCH models'
+    subjects = [{
+        'label': {
+            'value': ['subject 1', 'subject 2'],
+            'language': 'eng'
+        }
+    }, {
+        'label': {
+            'value': ['sujet 1', 'sujet 2'],
+            'language': 'fre'
+        }
+    }, {
+        'label': {
+            'value': ['subject with source 1', 'subject with source 2']
+        },
+        'source': 'RERO'
+    }]
+
+    assert views.subjects_format(subjects, 'en') == [{
+        'value':
+        'subject 1 ; subject 2'
+    }, {
+        'value': 'subject with source 1 ; subject with source 2',
+        'source': 'RERO'
+    }]
+
+    assert views.subjects_format(subjects, 'de') == [{
+        'value': 'subject with source 1 ; subject with source 2',
+        'source': 'RERO'
+    }]
 
 
 def test_identifiedby_format():

--- a/tests/ui/documents/test_marc21tojson.py
+++ b/tests/ui/documents/test_marc21tojson.py
@@ -1895,17 +1895,58 @@ def test_marc21_to_subjects():
         <subfield code="9">fre</subfield>
         <subfield code="a">sujet 1 ; sujet 2</subfield>
       </datafield>
+      <datafield tag="600" ind1=" " ind2=" ">
+        <subfield code="2">rero</subfield>
+        <subfield code="a">subject 600 1 ; subject 600 2</subfield>
+      </datafield>
     </record>
     """
     marc21json = create_record(marc21xml)
     data = marc21tojson.do(marc21json)
-    assert data.get('subjects') == [{
-        'language': 'eng',
-        'value': ['subject 1', 'subject 2']
-    }, {
-        'language': 'fre',
-        'value': ['sujet 1', 'sujet 2']
-    }]
+    assert data.get('subjects') == [
+        {
+            'label': {
+                'language': 'eng',
+                'value': ['subject 1', 'subject 2']
+            }
+        },
+        {
+            'label': {
+                'language': 'fre',
+                'value': ['sujet 1', 'sujet 2']
+            }
+        },
+        {
+            'label': {
+                'value': ['subject 600 1', 'subject 600 2']
+            },
+            'source': 'rero'
+        }
+    ]
+
+    # 600 without source
+    marc21xml = """
+    <record>
+      <datafield tag="600" ind1=" " ind2=" ">
+        <subfield code="a">subject 600 1 ; subject 600 2</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21tojson.do(marc21json)
+    assert not data.get('subjects')
+
+    # 695 without language
+    marc21xml = """
+    <record>
+      <datafield tag="695" ind1=" " ind2=" ">
+        <subfield code="a">subject 1 ; subject 2</subfield>
+      </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21tojson.do(marc21json)
+    assert not data.get('subjects')
 
 
 def test_marc21_to_identifiedby_from_020():


### PR DESCRIPTION
* Updates subjects property in JSON schema and elasticsearch mapping.
* Updates dojson transformation for subjects.
* Updates subjects display in document detail view.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>