### PR TITLE
documents: external URLs

### DIFF
--- a/sonar/modules/api.py
+++ b/sonar/modules/api.py
@@ -132,6 +132,7 @@ class SonarRecord(Record, FilesMixin):
 
         for kwargs, see add_file method below.
         """
+        kwargs['url'] = url
         self.add_file(requests.get(url).content, key, **kwargs)
 
     def add_file(self, data, key, **kwargs):
@@ -141,7 +142,7 @@ class SonarRecord(Record, FilesMixin):
         :param str key: File key
 
         kwargs may contain some additional data such as: file label, file type,
-        order.
+        order and url.
         """
         if not current_app.config.get('SONAR_DOCUMENTS_IMPORT_FILES'):
             return
@@ -157,6 +158,10 @@ class SonarRecord(Record, FilesMixin):
         self.files[key]['label'] = kwargs.get('label', key)
         self.files[key]['type'] = kwargs.get('type', 'file')
         self.files[key]['order'] = kwargs.get('order', 1)
+
+        # Store external file URL
+        if kwargs.get('url'):
+            self.files[key]['external_url'] = kwargs['url']
 
         # Create thumbnail
         if current_app.config.get('SONAR_DOCUMENTS_GENERATE_THUMBNAIL'):

--- a/sonar/modules/documents/config.py
+++ b/sonar/modules/documents/config.py
@@ -25,3 +25,6 @@ SONAR_DOCUMENTS_EXTRACT_FULLTEXT_ON_IMPORT = True
 
 SONAR_DOCUMENTS_GENERATE_THUMBNAIL = True
 """Automatically generate a thumbnail when a file is imported."""
+
+SONAR_DOCUMENTS_INSTITUTIONS_EXTERNAL_FILES = ['csal']
+"""Display external files URL for these institutions."""

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -1025,6 +1025,13 @@
             "type": "integer",
             "default": 1,
             "minimum": 1
+          },
+          "external_url": {
+            "title": "URL to file",
+            "description": "URL to file hosted in an external platform.",
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^https?://"
           }
         },
         "required": [

--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -27,13 +27,12 @@
 {% if record.institution %}
 <h5 class="text-secondary">{{ record.institution.name }}</h5>
 {% endif %}
-
 <section class="mt-3">
   <article class="">
     <div class="row">
       {% set main_file = record._files | files_by_type | first %}
       {% if main_file %}
-      {{ thumbnail('documents', record.pid, main_file, record._files, 'col-sm-3') }}
+      {{ thumbnail('documents', record, main_file, 'col-sm-3') }}
       {% endif %}
       <div class="col">
         <dl class="row mb-0">
@@ -150,31 +149,30 @@
     <div class="row">
       {% for file in files %}
       {% if loop.index > 1 %}
-      {{ thumbnail('documents', record.pid, file, record._files, 'col-sm-2') }}
+      {{ thumbnail('documents', record, file, 'col-sm-2 mb-4') }}
       {% endif %}
       {% endfor %}
     </div>
+    {% endif %}
+  </article>
 
-    <!-- Preview modal -->
-    <div class="modal fade" id="previewModal" tabindex="-1" role="dialog" aria-hidden="true">
-      <div class="modal-dialog modal-lg" role="document">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title" id="preview-title">Modal title</h5>
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-              <span aria-hidden="true">&times;</span>
-            </button>
-          </div>
-          <div class="modal-body">
-            <iframe class="preview-iframe" id="preview-iframe" width="100%" height="800" src=""
-              style="border: none;"></iframe>
-          </div>
+  <!-- Preview modal -->
+  <div class="modal fade" id="previewModal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog modal-lg" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="preview-title">Modal title</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <iframe class="preview-iframe" id="preview-iframe" width="100%" height="800" src=""
+            style="border: none;"></iframe>
         </div>
       </div>
     </div>
-
-    {% endif %}
-  </article>
+  </div>
 </section>
 {%- endblock %}
 

--- a/sonar/modules/documents/views.py
+++ b/sonar/modules/documents/views.py
@@ -230,7 +230,7 @@ def file_size(size):
 
     :param size: integer representing the size of the file.
     """
-    return str(round(size/(1024*1024), 2)) + 'Mb'
+    return str(round(size / (1024 * 1024), 2)) + 'Mb'
 
 
 @blueprint.app_template_filter()
@@ -260,6 +260,17 @@ def thumbnail(file, files):
         return None
 
     return matches[0]
+
+
+@blueprint.app_template_filter()
+def has_external_urls_for_files(record):
+    """Check if files point to external website.
+
+    :param record: Current record.
+    """
+    return record.get('institution', {}).get('pid') and record['institution'][
+        'pid'] in current_app.config.get(
+            'SONAR_DOCUMENTS_INSTITUTIONS_EXTERNAL_FILES')
 
 
 def get_language_from_bibliographic_code(language_code):

--- a/sonar/theme/templates/sonar/macros/macro.html
+++ b/sonar/theme/templates/sonar/macros/macro.html
@@ -62,21 +62,35 @@
 {% endif %}
 {% endmacro %}
 
-{% macro thumbnail(resource_type, pid, file, files, class = '') %}
-{% set thumbnail = file | thumbnail(files) %}
+{% macro thumbnail(resource_type, record, file, class = '') %}
+{% set thumbnail = file | thumbnail(record._files) %}
 {% if thumbnail %}
 {% set file_title = file | file_title %}
+{% set externalUrl = record | has_external_urls_for_files %}
 <div class="text-center {{ class }}">
-  <a href="/{{ resource_type }}/{{ pid }}/preview/{{ file.key }}" data-title="{{ file_title }}" class="previewLink">
-    <img src="/{{ resource_type }}/{{ pid }}/files/{{ thumbnail.key }}" class="img-thumbnail img-fluid"
+  {% if externalUrl %}
+  {% if file.external_url %}
+  <a href="{{ file.external_url }}" target="_blank">
+    <img src="/{{ resource_type }}/{{ record.pid }}/files/{{ thumbnail.key }}" class="img-thumbnail img-fluid"
       alt="{{ file_title }}">
   </a>
+  {% endif %}
+  {% else %}
+  <a href="/{{ resource_type }}/{{ record.pid }}/preview/{{ file.key }}" data-title="{{ file_title }}"
+    class="previewLink">
+    <img src="/{{ resource_type }}/{{ record.pid }}/files/{{ thumbnail.key }}" class="img-thumbnail img-fluid"
+      alt="{{ file_title }}">
+  </a>
+  {% endif %}
   <p class="my-1 small">{{ file_title }}</p>
+  {% if not externalUrl %}
   <p class="m-0">
-    <a href="/{{ resource_type }}/{{ pid }}/preview/{{ file.key }}" data-title="{{ file_title }}" class="previewLink"><i
-        class="fa fa-eye mr-2"></i></a>
-    <a href="/{{ resource_type }}/{{ pid }}/files/{{ file.key }}" target="_blank"><i class="fa fa-download"></i></a>
+    <a href="/{{ resource_type }}/{{ record.pid }}/preview/{{ file.key }}" data-title="{{ file_title }}"
+      class="previewLink"><i class="fa fa-eye mr-2"></i></a>
+    <a href="/{{ resource_type }}/{{ record.pid }}/files/{{ file.key }}" target="_blank"><i
+        class="fa fa-download"></i></a>
   </p>
+  {% endif %}
 </div>
 {% endif %}
 {% endmacro %}

--- a/tests/ui/documents/test_documents_views.py
+++ b/tests/ui/documents/test_documents_views.py
@@ -334,3 +334,29 @@ def test_thumbnail():
     }]
 
     assert not views.thumbnail(files[0], files)
+
+
+def test_has_external_urls_for_files(app):
+    """Test if record has to point files to external URL or not."""
+    assert views.has_external_urls_for_files({
+        'pid': 1,
+        'institution': {
+            'pid': 'csal'
+        }
+    })
+
+    assert not views.has_external_urls_for_files({
+        'pid': 1,
+        'institution': {
+            'pid': 'unisi'
+        }
+    })
+
+    assert not views.has_external_urls_for_files({
+        'pid': 1,
+        'institution': {}
+    })
+
+    assert not views.has_external_urls_for_files({
+        'pid': 1
+    })


### PR DESCRIPTION
* Points files to external URLs for NL documents.
* Moves modal html to display it when no additional files are not available.
* Adds margin bottom to additional files.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>