### PR TITLE
records: improve serializer

### DIFF
--- a/sonar/config.py
+++ b/sonar/config.py
@@ -461,9 +461,6 @@ RECORDS_FILES_REST_ENDPOINTS = {
 SONAR_ENDPOINTS_ENABLED = True
 """Enable/disable automatic endpoint registration."""
 
-JSONSCHEMAS_RESOLVE_SCHEMA = True
-JSONSCHEMAS_REPLACE_REFS = True
-
 # OAUTH
 # =====
 OAUTHCLIENT_REMOTE_APPS = dict(orcid=orcid.REMOTE_APP)

--- a/sonar/modules/api.py
+++ b/sonar/modules/api.py
@@ -62,8 +62,7 @@ class SonarRecord(Record, FilesMixin):
             id_ = uuid4()
 
         if '$schema' not in data:
-            data["$schema"] = current_jsonschemas.path_to_url(
-                '{schema}s/{schema}-v1.0.0.json'.format(schema=cls.schema))
+            data["$schema"] = current_jsonschemas.path_to_url(cls.schema)
 
         cls.minter(id_, data)
 
@@ -211,8 +210,8 @@ class SonarRecord(Record, FilesMixin):
 
         try:
             # Create thumbnail
-            image_blob = create_thumbnail_from_file(
-                file.file.uri, file.mimetype)
+            image_blob = create_thumbnail_from_file(file.file.uri,
+                                                    file.mimetype)
 
             thumbnail_key = change_filename_extension(file['key'], 'jpg')
 

--- a/sonar/modules/deposits/api.py
+++ b/sonar/modules/deposits/api.py
@@ -63,7 +63,7 @@ class DepositRecord(SonarRecord):
     minter = deposit_pid_minter
     fetcher = deposit_pid_fetcher
     provider = DepositProvider
-    schema = 'deposit'
+    schema = 'deposits/deposit-v1.0.0.json'
 
     @classmethod
     def create(cls, data, id_=None, dbcommit=False, with_bucket=True,

--- a/sonar/modules/documents/api.py
+++ b/sonar/modules/documents/api.py
@@ -50,7 +50,7 @@ class DocumentRecord(SonarRecord):
     minter = document_pid_minter
     fetcher = document_pid_fetcher
     provider = DocumentProvider
-    schema = 'document'
+    schema = 'documents/document-v1.0.0.json'
     affiliations = []
 
     @staticmethod

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -13,7 +13,7 @@
       "title": "Schema",
       "description": "Schema to validate document against.",
       "type": "string",
-      "default": "https://sonar.ch/schema/documents/document-v1.0.0.json",
+      "default": "https://sonar.ch/schemas/documents/document-v1.0.0.json",
       "minLength": 1
     },
     "_bucket": {

--- a/sonar/modules/documents/serializers/__init__.py
+++ b/sonar/modules/documents/serializers/__init__.py
@@ -19,16 +19,17 @@
 
 from __future__ import absolute_import, print_function
 
-from invenio_records_rest.serializers.json import JSONSerializer
 from invenio_records_rest.serializers.response import record_responsify, \
     search_responsify
+
+from sonar.modules.serializers import JSONSerializer
 
 from ..marshmallow import DocumentSchemaV1
 
 # Serializers
 # ===========
 #: JSON serializer definition.
-json_v1 = JSONSerializer(DocumentSchemaV1, replace_refs=True)
+json_v1 = JSONSerializer(DocumentSchemaV1)
 
 # Records-REST serializers
 # ========================

--- a/sonar/modules/organisations/api.py
+++ b/sonar/modules/organisations/api.py
@@ -53,4 +53,4 @@ class OrganisationRecord(SonarRecord):
     minter = organisation_pid_minter
     fetcher = organisation_pid_fetcher
     provider = OrganisationProvider
-    schema = 'organisation'
+    schema = 'organisations/organisation-v1.0.0.json'

--- a/sonar/modules/organisations/marshmallow/json.py
+++ b/sonar/modules/organisations/marshmallow/json.py
@@ -19,11 +19,18 @@
 
 from __future__ import absolute_import, print_function
 
-from invenio_jsonschemas.proxies import current_jsonschemas
-from invenio_records_rest.schemas import Nested, StrictKeysMixin
-from invenio_records_rest.schemas.fields import DateString, \
+from functools import partial
+
+from invenio_records_rest.schemas import StrictKeysMixin
+from invenio_records_rest.schemas.fields import GenFunction, \
     PersistentIdentifier, SanitizedUnicode
-from marshmallow import fields, missing, validate
+from marshmallow import fields
+
+from sonar.modules.organisations.api import OrganisationRecord
+from sonar.modules.serializers import schema_from_context
+
+schema_from_organisation = partial(schema_from_context,
+                                   schema=OrganisationRecord.schema)
 
 
 class OrganisationMetadataSchemaV1(StrictKeysMixin):
@@ -31,6 +38,12 @@ class OrganisationMetadataSchemaV1(StrictKeysMixin):
 
     pid = PersistentIdentifier()
     name = SanitizedUnicode(required=True)
+    # When loading, if $schema is not provided, it's retrieved by
+    # Record.schema property.
+    schema = GenFunction(load_only=True,
+                         attribute="$schema",
+                         data_key="$schema",
+                         deserialize=schema_from_organisation)
 
 
 class OrganisationSchemaV1(StrictKeysMixin):

--- a/sonar/modules/organisations/serializers/__init__.py
+++ b/sonar/modules/organisations/serializers/__init__.py
@@ -19,16 +19,17 @@
 
 from __future__ import absolute_import, print_function
 
-from invenio_records_rest.serializers.json import JSONSerializer
 from invenio_records_rest.serializers.response import record_responsify, \
     search_responsify
+
+from sonar.modules.serializers import JSONSerializer
 
 from ..marshmallow import OrganisationSchemaV1
 
 # Serializers
 # ===========
 #: JSON serializer definition.
-json_v1 = JSONSerializer(OrganisationSchemaV1, replace_refs=True)
+json_v1 = JSONSerializer(OrganisationSchemaV1)
 
 # Records-REST serializers
 # ========================

--- a/sonar/modules/serializers.py
+++ b/sonar/modules/serializers.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""JSON serializer for SONAR."""
+
+from flask import request
+from invenio_jsonschemas import current_jsonschemas
+from invenio_records_rest.serializers.json import \
+    JSONSerializer as _JSONSerializer
+
+
+class JSONSerializer(_JSONSerializer):
+    """JSON serializer for SONAR."""
+
+    def preprocess_record(self, pid, record, links_factory=None, **kwargs):
+        """Prepare record for serialization."""
+        if request and request.args.get('resolve') == '1':
+            record = record.replace_refs()
+
+        return super(JSONSerializer,
+                     self).preprocess_record(pid=pid,
+                                             record=record,
+                                             links_factory=links_factory,
+                                             kwargs=kwargs)
+
+
+def schema_from_context(_, context, data, schema):
+    """Get the record's schema from context."""
+    record = (context or {}).get('record', {})
+
+    return record.get('$schema', current_jsonschemas.path_to_url(schema))

--- a/sonar/modules/users/api.py
+++ b/sonar/modules/users/api.py
@@ -82,7 +82,7 @@ class UserRecord(SonarRecord):
     minter = user_pid_minter
     fetcher = user_pid_fetcher
     provider = UserProvider
-    schema = 'user'
+    schema = 'users/user-v1.0.0.json'
 
     @classmethod
     def get_user_by_current_user(cls, user):

--- a/sonar/modules/users/marshmallow/json.py
+++ b/sonar/modules/users/marshmallow/json.py
@@ -19,10 +19,17 @@
 
 from __future__ import absolute_import, print_function
 
+from functools import partial
+
 from invenio_records_rest.schemas import StrictKeysMixin
-from invenio_records_rest.schemas.fields import PersistentIdentifier, \
-    SanitizedUnicode
+from invenio_records_rest.schemas.fields import GenFunction, \
+    PersistentIdentifier, SanitizedUnicode
 from marshmallow import fields
+
+from sonar.modules.serializers import schema_from_context
+from sonar.modules.users.api import UserRecord
+
+schema_from_user = partial(schema_from_context, schema=UserRecord.schema)
 
 
 class UserMetadataSchemaV1(StrictKeysMixin):
@@ -39,6 +46,12 @@ class UserMetadataSchemaV1(StrictKeysMixin):
     phone = SanitizedUnicode()
     organisation = fields.Dict(dump_only=True)
     roles = fields.List(SanitizedUnicode, required=True)
+    # When loading, if $schema is not provided, it's retrieved by
+    # Record.schema property.
+    schema = GenFunction(load_only=True,
+                         attribute="$schema",
+                         data_key="$schema",
+                         deserialize=schema_from_user)
 
 
 class UserSchemaV1(StrictKeysMixin):

--- a/sonar/modules/users/serializers/__init__.py
+++ b/sonar/modules/users/serializers/__init__.py
@@ -19,16 +19,17 @@
 
 from __future__ import absolute_import, print_function
 
-from invenio_records_rest.serializers.json import JSONSerializer
 from invenio_records_rest.serializers.response import record_responsify, \
     search_responsify
+
+from sonar.modules.serializers import JSONSerializer
 
 from ..marshmallow import UserSchemaV1
 
 # Serializers
 # ===========
 #: JSON serializer definition.
-json_v1 = JSONSerializer(UserSchemaV1, replace_refs=True)
+json_v1 = JSONSerializer(UserSchemaV1)
 
 # Records-REST serializers
 # ========================

--- a/sonar/theme/api_views.py
+++ b/sonar/theme/api_views.py
@@ -24,7 +24,6 @@ this file.
 
 from __future__ import absolute_import, print_function
 
-import copy
 import re
 
 from flask import Blueprint, abort, jsonify
@@ -32,20 +31,6 @@ from invenio_jsonschemas import current_jsonschemas
 from invenio_jsonschemas.errors import JSONSchemaNotFound
 
 blueprint = Blueprint('api_sonar', __name__)
-
-
-def prepare_jsonschema(schema):
-    """Json schema prep."""
-    schema = copy.deepcopy(schema)
-
-    del schema['$schema']
-
-    if 'pid' in schema.get('required', []):
-        schema['required'].remove('pid')
-
-    del schema['properties']['$schema']
-
-    return schema
 
 
 @blueprint.route('/schemaform/<document_type>')
@@ -59,6 +44,6 @@ def schemaform(document_type):
         schema_name = '{}/{}-v1.0.0.json'.format(document_type, doc_type)
         schema = current_jsonschemas.get_schema(schema_name)
 
-        return jsonify({'schema': prepare_jsonschema(schema)})
+        return jsonify({'schema': schema})
     except JSONSchemaNotFound:
         abort(404)

--- a/tests/api/deposits/test_deposits_rest.py
+++ b/tests/api/deposits/test_deposits_rest.py
@@ -19,6 +19,8 @@
 
 import json
 
+from flask import url_for
+
 from sonar.modules.deposits.rest import FilesResource
 from sonar.modules.users.api import UserRecord
 
@@ -113,8 +115,7 @@ def test_file_put(client, deposit_fixture):
 def test_publish(client, db, db_user_fixture, db_moderator_fixture,
                  deposit_fixture):
     """Test publishing a deposit."""
-    url = 'https://localhost:5000/deposits/{pid}/publish'.format(
-        pid=deposit_fixture['pid'])
+    url = url_for('deposits.publish', pid=deposit_fixture['pid'])
 
     # Everything OK
     response = client.post(url, data={})
@@ -141,8 +142,7 @@ def test_publish(client, db, db_user_fixture, db_moderator_fixture,
 def test_review(client, db, db_user_fixture, db_moderator_fixture,
                 deposit_fixture):
     """Test reviewing a deposit."""
-    url = 'https://localhost:5000/deposits/{pid}/review'.format(
-        pid=deposit_fixture['pid'])
+    url = url_for('deposits.review', pid=deposit_fixture['pid'])
 
     headers = {
         'Content-Type': 'application/json',
@@ -233,10 +233,9 @@ def test_review(client, db, db_user_fixture, db_moderator_fixture,
     assert response.status_code == 200
 
 
-def test_extract_metadata(app, client, deposit_fixture):
+def test_extract_metadata(client, deposit_fixture):
     """Test PDF metadata extraction."""
-    url = 'https://localhost:5000/deposits/{pid}/extract-pdf-metadata'.format(
-        pid=deposit_fixture['pid'])
+    url = url_for('deposits.extract_metadata', pid=deposit_fixture['pid'])
 
     headers = {
         'Content-Type': 'application/json',
@@ -252,8 +251,7 @@ def test_extract_metadata(app, client, deposit_fixture):
     response = client.get(url, headers=headers)
     assert response.status_code == 500
 
-    response = client.get(
-        'https://localhost:5000/deposits/{pid}/extract-pdf-metadata'.format(
-            pid='not-existing'),
-        headers=headers)
+    response = client.get(url_for('deposits.extract_metadata',
+                                  pid='not-existing'),
+                          headers=headers)
     assert response.status_code == 400

--- a/tests/api/test_api_simple_flow.py
+++ b/tests/api/test_api_simple_flow.py
@@ -20,6 +20,7 @@
 import json
 
 import mock
+from flask import url_for
 from invenio_search import current_search
 from utils import VerifyRecordPermissionPatch
 
@@ -31,14 +32,14 @@ def test_simple_flow(client, document_json_fixture):
     headers = [('Content-Type', 'application/json')]
 
     # create a record
-    response = client.post('https://localhost:5000/documents/',
+    response = client.post(url_for('invenio_records_rest.doc_list'),
                            data=json.dumps(document_json_fixture),
                            headers=headers)
     assert response.status_code == 201
     current_search.flush_and_refresh('documents')
 
     # retrieve record
-    res = client.get('https://localhost:5000/documents/1')
+    res = client.get(url_for('invenio_records_rest.doc_item', pid_value=1))
     assert res.status_code == 200
     assert response.json['metadata']['title'][0]['mainTitle'][0][
         'value'] == 'Title of the document'
@@ -46,7 +47,8 @@ def test_simple_flow(client, document_json_fixture):
 
 def test_add_files_restrictions(client, document_with_file):
     """Test adding file restrictions before dumping object."""
-    res = client.get('https://localhost:5000/documents/10000')
+    res = client.get(
+        url_for('invenio_records_rest.doc_item', pid_value=10000, resolve=1))
     assert res.status_code == 200
     assert res.json['metadata']['_files'][0]['restricted'] == {
         'restricted': True,

--- a/tests/ui/test_api_views.py
+++ b/tests/ui/test_api_views.py
@@ -17,28 +17,9 @@
 
 """Test SONAR api views."""
 
-import json
-import os
-
 from invenio_app.factory import create_api
 
-from sonar.theme.api_views import prepare_jsonschema
-
 create_app = create_api
-
-
-def test_prepare_jsonschema():
-    """Test JSON schema transformation before returning by API endpoint."""
-    with open(
-            os.path.dirname(os.path.abspath(__file__)) +
-            '/data/json_to_compile.json') as json_file:
-        schema = json.load(json_file)
-        assert '$schema' in schema
-        assert 'pid' in schema['required']
-
-        schema = prepare_jsonschema(schema)
-        assert '$schema' not in schema
-        assert 'pid' not in schema['required']
 
 
 def test_json_schema_form(client):


### PR DESCRIPTION
* Creates a custom JSON serializer for replacing refs if a request parameter "resolve" is available and equal to 1.
* Resets JSONSCHEMAS_RESOLVE_SCHEMA configuration to default.
* Resets JSONSCHEMAS_REPLACE_REFS configuration to default.
* Stores full schema path in "schema" property in records classes.
* Fixes path to schema in document JSON schema.
* Guesses $schema property during deserialization in marshmallow.
* Removes automatic replace refs in JSON serializer.
* Removes useless prepare_jsonschema function.
* Uses url_for function instead of hardcoding urls in tests.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>