### PR TITLE
organisation: create default organisation

### DIFF
--- a/data/organisations.json
+++ b/data/organisations.json
@@ -1,0 +1,6 @@
+[
+  {
+      "code": "rero",
+      "name": "RERO"
+  }
+]

--- a/data/users.json
+++ b/data/users.json
@@ -8,7 +8,10 @@
     "street": "Sonnenbergstr 39",
     "postal_code": "6544",
     "city": "Braggio",
-    "phone": "+41916658961"
+    "phone": "+41916658961",
+    "organisation": {
+      "$ref": "https://sonar.ch/api/organisations/rero"
+    }
   },
   {
     "full_name": "Elia Rossi",
@@ -19,7 +22,10 @@
     "street": "Brunnacherstrasse 112",
     "postal_code": "5330",
     "city": "Zurzach",
-    "phone": "+41625037543"
+    "phone": "+41625037543",
+    "organisation": {
+      "$ref": "https://sonar.ch/api/organisations/rero"
+    }
   },
   {
     "full_name": "Emanuele Fiorentini",
@@ -30,7 +36,10 @@
     "street": "Lichtmattstrasse 123",
     "postal_code": "5736",
     "city": "Burg",
-    "phone": "+41627676171"
+    "phone": "+41627676171",
+    "organisation": {
+      "$ref": "https://sonar.ch/api/organisations/rero"
+    }
   },
   {
     "full_name": "Jules Brochu",
@@ -41,6 +50,9 @@
     "street": "Rasenstrasse 2",
     "postal_code": "4577",
     "city": "Hessigkofen",
-    "phone": "+41323666556"
+    "phone": "+41323666556",
+    "organisation": {
+      "$ref": "https://sonar.ch/api/organisations/rero"
+    }
   }
 ]

--- a/scripts/setup
+++ b/scripts/setup
@@ -76,7 +76,8 @@ pipenv run invenio fixtures deposits create
 # Create configuration for RERODOC OAI harvesting
 pipenv run invenio oaiharvester config create data/rerodoc_oai_sources.json
 
-# Create users
+# Create users and organisations
+pipenv run invenio fixtures organisations import $(pipenv --where)/data/organisations.json
 pipenv run invenio fixtures users import $(pipenv --where)/data/users.json
 
 # Create document sample

--- a/sonar/modules/cli.py
+++ b/sonar/modules/cli.py
@@ -29,6 +29,7 @@ from invenio_search.proxies import current_search
 from jsonref import JsonLoader
 
 from .deposits.cli import deposits
+from .organisations.cli.organisations import organisations
 from .users.cli import users
 
 
@@ -38,6 +39,7 @@ def fixtures():
 
 
 fixtures.add_command(users)
+fixtures.add_command(organisations)
 fixtures.add_command(deposits)
 
 

--- a/sonar/modules/organisations/cli/organisations.py
+++ b/sonar/modules/organisations/cli/organisations.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Documents CLI commands."""
+
+import json
+
+import click
+from click.exceptions import ClickException
+from flask.cli import with_appcontext
+from invenio_db import db
+
+from sonar.modules.organisations.api import OrganisationIndexer, \
+    OrganisationRecord
+
+
+@click.group()
+def organisations():
+    """Organisations CLI commands."""
+
+
+@organisations.command('import')
+@click.argument('file', type=click.File('r'))
+@with_appcontext
+def import_organisations(file):
+    """Import organisations from JSON file."""
+    click.secho('Importing organisations from {file}'.format(file=file.name))
+
+    indexer = OrganisationIndexer()
+
+    for record in json.load(file):
+        try:
+            # Check existence in DB
+            db_record = OrganisationRecord.get_record_by_pid(record['code'])
+
+            if db_record:
+                raise ClickException('Record already exists in DB')
+
+            # Register record to DB
+            db_record = OrganisationRecord.create(record)
+            db.session.commit()
+
+            indexer.index(db_record)
+        except Exception as error:
+            click.secho(
+                'Organisation {org} could not be imported: {error}'.format(
+                    org=record, error=str(error)),
+                fg='red')
+
+    click.secho('Finished', fg='green')

--- a/sonar/modules/users/jsonschemas/users/user-v1.0.0.json
+++ b/sonar/modules/users/jsonschemas/users/user-v1.0.0.json
@@ -85,7 +85,10 @@
             }
           }
         }
-      }
+      },
+      "required": [
+        "$ref"
+      ]
     },
     "roles": {
       "title": "Role",
@@ -139,6 +142,7 @@
     "full_name",
     "email",
     "roles",
+    "organisation",
     "$schema"
   ]
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,12 +123,15 @@ def organisation_fixture(app, db):
 
 
 @pytest.fixture()
-def db_user_fixture(app, db):
+def db_user_fixture(app, db, organisation_fixture):
     """Create user in database."""
     data = {
         'email': 'user@rero.ch',
         'full_name': 'John Doe',
-        'roles': ['user']
+        'roles': ['user'],
+        'organisation': {
+            '$ref': 'https://sonar.ch/api/organisations/org'
+        }
     }
 
     user = UserRecord.create(data, dbcommit=True)
@@ -139,12 +142,15 @@ def db_user_fixture(app, db):
 
 
 @pytest.fixture()
-def db_moderator_fixture(app, db):
+def db_moderator_fixture(app, db, organisation_fixture):
     """Create moderator in database."""
     data = {
         'email': 'moderator@rero.ch',
         'full_name': 'John Doe',
-        'roles': ['moderator']
+        'roles': ['moderator'],
+        'organisation': {
+            '$ref': 'https://sonar.ch/api/organisations/org'
+        }
     }
 
     user = UserRecord.create(data, dbcommit=True)

--- a/tests/ui/organisations/cli/test_organisations_cli_organisations.py
+++ b/tests/ui/organisations/cli/test_organisations_cli_organisations.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test CLI for organisations."""
+
+from click.testing import CliRunner
+
+import sonar.modules.organisations.cli.organisations as Cli
+from sonar.modules.organisations.api import OrganisationRecord
+
+
+def test_import_organisations(app, script_info):
+    """Test import organisations."""
+    runner = CliRunner()
+
+    datastore = app.extensions['security'].datastore
+    datastore.create_role(name='admin')
+
+    # Import ok
+    result = runner.invoke(Cli.import_organisations,
+                           ['./tests/ui/organisations/data/valid.json'],
+                           obj=script_info)
+    organisation = OrganisationRecord.get_record_by_pid('test')
+    assert organisation
+    assert organisation['pid'] == 'test'
+
+    # Already existing
+    result = runner.invoke(Cli.import_organisations,
+                           ['./tests/ui/organisations/data/valid.json'],
+                           obj=script_info)
+    assert result.output.find(
+        'Organisation {\'code\': \'test\', \'name\': \'Test\'} could not be '
+        'imported: Record already exists in DB'
+    )

--- a/tests/ui/organisations/data/valid.json
+++ b/tests/ui/organisations/data/valid.json
@@ -1,0 +1,6 @@
+[
+  {
+    "code": "test",
+    "name": "Test"
+  }
+]

--- a/tests/ui/users/data/valid.json
+++ b/tests/ui/users/data/valid.json
@@ -10,6 +10,9 @@
     "password": "123456",
     "phone": "+39324993597",
     "postal_code": "11100",
-    "street": "Viale Rue Gran Paradiso, 44"
+    "street": "Viale Rue Gran Paradiso, 44",
+    "organisation": {
+      "$ref": "https://sonar.ch/api/organisations/org"
+    }
   }
 ]

--- a/tests/ui/users/data/without_email.json
+++ b/tests/ui/users/data/without_email.json
@@ -9,6 +9,9 @@
     "password": "123456",
     "phone": "+39324993597",
     "postal_code": "11100",
-    "street": "Viale Rue Gran Paradiso, 44"
+    "street": "Viale Rue Gran Paradiso, 44",
+    "organisation": {
+      "$ref": "https://sonar.ch/api/organisations/org"
+    }
   }
 ]

--- a/tests/ui/users/data/without_roles.json
+++ b/tests/ui/users/data/without_roles.json
@@ -7,6 +7,9 @@
     "password": "123456",
     "phone": "+39324993597",
     "postal_code": "11100",
-    "street": "Viale Rue Gran Paradiso, 44"
+    "street": "Viale Rue Gran Paradiso, 44",
+    "organisation": {
+      "$ref": "https://sonar.ch/api/organisations/org"
+    }
   }
 ]

--- a/tests/ui/users/test_user_jsonresolvers.py
+++ b/tests/ui/users/test_user_jsonresolvers.py
@@ -21,13 +21,16 @@ from sonar.modules.deposits.api import DepositRecord
 from sonar.modules.users.api import UserRecord
 
 
-def test_user_resolver(app):
+def test_user_resolver(app, organisation_fixture):
     """Test user resolver."""
     UserRecord.create({
         'pid': '1',
         'full_name': 'Jules Brochu',
         'email': 'admin@test.com',
-        'roles': ['user']
+        'roles': ['user'],
+        'organisation': {
+            '$ref': 'https://sonar.ch/api/organisations/org'
+        }
     })
 
     record = DepositRecord.create({

--- a/tests/ui/users/test_users_api.py
+++ b/tests/ui/users/test_users_api.py
@@ -23,13 +23,16 @@ from invenio_accounts.testutils import login_user_via_view
 from sonar.modules.users.api import UserRecord, UserSearch
 
 
-def test_get_moderators(app):
+def test_get_moderators(app, organisation_fixture):
     """Test search for moderators."""
     user = UserRecord.create(
         {
             'full_name': 'John Doe',
             'email': 'john.doe@rero.ch',
-            'roles': [UserRecord.ROLE_MODERATOR]
+            'roles': [UserRecord.ROLE_MODERATOR],
+            'organisation': {
+                '$ref': 'https://sonar.ch/api/organisations/org'
+            }
         },
         dbcommit=True)
     user.reindex()
@@ -41,7 +44,8 @@ def test_get_moderators(app):
     assert not list(moderators)
 
 
-def test_get_user_by_current_user(app, client, admin_user_fixture):
+def test_get_user_by_current_user(app, client, admin_user_fixture,
+                                  organisation_fixture):
     """Test getting a user with email taken from logged user."""
     login_user_via_view(client,
                         email=admin_user_fixture.email,
@@ -53,7 +57,10 @@ def test_get_user_by_current_user(app, client, admin_user_fixture):
         {
             'full_name': 'John Doe',
             'email': 'admin@test.com',
-            'roles': [UserRecord.ROLE_MODERATOR]
+            'roles': [UserRecord.ROLE_MODERATOR],
+            'organisation': {
+                '$ref': 'https://sonar.ch/api/organisations/org'
+            }
         },
         dbcommit=True)
     user.reindex()
@@ -74,13 +81,16 @@ def test_get_reachable_roles(app):
     assert not roles
 
 
-def test_get_moderators_emails(app):
+def test_get_moderators_emails(app, organisation_fixture):
     """Test getting list of moderators emails."""
     user = UserRecord.create(
         {
             'full_name': 'John Doe',
             'email': 'john.doe@rero.ch',
-            'roles': [UserRecord.ROLE_MODERATOR]
+            'roles': [UserRecord.ROLE_MODERATOR],
+            'organisation': {
+                '$ref': 'https://sonar.ch/api/organisations/org'
+            }
         },
         dbcommit=True)
     user.reindex()
@@ -96,13 +106,16 @@ def test_get_moderators_emails(app):
     assert not emails
 
 
-def test_is_granted(app):
+def test_is_granted(app, organisation_fixture):
     """Test if user is granted with a role."""
     user = UserRecord.create(
         {
             'full_name': 'John Doe',
             'email': 'john.doe@rero.ch',
-            'roles': [UserRecord.ROLE_MODERATOR]
+            'roles': [UserRecord.ROLE_MODERATOR],
+            'organisation': {
+                '$ref': 'https://sonar.ch/api/organisations/org'
+            }
         },
         dbcommit=True)
 
@@ -115,13 +128,16 @@ def test_is_granted(app):
     assert not user.is_granted(UserRecord.ROLE_MODERATOR)
 
 
-def test_is_role_property():
+def test_is_role_property(organisation_fixture):
     """Test if user is in a particular role."""
     user = UserRecord.create(
         {
             'full_name': 'John Doe',
             'email': 'john.doe@rero.ch',
-            'roles': [UserRecord.ROLE_MODERATOR]
+            'roles': [UserRecord.ROLE_MODERATOR],
+            'organisation': {
+                '$ref': 'https://sonar.ch/api/organisations/org'
+            }
         },
         dbcommit=True)
 

--- a/tests/ui/users/test_users_cli.py
+++ b/tests/ui/users/test_users_cli.py
@@ -22,7 +22,7 @@ from click.testing import CliRunner
 import sonar.modules.users.cli as Cli
 
 
-def test_import_users(app, script_info):
+def test_import_users(app, script_info, organisation_fixture):
     """Test import users."""
     runner = CliRunner()
 


### PR DESCRIPTION
* Creates a default organisation during setup.
* Associates default organisation to users.
* Adds a CLI command for creating organisations from file.
* Sets organisation as required in user JSON schema.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>