### PR TITLE
authentication: ORCID for production

### DIFF
--- a/sonar/config.py
+++ b/sonar/config.py
@@ -468,7 +468,7 @@ SONAR_ENDPOINTS_ENABLED = True
 # =====
 OAUTHCLIENT_REMOTE_APPS = dict(orcid=orcid.REMOTE_APP)
 
-ORCID_DOMAIN = 'sandbox.orcid.org'
+ORCID_DOMAIN = os.environ.get('ORCID_CONSUMER_DOMAIN', 'sandbox.orcid.org')
 
 OAUTHCLIENT_REMOTE_APPS['orcid']['signup_handler']['info'] = \
     'sonar.modules.oauth.orcid:account_info'

--- a/sonar/modules/oauth/orcid.py
+++ b/sonar/modules/oauth/orcid.py
@@ -133,7 +133,7 @@ def get_orcid_record(orcid_id, token, request_type=''):
     api = orcid.PublicAPI(
         credentials['consumer_key'],
         credentials['consumer_secret'],
-        sandbox=True,
+        sandbox=(current_app.config.get('ORCID_DOMAIN').startswith('sandbox'))
     )
     try:
         return api.read_record_public(orcid_id, request_type, token)


### PR DESCRIPTION
* Checks an environment variable for setting ORCID API domain.
* Checks ORDCID API domain to do calls on API in sandbox mode or not.
* Closes #103.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>