### PR TITLE
documents: fix affiliations file path

### DIFF
--- a/sonar/modules/documents/api.py
+++ b/sonar/modules/documents/api.py
@@ -56,8 +56,7 @@ class DocumentRecord(SonarRecord):
     @staticmethod
     def load_affiliations():
         """Load affiliations from reference file."""
-        csv_file = os.path.dirname(
-            __file__) + '/../../../data/affiliations.csv'
+        csv_file = './data/affiliations.csv'
 
         DocumentRecord.affiliations = []
 


### PR DESCRIPTION
* Fixes an error on clusters by changing path to affiliations file.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>