### PR TITLE
security: add permissions for accessing resources

### DIFF
--- a/sonar/modules/deposits/loaders/__init__.py
+++ b/sonar/modules/deposits/loaders/__init__.py
@@ -15,10 +15,17 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Marshmallow for deposits."""
+"""Deposit loaders."""
 
 from __future__ import absolute_import, print_function
 
-from .json import UserMetadataSchemaV1, UserSchemaV1
+from invenio_records_rest.loaders.marshmallow import json_patch_loader, \
+    marshmallow_loader
 
-__all__ = ('UserMetadataSchemaV1', 'UserSchemaV1',)
+from ..marshmallow import DepositMetadataSchemaV1
+
+json_v1 = marshmallow_loader(DepositMetadataSchemaV1)
+
+__all__ = (
+    'json_v1',
+)

--- a/sonar/modules/deposits/marshmallow/__init__.py
+++ b/sonar/modules/deposits/marshmallow/__init__.py
@@ -15,10 +15,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Marshmallow for deposits."""
+"""Schemas for marshmallow."""
 
 from __future__ import absolute_import, print_function
 
-from .json import UserMetadataSchemaV1, UserSchemaV1
+from .json import DepositMetadataSchemaV1, DepositSchemaV1
 
-__all__ = ('UserMetadataSchemaV1', 'UserSchemaV1',)
+__all__ = ('DepositMetadataSchemaV1', 'DepositSchemaV1',)

--- a/sonar/modules/deposits/marshmallow/json.py
+++ b/sonar/modules/deposits/marshmallow/json.py
@@ -27,49 +27,55 @@ from invenio_records_rest.schemas.fields import GenFunction, \
     PersistentIdentifier, SanitizedUnicode
 from marshmallow import fields, pre_dump
 
-from sonar.modules.organisations.api import OrganisationRecord
-from sonar.modules.organisations.permissions import OrganisationPermission
+from sonar.modules.deposits.api import DepositRecord
+from sonar.modules.deposits.permissions import DepositPermission
 from sonar.modules.serializers import schema_from_context
 
-schema_from_organisation = partial(schema_from_context,
-                                   schema=OrganisationRecord.schema)
+schema_from_deposit = partial(schema_from_context, schema=DepositRecord.schema)
 
 
-class OrganisationMetadataSchemaV1(StrictKeysMixin):
-    """Schema for the organisation metadata."""
+class DepositMetadataSchemaV1(StrictKeysMixin):
+    """Schema for the deposit metadata."""
 
     pid = PersistentIdentifier()
-    code = SanitizedUnicode(required=True)
-    name = SanitizedUnicode(required=True)
+    contributors = fields.List(fields.Dict())
+    diffusion = fields.Dict()
+    document = fields.Dict()
+    logs = fields.List(fields.Dict())
+    metadata = fields.Dict()
+    status = SanitizedUnicode()
+    step = SanitizedUnicode()
+    user = fields.Dict()
+    _files = fields.List(fields.Dict())
+    _bucket = SanitizedUnicode()
     # When loading, if $schema is not provided, it's retrieved by
     # Record.schema property.
     schema = GenFunction(load_only=True,
                          attribute="$schema",
                          data_key="$schema",
-                         deserialize=schema_from_organisation)
+                         deserialize=schema_from_deposit)
     permissions = fields.Dict(dump_only=True)
 
     @pre_dump
     def add_permissions(self, item):
         """Add permissions to record.
 
-        :param item: Dict representing the record.
-        :returns: Modified dict.
+        :param item: Dict representing the record
+        :returns: Dict of modified record.
         """
         item['permissions'] = {
-            'read': OrganisationPermission.read(current_user, item),
-            'update': OrganisationPermission.update(current_user, item),
-            'delete': OrganisationPermission.delete(current_user, item)
+            'read': DepositPermission.read(current_user, item),
+            'update': DepositPermission.update(current_user, item),
+            'delete': DepositPermission.delete(current_user, item)
         }
 
         return item
 
 
-class OrganisationSchemaV1(StrictKeysMixin):
-    """organisation schema."""
+class DepositSchemaV1(StrictKeysMixin):
+    """Deposit schema."""
 
-    metadata = fields.Nested(OrganisationMetadataSchemaV1)
+    metadata = fields.Nested(DepositMetadataSchemaV1)
     created = fields.Str(dump_only=True)
     updated = fields.Str(dump_only=True)
     links = fields.Dict(dump_only=True)
-    id = PersistentIdentifier()

--- a/sonar/modules/deposits/permissions.py
+++ b/sonar/modules/deposits/permissions.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Permissions for deposits."""
+
+import copy
+
+from sonar.modules.deposits.api import DepositRecord
+from sonar.modules.organisations.api import OrganisationRecord, \
+    current_organisation
+from sonar.modules.permissions import RecordPermission
+from sonar.modules.users.api import UserRecord, current_user_record
+
+
+class DepositPermission(RecordPermission):
+    """Deposits permissions."""
+
+    @classmethod
+    def list(cls, user, record=None):
+        """List permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True is action can be done.
+        """
+        # At least for publishers logged users.
+        if not current_user_record or not current_user_record.is_publisher:
+            return False
+
+        return True
+
+    @classmethod
+    def create(cls, user, record=None):
+        """Create permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True is action can be done.
+        """
+        # No logged user.
+        if not current_user_record:
+            return False
+
+        return current_user_record.is_publisher
+
+    @classmethod
+    def read(cls, user, record):
+        """Read permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True is action can be done.
+        """
+        # At least for publishers logged users.
+        if not current_user_record or not current_user_record.is_publisher:
+            return False
+
+        # Superuser is allowd
+        if current_user_record.is_superuser:
+            return True
+
+        deposit = DepositRecord.get_record_by_pid(record['pid'])
+        deposit = deposit.replace_refs()
+
+        # Moderators are allowed only for their organisation's deposits.
+        if current_user_record.is_moderator:
+            return current_organisation['pid'] == deposit['user'][
+                'organisation']['pid']
+
+        # Publishers have only access to their own deposits.
+        return current_user_record['pid'] == deposit['user']['pid']
+
+    @classmethod
+    def update(cls, user, record):
+        """Update permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True is action can be done.
+        """
+        # Same rules as read.
+        return cls.read(user, record)
+
+    @classmethod
+    def delete(cls, user, record):
+        """Delete permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True is action can be done.
+        """
+        # Cannot delete a validated deposit.
+        if record['status'] == DepositRecord.STATUS_VALIDATED:
+            return False
+
+        # Same rules as read.
+        return cls.read(user, record)

--- a/sonar/modules/deposits/query.py
+++ b/sonar/modules/deposits/query.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Query for deposits."""
+
+from invenio_records_rest.query import es_search_factory
+
+from sonar.modules.organisations.api import current_organisation
+from sonar.modules.users.api import current_user_record
+
+
+def search_factory(self, search, query_parser=None):
+    """Deposit search factory.
+
+    :param search: Search instance.
+    :param query_parser: Url arguments.
+    :returns: Tuple with search instance and URL arguments.
+    """
+    search, urlkwargs = es_search_factory(self, search)
+
+    # For superusers, records are not filtered.
+    if current_user_record.is_superuser:
+        return (search, urlkwargs)
+
+    # For admin and moderator, only records that belongs to his organisation.
+    if current_user_record.is_admin or current_user_record.is_moderator:
+        search = search.filter(
+            'term', user__organisation__pid=current_organisation['pid'])
+        return (search, urlkwargs)
+
+    # For user, only records that belongs to him.
+    if current_user_record.is_publisher:
+        search = search.filter(
+            'term', user__pid=current_user_record['pid'])
+
+    return (search, urlkwargs)

--- a/sonar/modules/deposits/serializers/__init__.py
+++ b/sonar/modules/deposits/serializers/__init__.py
@@ -15,10 +15,31 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Marshmallow for deposits."""
+"""Deposit serializers."""
 
 from __future__ import absolute_import, print_function
 
-from .json import UserMetadataSchemaV1, UserSchemaV1
+from invenio_records_rest.serializers.response import record_responsify, \
+    search_responsify
 
-__all__ = ('UserMetadataSchemaV1', 'UserSchemaV1',)
+from sonar.modules.serializers import JSONSerializer
+
+from ..marshmallow import DepositSchemaV1
+
+# Serializers
+# ===========
+#: JSON serializer definition.
+json_v1 = JSONSerializer(DepositSchemaV1)
+
+# Records-REST serializers
+# ========================
+#: JSON record serializer for individual records.
+json_v1_response = record_responsify(json_v1, 'application/json')
+#: JSON record serializer for search results.
+json_v1_search = search_responsify(json_v1, 'application/json')
+
+__all__ = (
+    'json_v1',
+    'json_v1_response',
+    'json_v1_search',
+)

--- a/sonar/modules/deposits/templates/email/validation.en.txt
+++ b/sonar/modules/deposits/templates/email/validation.en.txt
@@ -6,4 +6,4 @@ Title of the deposit: {{ deposit.metadata.title }}
 
 You can review this deposit by following this link:
 
-{{ link }}records/deposits?q=&pid={{ deposit.pid }}
+{{ link }}records/deposits?q=pid:{{ deposit.pid }}

--- a/sonar/modules/documents/permissions.py
+++ b/sonar/modules/documents/permissions.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Permissions for documents."""
+
+from flask import request
+
+from sonar.modules.documents.api import DocumentRecord
+from sonar.modules.organisations.api import OrganisationRecord, \
+    current_organisation
+from sonar.modules.permissions import RecordPermission
+from sonar.modules.users.api import current_user_record
+
+
+class DocumentPermission(RecordPermission):
+    """Documents permissions."""
+
+    @classmethod
+    def list(cls, user, record=None):
+        """List permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True is action can be done.
+        """
+        view = request.args.get('view')
+
+        # Documents are accessess in public view, but eventually filtered later
+        # by organisation
+        if view:
+            return True
+
+        # Only for moderators users.
+        if (not current_user_record or not current_user_record.is_moderator or
+                not current_organisation):
+            return False
+
+        return True
+
+    @classmethod
+    def create(cls, user, record=None):
+        """Create permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True is action can be done.
+        """
+        # Only for moderators users
+        return current_user_record and current_user_record.is_moderator
+
+    @classmethod
+    def read(cls, user, record):
+        """Read permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True is action can be done.
+        """
+        # Only for moderator users.
+        if not current_user_record or not current_user_record.is_moderator:
+            return False
+
+        # Superuser is allowed.
+        if current_user_record.is_superuser:
+            return True
+
+        document = DocumentRecord.get_record_by_pid(record['pid'])
+        document = document.replace_refs()
+
+        # For admin or moderators users, they can access only to their
+        # organisation's documents.
+        return current_organisation['pid'] == document['organisation']['pid']
+
+    @classmethod
+    def update(cls, user, record):
+        """Update permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True is action can be done.
+        """
+        # Same rules as read
+        return cls.read(user, record)
+
+    @classmethod
+    def delete(cls, user, record):
+        """Delete permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True is action can be done.
+        """
+        # Delete is only for admins.
+        if not current_user_record or not current_user_record.is_admin:
+            return False
+
+        # Same rules as read
+        return cls.read(user, record)

--- a/sonar/modules/documents/query.py
+++ b/sonar/modules/documents/query.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Query for documents."""
+
+from flask import current_app, request
+from invenio_records_rest.query import es_search_factory
+
+from sonar.modules.organisations.api import current_organisation
+from sonar.modules.users.api import current_user_record
+
+
+def search_factory(self, search, query_parser=None):
+    """Documents search factory.
+
+    :param search: Search instance.
+    :param query_parser: Url arguments.
+    :returns: Tuple with search instance and URL arguments.
+    """
+    view = request.args.get('view')
+
+    search, urlkwargs = es_search_factory(self, search)
+
+    # Public search
+    if view:
+        # Filter record by organisation view.
+        if view != current_app.config.get('SONAR_APP_DEFAULT_ORGANISATION'):
+            search = search.filter('term', organisation__pid=view)
+    # Admin
+    else:
+        # Filters records by user's organisation
+        if not current_user_record.is_superuser:
+            search = search.filter(
+                'term', organisation__pid=current_organisation['pid'])
+
+    return (search, urlkwargs)

--- a/sonar/modules/documents/tasks.py
+++ b/sonar/modules/documents/tasks.py
@@ -33,6 +33,7 @@ def import_records(records_to_import):
     get the status and/or the result of the task, execution is faster.
 
     :param list records_to_import: List of records to import.
+    :returns: List of IDs.
     """
     indexer = RecordIndexer()
 
@@ -88,3 +89,5 @@ def import_records(records_to_import):
     db.session.commit()
     indexer.bulk_index(ids)
     indexer.process_bulk_queue()
+
+    return ids

--- a/sonar/modules/organisations/permissions.py
+++ b/sonar/modules/organisations/permissions.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Permissions for organisations."""
+
+from sonar.modules.organisations.api import current_organisation
+from sonar.modules.permissions import RecordPermission
+from sonar.modules.users.api import current_user_record
+
+
+class OrganisationPermission(RecordPermission):
+    """Organisations permissions."""
+
+    @classmethod
+    def list(cls, user, record=None):
+        """List permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True is action can be done.
+        """
+        # Only for admin users at least.
+        if not current_user_record or not current_user_record.is_admin:
+            return False
+
+        return True
+
+    @classmethod
+    def create(cls, user, record=None):
+        """Create permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True is action can be done.
+        """
+        # Only superuser can create an organisation.
+        return current_user_record and current_user_record.is_superuser
+
+    @classmethod
+    def read(cls, user, record):
+        """Read permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True is action can be done.
+        """
+        # Only for admin users
+        if not current_user_record or not current_user_record.is_admin:
+            return False
+
+        # Super user is allowed
+        if current_user_record.is_superuser:
+            return True
+
+        # For admin users, they can read only their own organisation.
+        return current_organisation['pid'] == record['pid']
+
+    @classmethod
+    def update(cls, user, record):
+        """Update permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True is action can be done.
+        """
+        # Same rules as read.
+        return cls.read(user, record)
+
+    @classmethod
+    def delete(cls, user, record):
+        """Delete permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True if action can be done.
+        """
+        # Nobody can remove an organisation
+        return False

--- a/sonar/modules/organisations/query.py
+++ b/sonar/modules/organisations/query.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Query for organisations."""
+
+from invenio_records_rest.query import es_search_factory
+
+from sonar.modules.organisations.api import current_organisation
+from sonar.modules.users.api import current_user_record
+
+
+def search_factory(self, search, query_parser=None):
+    """Organisation search factory.
+
+    :param search: Search instance.
+    :param query_parser: Url arguments.
+    :returns: Tuple with search instance and URL arguments.
+    """
+    search, urlkwargs = es_search_factory(self, search)
+
+    # Records are not filtered for superusers.
+    if current_user_record.is_superuser:
+        return (search, urlkwargs)
+
+    # For admins, records are filtered by organisation of the current user.
+    search = search.filter('term', code=current_organisation['pid'])
+
+    return (search, urlkwargs)

--- a/sonar/modules/users/api.py
+++ b/sonar/modules/users/api.py
@@ -98,7 +98,9 @@ class UserRecord(SonarRecord):
     fetcher = user_pid_fetcher
     provider = UserProvider
     schema = 'users/user-v1.0.0.json'
-    available_roles = [ROLE_SUPERUSER, ROLE_ADMIN, ROLE_MODERATOR, ROLE_USER]
+    available_roles = [
+        ROLE_SUPERUSER, ROLE_ADMIN, ROLE_MODERATOR, ROLE_PUBLISHER, ROLE_USER
+    ]
 
     @classmethod
     def create(cls,

--- a/sonar/modules/users/permissions.py
+++ b/sonar/modules/users/permissions.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Permissions for users."""
+
+from sonar.modules.organisations.api import OrganisationRecord, \
+    current_organisation
+from sonar.modules.permissions import RecordPermission
+from sonar.modules.users.api import UserRecord, current_user_record
+
+
+class UserPermission(RecordPermission):
+    """Users permissions."""
+
+    @classmethod
+    def list(cls, user, record=None):
+        """List permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True is action can be done.
+        """
+        if not current_user_record:
+            return False
+
+        return True
+
+    @classmethod
+    def create(cls, user, record=None):
+        """Create permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True is action can be done.
+        """
+        if not current_user_record:
+            return False
+
+        return current_user_record.is_admin
+
+    @classmethod
+    def read(cls, user, record):
+        """Read permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True is action can be done.
+        """
+        if not current_user_record:
+            return False
+
+        # Can read himself in all cases
+        if current_user_record['pid'] == record['pid']:
+            return True
+
+        # If not admin, no access
+        if not current_user_record.is_admin:
+            return False
+
+        # Superuser is allowed
+        if current_user_record.is_superuser:
+            return True
+
+        # Cannot read superusers records
+        if UserRecord.ROLE_SUPERUSER in record['roles']:
+            return False
+
+        user = UserRecord.get_record_by_pid(record['pid'])
+        user = user.replace_refs()
+
+        return current_organisation['pid'] == user['organisation']['pid']
+
+    @classmethod
+    def update(cls, user, record):
+        """Update permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True is action can be done.
+        """
+        # Same rules as read permission.
+        return cls.read(user, record)
+
+    @classmethod
+    def delete(cls, user, record):
+        """Delete permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True is action can be done.
+        """
+        # At least for admin logged users.
+        if not current_user_record or not current_user_record.is_admin:
+            return False
+
+        # Superuser is allowed
+        if current_user_record.is_superuser:
+            return True
+
+        # Cannot delete himself
+        if current_user_record['pid'] == record['pid']:
+            return False
+
+        # For admin read is only for logged user organisation
+        if record['organisation'].get('$ref'):
+            return current_organisation[
+                'pid'] == OrganisationRecord.get_pid_by_ref_link(
+                    record['organisation']['$ref'])
+
+        return current_organisation['pid'] == record['organisation']['pid']

--- a/sonar/modules/users/query.py
+++ b/sonar/modules/users/query.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Query for users."""
+
+from invenio_records_rest.query import es_search_factory
+
+from sonar.modules.organisations.api import current_organisation
+from sonar.modules.users.api import current_user_record
+
+
+def search_factory(self, search, query_parser=None):
+    """User search factory.
+
+    :param search: Search instance.
+    :param query_parser: Url arguments.
+    :returns: Tuple with search instance and URL arguments.
+    """
+    search, urlkwargs = es_search_factory(self, search)
+
+    # Searching for existing email, everybody can do that
+    if urlkwargs.get('q') and urlkwargs['q'].startswith('email:'):
+        search = search.source(includes=['pid'])
+        return (search, urlkwargs)
+
+    # Super users can list all records
+    if current_user_record.is_superuser:
+        return (search, urlkwargs)
+
+    # For admins, records are filtererd by user's organisation and they cannot
+    # get superuser records.
+    if current_user_record.is_admin:
+        search = search \
+            .filter('term', organisation__pid=current_organisation['pid']) \
+            .filter('bool', must_not={'term': {'roles': 'superuser'}})
+        return (search, urlkwargs)
+
+    # For remaining roles, they can only list themselves
+    search = search.filter('term', pid=current_user_record['pid'])
+
+    return (search, urlkwargs)

--- a/sonar/translations/de/LC_MESSAGES/messages.po
+++ b/sonar/translations/de/LC_MESSAGES/messages.po
@@ -5,7 +5,6 @@
 #
 # Translators:
 # Nicolas Prongué <n.prongue@outlook.com>, 2020
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
@@ -670,418 +669,418 @@ msgid "Year"
 msgstr ""
 
 msgid "bf:Agent"
-msgstr ""
+msgstr "Agent"
 
 msgid "bf:AudioIssueNumber"
-msgstr ""
+msgstr "Audio issue number"
 
 msgid "bf:ClassificationDdc"
-msgstr ""
+msgstr "DDC Classification"
 
 msgid "bf:ClassificationUdc"
-msgstr ""
+msgstr "UDC Classification"
 
 msgid "bf:Doi"
-msgstr ""
+msgstr "DOI"
 
 msgid "bf:Ean"
-msgstr ""
+msgstr "EAN"
 
 msgid "bf:Gtin14Number"
-msgstr ""
+msgstr "Global Trade Item Number 14"
 
 msgid "bf:Identifier"
-msgstr ""
+msgstr "Identifier"
 
 msgid "bf:Isan"
-msgstr ""
+msgstr "ISAN"
 
 msgid "bf:Isbn"
-msgstr ""
+msgstr "ISBN"
 
 msgid "bf:Ismn"
-msgstr ""
+msgstr "ISMN"
 
 msgid "bf:Isrc"
-msgstr ""
+msgstr "ISRC"
 
 msgid "bf:Issn"
-msgstr ""
+msgstr "ISSN"
 
 msgid "bf:IssnL"
-msgstr ""
+msgstr "ISSN-L"
 
 msgid "bf:Language"
-msgstr ""
+msgstr "Language entity"
 
 msgid "bf:Local"
-msgstr ""
+msgstr "Local identifier"
 
 msgid "bf:Manufacture"
-msgstr ""
+msgstr "Manufacturer"
 
 msgid "bf:MatrixNumber"
-msgstr ""
+msgstr "Audio matrix number"
 
 msgid "bf:Meeting"
-msgstr ""
+msgstr "Meeting"
 
 msgid "bf:MusicDistributorNumber"
-msgstr ""
+msgstr "Music distributor number"
 
 msgid "bf:MusicPlate"
-msgstr ""
+msgstr "Music plate number"
 
 msgid "bf:MusicPublisherNumber"
-msgstr ""
+msgstr "Music publisher number"
 
 msgid "bf:Organization"
-msgstr ""
+msgstr "Organization"
 
 msgid "bf:Person"
-msgstr ""
+msgstr "Person"
 
 msgid "bf:Place"
-msgstr ""
+msgstr "Place"
 
 msgid "bf:Publication"
-msgstr ""
+msgstr "Publisher"
 
 msgid "bf:PublisherNumber"
-msgstr ""
+msgstr "Publisher number"
 
 msgid "bf:ReportNumber"
-msgstr ""
+msgstr "Technical report number"
 
 msgid "bf:Strn"
-msgstr ""
+msgstr "STRN"
 
 msgid "bf:Title"
-msgstr ""
+msgstr "Title entity"
 
 msgid "bf:Upc"
-msgstr ""
+msgstr "UPC"
 
 msgid "bf:Urn"
-msgstr ""
+msgstr "URN"
 
 msgid "bf:VideoRecordingNumber"
-msgstr ""
+msgstr "Video recording number"
 
 msgid "classification_004"
-msgstr ""
+msgstr "Computer science"
 
 msgid "classification_02"
-msgstr ""
+msgstr "Library sciences"
 
 msgid "classification_1"
-msgstr ""
+msgstr "Philosophy"
 
 msgid "classification_159.9"
-msgstr ""
+msgstr "Psychology"
 
 msgid "classification_159.953"
-msgstr ""
+msgstr "Memory and learning"
 
 msgid "classification_16"
-msgstr ""
+msgstr "Logic"
 
 msgid "classification_2"
-msgstr ""
+msgstr "Religion Theology"
 
 msgid "classification_294/299"
-msgstr ""
+msgstr "Orientalism"
 
 msgid "classification_3"
-msgstr ""
+msgstr "Social sciences"
 
 msgid "classification_31"
-msgstr ""
+msgstr "Demography Sociology Statistics"
 
 msgid "classification_32"
-msgstr ""
+msgstr "Political sciences"
 
 msgid "classification_33"
-msgstr ""
+msgstr "Economics"
 
 msgid "classification_34"
-msgstr ""
+msgstr "Law"
 
 msgid "classification_35"
-msgstr ""
+msgstr "Public administration"
 
 msgid "classification_36"
-msgstr ""
+msgstr "Social work"
 
 msgid "classification_37"
-msgstr ""
+msgstr "Education Teaching"
 
 msgid "classification_370"
-msgstr ""
+msgstr "Orthophony"
 
 msgid "classification_376"
-msgstr ""
+msgstr "Special education"
 
 msgid "classification_378.6"
-msgstr ""
+msgstr "Higher Education Institutions"
 
 msgid "classification_39"
-msgstr ""
+msgstr "Anthropology Ethnology"
 
 msgid "classification_51"
-msgstr ""
+msgstr "Mathematics"
 
 msgid "classification_519.2"
-msgstr ""
+msgstr "Probabilites Statistics"
 
 msgid "classification_52"
-msgstr ""
+msgstr "Astronomy Astrophysics"
 
 msgid "classification_524.8"
-msgstr ""
+msgstr "Cosmology"
 
 msgid "classification_53"
-msgstr ""
+msgstr "Physics"
 
 msgid "classification_54"
-msgstr ""
+msgstr "Chemistry"
 
 msgid "classification_543"
-msgstr ""
+msgstr "Analytical chemistry"
 
 msgid "classification_548"
-msgstr ""
+msgstr "Crystallography"
 
 msgid "classification_549"
-msgstr ""
+msgstr "Mineralogy"
 
 msgid "classification_55"
-msgstr ""
+msgstr "Geology"
 
 msgid "classification_55/56"
-msgstr ""
+msgstr "Earth sciences"
 
 msgid "classification_551"
-msgstr ""
+msgstr "Climate"
 
 msgid "classification_556"
-msgstr ""
+msgstr "Hydrology"
 
 msgid "classification_56"
-msgstr ""
+msgstr "Paleontology"
 
 msgid "classification_57"
-msgstr ""
+msgstr "Biology"
 
 msgid "classification_57/59"
-msgstr ""
+msgstr "Biology Life sciences"
 
 msgid "classification_574"
-msgstr ""
+msgstr "Ecology"
 
 msgid "classification_58"
-msgstr ""
+msgstr "Botany"
 
 msgid "classification_59"
-msgstr ""
+msgstr "Zoology"
 
 msgid "classification_6"
-msgstr ""
+msgstr "Engineering"
 
 msgid "classification_60"
-msgstr ""
+msgstr "Biotechnology"
 
 msgid "classification_61"
-msgstr ""
+msgstr "Medicine"
 
 msgid "classification_613.2"
-msgstr ""
+msgstr "Nutrition and Dietetics"
 
 msgid "classification_614.253.5"
-msgstr ""
+msgstr "Midwife"
 
 msgid "classification_615"
-msgstr ""
+msgstr "Therapeutic. Pharmacy Pharmacology"
 
 msgid "classification_615.8"
-msgstr ""
+msgstr "Physiotherapy"
 
 msgid "classification_615.84"
-msgstr ""
+msgstr "Medical Radiation Technology"
 
 msgid "classification_616"
-msgstr ""
+msgstr "Clinical medicine"
 
 msgid "classification_616-083"
-msgstr ""
+msgstr "Nursing"
 
 msgid "classification_616.31"
-msgstr ""
+msgstr "Dental medicine"
 
 msgid "classification_61_2"
-msgstr ""
+msgstr "Health"
 
 msgid "classification_620.1"
-msgstr ""
+msgstr "Materials"
 
 msgid "classification_620.9"
-msgstr ""
+msgstr "Energy"
 
 msgid "classification_621"
-msgstr ""
+msgstr "Industrial Engineering"
 
 msgid "classification_621.01"
-msgstr ""
+msgstr "Mechanics"
 
 msgid "classification_621.3"
-msgstr ""
+msgstr "Electricity"
 
 msgid "classification_621.38"
-msgstr ""
+msgstr "Electronics"
 
 msgid "classification_621.39"
-msgstr ""
+msgstr "Telecommunications"
 
 msgid "classification_621.762"
-msgstr ""
+msgstr "Powder metallurgy"
 
 msgid "classification_63"
-msgstr ""
+msgstr "Agriculture Agronomy"
 
 msgid "classification_65"
-msgstr ""
+msgstr "Information communication and media sciences"
 
 msgid "classification_66"
-msgstr ""
+msgstr "Chemical technology"
 
 msgid "classification_663"
-msgstr ""
+msgstr "Beverage industry"
 
 msgid "classification_664"
-msgstr ""
+msgstr "Food production and preservation"
 
 msgid "classification_681"
-msgstr ""
+msgstr "Microengineering"
 
 msgid "classification_7"
-msgstr ""
+msgstr "Arts"
 
 msgid "classification_7.071"
-msgstr ""
+msgstr "Art history"
 
 msgid "classification_71"
-msgstr ""
+msgstr "Urbanism"
 
 msgid "classification_72"
-msgstr ""
+msgstr "Architecture"
 
 msgid "classification_73/77"
-msgstr ""
+msgstr "Visual arts"
 
 msgid "classification_75"
-msgstr ""
+msgstr "Painting"
 
 msgid "classification_77"
-msgstr ""
+msgstr "Photography"
 
 msgid "classification_78"
-msgstr ""
+msgstr "Music"
 
 msgid "classification_796"
-msgstr ""
+msgstr "Sports sciences"
 
 msgid "classification_81"
-msgstr ""
+msgstr "Language Linguistics"
 
 msgid "classification_81´28"
-msgstr ""
+msgstr "Dialectology"
 
 msgid "classification_82"
-msgstr ""
+msgstr "Literature"
 
 msgid "classification_902"
-msgstr ""
+msgstr "Archeology"
 
 msgid "classification_903"
-msgstr ""
+msgstr "Pre-history"
 
 msgid "classification_91"
-msgstr ""
+msgstr "Geography"
 
 msgid "classification_929.5"
-msgstr ""
+msgstr "Genealogy"
 
 msgid "classification_93/94"
-msgstr ""
+msgstr "History"
 
 msgid "classification_931"
-msgstr ""
+msgstr "Ancient history"
 
 msgid "classification_94"
-msgstr ""
+msgstr "Medieval and modern history"
 
 msgid "classification_root_1"
-msgstr ""
+msgstr "Medicine, Technology, Engineering"
 
 msgid "classification_root_2"
-msgstr ""
+msgstr "Exact and natural sciences"
 
 msgid "classification_root_3"
-msgstr ""
+msgstr "Arts, Human and Social Science"
 
 msgid "contribution_role_cre"
-msgstr ""
+msgstr "Creator"
 
 msgid "contribution_role_ctb"
-msgstr ""
+msgstr "Contributor"
 
 msgid "contribution_role_dgs"
-msgstr ""
+msgstr "Degree supervisor"
 
 msgid "contribution_role_edt"
-msgstr ""
+msgstr "Editor"
 
 msgid "contribution_role_prt"
-msgstr ""
+msgstr "Printer"
 
 msgid "contributor"
 msgstr ""
 
 msgid "csal"
-msgstr ""
+msgstr "National licenses"
 
 msgid "deposit_log_action_approve"
-msgstr ""
+msgstr "Approve"
 
 msgid "deposit_log_action_ask_for_changes"
-msgstr ""
+msgstr "Ask for changes"
 
 msgid "deposit_log_action_reject"
-msgstr ""
+msgstr "Reject"
 
 msgid "deposit_log_action_submit"
-msgstr ""
+msgstr "Submit"
 
 msgid "deposit_status_ask_for_changes"
-msgstr ""
+msgstr "Ask for changes"
 
 msgid "deposit_status_in_progress"
-msgstr ""
+msgstr "In progress"
 
 msgid "deposit_status_rejected"
-msgstr ""
+msgstr "Rejected"
 
 msgid "deposit_status_to_validate"
-msgstr ""
+msgstr "To validate"
 
 msgid "deposit_status_validated"
-msgstr ""
+msgstr "Validated"
 
 msgid "document_type"
-msgstr ""
+msgstr "Document types"
 
 msgid "document_type_advanced_studies_thesis"
-msgstr ""
+msgstr "Advanced studies thesis"
 
 msgid "document_type_coar:c_0640"
 msgstr "Zeitschrift"
@@ -1090,52 +1089,52 @@ msgid "document_type_coar:c_12cc"
 msgstr "kartographisches Material"
 
 msgid "document_type_coar:c_15cd"
-msgstr ""
+msgstr "Patent"
 
 msgid "document_type_coar:c_1843"
-msgstr ""
+msgstr "Other"
 
 msgid "document_type_coar:c_186u"
-msgstr ""
+msgstr "Policy report"
 
 msgid "document_type_coar:c_18cc"
 msgstr "Ton"
 
 msgid "document_type_coar:c_18co"
-msgstr ""
+msgstr "Conference poster not in proceedings"
 
 msgid "document_type_coar:c_18cp"
-msgstr ""
+msgstr "Conference paper not in proceedings"
 
 msgid "document_type_coar:c_18cw"
 msgstr "Partitur"
 
 msgid "document_type_coar:c_18gh"
-msgstr ""
+msgstr "Technical report"
 
 msgid "document_type_coar:c_18hj"
-msgstr ""
+msgstr "Report to funding agency"
 
 msgid "document_type_coar:c_18op"
-msgstr ""
+msgstr "Project deliverable"
 
 msgid "document_type_coar:c_18wq"
-msgstr ""
+msgstr "Other type of report"
 
 msgid "document_type_coar:c_18ws"
 msgstr "Forschungsbericht"
 
 msgid "document_type_coar:c_18ww"
-msgstr ""
+msgstr "Internal report"
 
 msgid "document_type_coar:c_18wz"
-msgstr ""
+msgstr "Memorandum"
 
 msgid "document_type_coar:c_2659"
-msgstr ""
+msgstr "Periodical"
 
 msgid "document_type_coar:c_2cd9"
-msgstr ""
+msgstr "Magazine"
 
 msgid "document_type_coar:c_2f33"
 msgstr "Buch"
@@ -1147,7 +1146,7 @@ msgid "document_type_coar:c_3248"
 msgstr "Buchkapitel"
 
 msgid "document_type_coar:c_3e5a"
-msgstr ""
+msgstr "Contribution to journal"
 
 msgid "document_type_coar:c_46ec"
 msgstr "Abschlussarbeit"
@@ -1156,76 +1155,76 @@ msgid "document_type_coar:c_5794"
 msgstr "Konferenzbeitrag"
 
 msgid "document_type_coar:c_5ce6"
-msgstr ""
+msgstr "Software"
 
 msgid "document_type_coar:c_6501"
 msgstr "wissenschaftlicher Artikel"
 
 msgid "document_type_coar:c_6670"
-msgstr ""
+msgstr "Conference poster"
 
 msgid "document_type_coar:c_7a1f"
 msgstr "Abschlussarbeit (Bachelor)"
 
 msgid "document_type_coar:c_8042"
-msgstr ""
+msgstr "Working paper"
 
 msgid "document_type_coar:c_816b"
 msgstr "Preprint"
 
 msgid "document_type_coar:c_8544"
-msgstr ""
+msgstr "Lecture"
 
 msgid "document_type_coar:c_8a7e"
-msgstr ""
+msgstr "Moving image"
 
 msgid "document_type_coar:c_93fc"
-msgstr ""
+msgstr "Report"
 
 msgid "document_type_coar:c_998f"
-msgstr ""
+msgstr "Newspaper article"
 
 msgid "document_type_coar:c_ba1f"
-msgstr ""
+msgstr "Report part"
 
 msgid "document_type_coar:c_bdcc"
 msgstr "Abschlussarbeit (Master)"
 
 msgid "document_type_coar:c_beb9"
-msgstr ""
+msgstr "Data paper"
 
 msgid "document_type_coar:c_c94f"
-msgstr ""
+msgstr "Conference object"
 
 msgid "document_type_coar:c_db06"
 msgstr "Dissertation"
 
 msgid "document_type_coar:c_dcae04bc"
-msgstr ""
+msgstr "Review article"
 
 msgid "document_type_coar:c_ddb1"
-msgstr ""
+msgstr "Dataset"
 
 msgid "document_type_coar:c_ecc8"
 msgstr "Bild"
 
 msgid "document_type_coar:c_f744"
-msgstr ""
+msgstr "Conference proceedings"
 
 msgid "document_type_habilitation_thesis"
-msgstr ""
+msgstr "Habilitation thesis"
 
 msgid "document_type_non_textual_object"
-msgstr ""
+msgstr "Non-textual object"
 
 msgid "document_type_other"
-msgstr ""
+msgstr "Other"
 
 msgid "eduid"
-msgstr ""
+msgstr "Switch edu-ID"
 
 msgid "eduidtest"
-msgstr ""
+msgstr "Switch edu-ID Test"
 
 msgid "lang_aar"
 msgstr "Afar"
@@ -2698,22 +2697,22 @@ msgid "pid"
 msgstr ""
 
 msgid "role_admin"
-msgstr ""
+msgstr "Admin"
 
 msgid "role_moderator"
-msgstr ""
+msgstr "Moderator"
 
 msgid "role_publisher"
-msgstr ""
+msgstr "Submitter"
 
 msgid "role_superuser"
-msgstr ""
+msgstr "Super user"
 
 msgid "role_user"
-msgstr ""
+msgstr "User"
 
 msgid "specific_collections"
-msgstr ""
+msgstr "Specific collections"
 
 msgid "status"
 msgstr ""
@@ -2722,13 +2721,13 @@ msgid "subject"
 msgstr ""
 
 msgid "unifr"
-msgstr ""
+msgstr "University of Fribourg"
 
 msgid "unisi"
-msgstr ""
+msgstr "University of Lugano"
 
 msgid "uri"
-msgstr ""
+msgstr "URI"
 
 msgid "user"
 msgstr ""

--- a/sonar/translations/en/LC_MESSAGES/messages.po
+++ b/sonar/translations/en/LC_MESSAGES/messages.po
@@ -5,7 +5,6 @@
 #
 # Translators:
 # Nicolas Prongué <n.prongue@outlook.com>, 2020
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
@@ -1078,7 +1077,7 @@ msgid "deposit_status_validated"
 msgstr "Validated"
 
 msgid "document_type"
-msgstr "Document type"
+msgstr "Document types"
 
 msgid "document_type_advanced_studies_thesis"
 msgstr "Advanced studies thesis"
@@ -2713,7 +2712,7 @@ msgid "role_user"
 msgstr "User"
 
 msgid "specific_collections"
-msgstr ""
+msgstr "Specific collections"
 
 msgid "status"
 msgstr ""
@@ -2728,7 +2727,7 @@ msgid "unisi"
 msgstr "University of Lugano"
 
 msgid "uri"
-msgstr ""
+msgstr "URI"
 
 msgid "user"
 msgstr ""

--- a/sonar/translations/fr/LC_MESSAGES/messages.po
+++ b/sonar/translations/fr/LC_MESSAGES/messages.po
@@ -6,7 +6,6 @@
 # Translators:
 # Nicolas Prongué <n.prongue@outlook.com>, 2020
 # MarionRERO <marion.davis@rero.ch>, 2020
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
@@ -686,418 +685,418 @@ msgid "Year"
 msgstr "Année"
 
 msgid "bf:Agent"
-msgstr "bf:Agent"
+msgstr "Agent"
 
 msgid "bf:AudioIssueNumber"
-msgstr ""
+msgstr "Audio issue number"
 
 msgid "bf:ClassificationDdc"
-msgstr ""
+msgstr "DDC Classification"
 
 msgid "bf:ClassificationUdc"
-msgstr ""
+msgstr "UDC Classification"
 
 msgid "bf:Doi"
-msgstr ""
+msgstr "DOI"
 
 msgid "bf:Ean"
-msgstr ""
+msgstr "EAN"
 
 msgid "bf:Gtin14Number"
-msgstr ""
+msgstr "Global Trade Item Number 14"
 
 msgid "bf:Identifier"
-msgstr "bf:Identifiant"
+msgstr "Identifier"
 
 msgid "bf:Isan"
-msgstr ""
+msgstr "ISAN"
 
 msgid "bf:Isbn"
-msgstr ""
+msgstr "ISBN"
 
 msgid "bf:Ismn"
-msgstr ""
+msgstr "ISMN"
 
 msgid "bf:Isrc"
-msgstr ""
+msgstr "ISRC"
 
 msgid "bf:Issn"
-msgstr ""
+msgstr "ISSN"
 
 msgid "bf:IssnL"
-msgstr ""
+msgstr "ISSN-L"
 
 msgid "bf:Language"
-msgstr "bf:Langue"
+msgstr "Language entity"
 
 msgid "bf:Local"
-msgstr ""
+msgstr "Local identifier"
 
 msgid "bf:Manufacture"
-msgstr "bf:Manufacture"
+msgstr "Manufacturer"
 
 msgid "bf:MatrixNumber"
-msgstr ""
+msgstr "Audio matrix number"
 
 msgid "bf:Meeting"
-msgstr "bf:Réunion"
+msgstr "Meeting"
 
 msgid "bf:MusicDistributorNumber"
-msgstr ""
+msgstr "Music distributor number"
 
 msgid "bf:MusicPlate"
-msgstr ""
+msgstr "Music plate number"
 
 msgid "bf:MusicPublisherNumber"
-msgstr ""
+msgstr "Music publisher number"
 
 msgid "bf:Organization"
-msgstr "bf:Organisation"
+msgstr "Organization"
 
 msgid "bf:Person"
-msgstr "bf:Personne"
+msgstr "Person"
 
 msgid "bf:Place"
-msgstr "bf:Lieu"
+msgstr "Place"
 
 msgid "bf:Publication"
-msgstr "bf:Publication"
+msgstr "Publisher"
 
 msgid "bf:PublisherNumber"
-msgstr ""
+msgstr "Publisher number"
 
 msgid "bf:ReportNumber"
-msgstr ""
+msgstr "Technical report number"
 
 msgid "bf:Strn"
-msgstr ""
+msgstr "STRN"
 
 msgid "bf:Title"
-msgstr "bf:Titre"
+msgstr "Title entity"
 
 msgid "bf:Upc"
-msgstr ""
+msgstr "UPC"
 
 msgid "bf:Urn"
-msgstr ""
+msgstr "URN"
 
 msgid "bf:VideoRecordingNumber"
-msgstr ""
+msgstr "Video recording number"
 
 msgid "classification_004"
-msgstr ""
+msgstr "Computer science"
 
 msgid "classification_02"
-msgstr ""
+msgstr "Library sciences"
 
 msgid "classification_1"
-msgstr ""
+msgstr "Philosophy"
 
 msgid "classification_159.9"
-msgstr ""
+msgstr "Psychology"
 
 msgid "classification_159.953"
-msgstr ""
+msgstr "Memory and learning"
 
 msgid "classification_16"
-msgstr ""
+msgstr "Logic"
 
 msgid "classification_2"
-msgstr ""
+msgstr "Religion Theology"
 
 msgid "classification_294/299"
-msgstr ""
+msgstr "Orientalism"
 
 msgid "classification_3"
-msgstr ""
+msgstr "Social sciences"
 
 msgid "classification_31"
-msgstr ""
+msgstr "Demography Sociology Statistics"
 
 msgid "classification_32"
-msgstr ""
+msgstr "Political sciences"
 
 msgid "classification_33"
-msgstr ""
+msgstr "Economics"
 
 msgid "classification_34"
-msgstr ""
+msgstr "Law"
 
 msgid "classification_35"
-msgstr ""
+msgstr "Public administration"
 
 msgid "classification_36"
-msgstr ""
+msgstr "Social work"
 
 msgid "classification_37"
-msgstr ""
+msgstr "Education Teaching"
 
 msgid "classification_370"
-msgstr ""
+msgstr "Orthophony"
 
 msgid "classification_376"
-msgstr ""
+msgstr "Special education"
 
 msgid "classification_378.6"
-msgstr ""
+msgstr "Higher Education Institutions"
 
 msgid "classification_39"
-msgstr ""
+msgstr "Anthropology Ethnology"
 
 msgid "classification_51"
-msgstr ""
+msgstr "Mathematics"
 
 msgid "classification_519.2"
-msgstr ""
+msgstr "Probabilites Statistics"
 
 msgid "classification_52"
-msgstr ""
+msgstr "Astronomy Astrophysics"
 
 msgid "classification_524.8"
-msgstr ""
+msgstr "Cosmology"
 
 msgid "classification_53"
-msgstr ""
+msgstr "Physics"
 
 msgid "classification_54"
-msgstr ""
+msgstr "Chemistry"
 
 msgid "classification_543"
-msgstr ""
+msgstr "Analytical chemistry"
 
 msgid "classification_548"
-msgstr ""
+msgstr "Crystallography"
 
 msgid "classification_549"
-msgstr ""
+msgstr "Mineralogy"
 
 msgid "classification_55"
-msgstr ""
+msgstr "Geology"
 
 msgid "classification_55/56"
-msgstr ""
+msgstr "Earth sciences"
 
 msgid "classification_551"
-msgstr ""
+msgstr "Climate"
 
 msgid "classification_556"
-msgstr ""
+msgstr "Hydrology"
 
 msgid "classification_56"
-msgstr ""
+msgstr "Paleontology"
 
 msgid "classification_57"
-msgstr ""
+msgstr "Biology"
 
 msgid "classification_57/59"
-msgstr ""
+msgstr "Biology Life sciences"
 
 msgid "classification_574"
-msgstr ""
+msgstr "Ecology"
 
 msgid "classification_58"
-msgstr ""
+msgstr "Botany"
 
 msgid "classification_59"
-msgstr ""
+msgstr "Zoology"
 
 msgid "classification_6"
-msgstr ""
+msgstr "Engineering"
 
 msgid "classification_60"
-msgstr ""
+msgstr "Biotechnology"
 
 msgid "classification_61"
-msgstr ""
+msgstr "Medicine"
 
 msgid "classification_613.2"
-msgstr ""
+msgstr "Nutrition and Dietetics"
 
 msgid "classification_614.253.5"
-msgstr ""
+msgstr "Midwife"
 
 msgid "classification_615"
-msgstr ""
+msgstr "Therapeutic. Pharmacy Pharmacology"
 
 msgid "classification_615.8"
-msgstr ""
+msgstr "Physiotherapy"
 
 msgid "classification_615.84"
-msgstr ""
+msgstr "Medical Radiation Technology"
 
 msgid "classification_616"
-msgstr ""
+msgstr "Clinical medicine"
 
 msgid "classification_616-083"
-msgstr ""
+msgstr "Nursing"
 
 msgid "classification_616.31"
-msgstr ""
+msgstr "Dental medicine"
 
 msgid "classification_61_2"
-msgstr ""
+msgstr "Health"
 
 msgid "classification_620.1"
-msgstr ""
+msgstr "Materials"
 
 msgid "classification_620.9"
-msgstr ""
+msgstr "Energy"
 
 msgid "classification_621"
-msgstr ""
+msgstr "Industrial Engineering"
 
 msgid "classification_621.01"
-msgstr ""
+msgstr "Mechanics"
 
 msgid "classification_621.3"
-msgstr ""
+msgstr "Electricity"
 
 msgid "classification_621.38"
-msgstr ""
+msgstr "Electronics"
 
 msgid "classification_621.39"
-msgstr ""
+msgstr "Telecommunications"
 
 msgid "classification_621.762"
-msgstr ""
+msgstr "Powder metallurgy"
 
 msgid "classification_63"
-msgstr ""
+msgstr "Agriculture Agronomy"
 
 msgid "classification_65"
-msgstr ""
+msgstr "Information communication and media sciences"
 
 msgid "classification_66"
-msgstr ""
+msgstr "Chemical technology"
 
 msgid "classification_663"
-msgstr ""
+msgstr "Beverage industry"
 
 msgid "classification_664"
-msgstr ""
+msgstr "Food production and preservation"
 
 msgid "classification_681"
-msgstr ""
+msgstr "Microengineering"
 
 msgid "classification_7"
-msgstr ""
+msgstr "Arts"
 
 msgid "classification_7.071"
-msgstr ""
+msgstr "Art history"
 
 msgid "classification_71"
-msgstr ""
+msgstr "Urbanism"
 
 msgid "classification_72"
-msgstr ""
+msgstr "Architecture"
 
 msgid "classification_73/77"
-msgstr ""
+msgstr "Visual arts"
 
 msgid "classification_75"
-msgstr ""
+msgstr "Painting"
 
 msgid "classification_77"
-msgstr ""
+msgstr "Photography"
 
 msgid "classification_78"
-msgstr ""
+msgstr "Music"
 
 msgid "classification_796"
-msgstr ""
+msgstr "Sports sciences"
 
 msgid "classification_81"
-msgstr ""
+msgstr "Language Linguistics"
 
 msgid "classification_81´28"
-msgstr ""
+msgstr "Dialectology"
 
 msgid "classification_82"
-msgstr ""
+msgstr "Literature"
 
 msgid "classification_902"
-msgstr ""
+msgstr "Archeology"
 
 msgid "classification_903"
-msgstr ""
+msgstr "Pre-history"
 
 msgid "classification_91"
-msgstr ""
+msgstr "Geography"
 
 msgid "classification_929.5"
-msgstr ""
+msgstr "Genealogy"
 
 msgid "classification_93/94"
-msgstr ""
+msgstr "History"
 
 msgid "classification_931"
-msgstr ""
+msgstr "Ancient history"
 
 msgid "classification_94"
-msgstr ""
+msgstr "Medieval and modern history"
 
 msgid "classification_root_1"
-msgstr ""
+msgstr "Medicine, Technology, Engineering"
 
 msgid "classification_root_2"
-msgstr ""
+msgstr "Exact and natural sciences"
 
 msgid "classification_root_3"
-msgstr ""
+msgstr "Arts, Human and Social Science"
 
 msgid "contribution_role_cre"
-msgstr ""
+msgstr "Creator"
 
 msgid "contribution_role_ctb"
-msgstr ""
+msgstr "Contributor"
 
 msgid "contribution_role_dgs"
-msgstr ""
+msgstr "Degree supervisor"
 
 msgid "contribution_role_edt"
-msgstr ""
+msgstr "Editor"
 
 msgid "contribution_role_prt"
-msgstr ""
+msgstr "Printer"
 
 msgid "contributor"
 msgstr "contributeur"
 
 msgid "csal"
-msgstr ""
+msgstr "National licenses"
 
 msgid "deposit_log_action_approve"
-msgstr ""
+msgstr "Approve"
 
 msgid "deposit_log_action_ask_for_changes"
-msgstr ""
+msgstr "Ask for changes"
 
 msgid "deposit_log_action_reject"
-msgstr ""
+msgstr "Reject"
 
 msgid "deposit_log_action_submit"
-msgstr ""
+msgstr "Submit"
 
 msgid "deposit_status_ask_for_changes"
-msgstr "demande de modifications"
+msgstr "Demande de modifications"
 
 msgid "deposit_status_in_progress"
-msgstr "en cours"
+msgstr "En cours"
 
 msgid "deposit_status_rejected"
-msgstr "refusé"
+msgstr "Refusé"
 
 msgid "deposit_status_to_validate"
-msgstr "à valider"
+msgstr "A valider"
 
 msgid "deposit_status_validated"
-msgstr "validé"
+msgstr "Validé"
 
 msgid "document_type"
-msgstr ""
+msgstr "Document types"
 
 msgid "document_type_advanced_studies_thesis"
-msgstr ""
+msgstr "Advanced studies thesis"
 
 msgid "document_type_coar:c_0640"
 msgstr "revue"
@@ -1106,52 +1105,52 @@ msgid "document_type_coar:c_12cc"
 msgstr "matériel cartographique"
 
 msgid "document_type_coar:c_15cd"
-msgstr ""
+msgstr "Patent"
 
 msgid "document_type_coar:c_1843"
-msgstr ""
+msgstr "Other"
 
 msgid "document_type_coar:c_186u"
-msgstr ""
+msgstr "Policy report"
 
 msgid "document_type_coar:c_18cc"
 msgstr "son"
 
 msgid "document_type_coar:c_18co"
-msgstr ""
+msgstr "Conference poster not in proceedings"
 
 msgid "document_type_coar:c_18cp"
-msgstr ""
+msgstr "Conference paper not in proceedings"
 
 msgid "document_type_coar:c_18cw"
 msgstr "partition"
 
 msgid "document_type_coar:c_18gh"
-msgstr ""
+msgstr "Technical report"
 
 msgid "document_type_coar:c_18hj"
-msgstr ""
+msgstr "Report to funding agency"
 
 msgid "document_type_coar:c_18op"
-msgstr ""
+msgstr "Project deliverable"
 
 msgid "document_type_coar:c_18wq"
-msgstr ""
+msgstr "Other type of report"
 
 msgid "document_type_coar:c_18ws"
 msgstr "rapport de recherche"
 
 msgid "document_type_coar:c_18ww"
-msgstr ""
+msgstr "Internal report"
 
 msgid "document_type_coar:c_18wz"
-msgstr ""
+msgstr "Memorandum"
 
 msgid "document_type_coar:c_2659"
-msgstr ""
+msgstr "Periodical"
 
 msgid "document_type_coar:c_2cd9"
-msgstr ""
+msgstr "Magazine"
 
 msgid "document_type_coar:c_2f33"
 msgstr "livre"
@@ -1163,85 +1162,85 @@ msgid "document_type_coar:c_3248"
 msgstr "chapitre de livre"
 
 msgid "document_type_coar:c_3e5a"
-msgstr ""
+msgstr "Contribution to journal"
 
 msgid "document_type_coar:c_46ec"
-msgstr "thèse"
+msgstr "Thesis"
 
 msgid "document_type_coar:c_5794"
 msgstr "article de conférence"
 
 msgid "document_type_coar:c_5ce6"
-msgstr ""
+msgstr "Software"
 
 msgid "document_type_coar:c_6501"
 msgstr "article scientifique"
 
 msgid "document_type_coar:c_6670"
-msgstr ""
+msgstr "Conference poster"
 
 msgid "document_type_coar:c_7a1f"
 msgstr "mémoire de bachelor"
 
 msgid "document_type_coar:c_8042"
-msgstr ""
+msgstr "Working paper"
 
 msgid "document_type_coar:c_816b"
-msgstr "preprint"
+msgstr "Preprint"
 
 msgid "document_type_coar:c_8544"
-msgstr ""
+msgstr "Lecture"
 
 msgid "document_type_coar:c_8a7e"
-msgstr ""
+msgstr "Moving image"
 
 msgid "document_type_coar:c_93fc"
-msgstr ""
+msgstr "Report"
 
 msgid "document_type_coar:c_998f"
-msgstr ""
+msgstr "Newspaper article"
 
 msgid "document_type_coar:c_ba1f"
-msgstr ""
+msgstr "Report part"
 
 msgid "document_type_coar:c_bdcc"
 msgstr "mémoire de master"
 
 msgid "document_type_coar:c_beb9"
-msgstr ""
+msgstr "Data paper"
 
 msgid "document_type_coar:c_c94f"
-msgstr ""
+msgstr "Conference object"
 
 msgid "document_type_coar:c_db06"
 msgstr "thèse de doctorat"
 
 msgid "document_type_coar:c_dcae04bc"
-msgstr ""
+msgstr "Review article"
 
 msgid "document_type_coar:c_ddb1"
-msgstr ""
+msgstr "Dataset"
 
 msgid "document_type_coar:c_ecc8"
-msgstr "image"
+msgstr "Image"
 
 msgid "document_type_coar:c_f744"
-msgstr ""
+msgstr "Conference proceedings"
 
 msgid "document_type_habilitation_thesis"
-msgstr ""
+msgstr "Habilitation thesis"
 
 msgid "document_type_non_textual_object"
-msgstr ""
+msgstr "Non-textual object"
 
 msgid "document_type_other"
-msgstr ""
+msgstr "Other"
 
 msgid "eduid"
-msgstr ""
+msgstr "Switch edu-ID"
 
 msgid "eduidtest"
-msgstr ""
+msgstr "Switch edu-ID Test"
 
 msgid "lang_aar"
 msgstr "afar"
@@ -2714,22 +2713,22 @@ msgid "pid"
 msgstr ""
 
 msgid "role_admin"
-msgstr ""
+msgstr "Admin"
 
 msgid "role_moderator"
-msgstr ""
+msgstr "Moderator"
 
 msgid "role_publisher"
-msgstr ""
+msgstr "Submitter"
 
 msgid "role_superuser"
-msgstr ""
+msgstr "Super user"
 
 msgid "role_user"
-msgstr ""
+msgstr "User"
 
 msgid "specific_collections"
-msgstr ""
+msgstr "Specific collections"
 
 msgid "status"
 msgstr "statut"
@@ -2738,13 +2737,13 @@ msgid "subject"
 msgstr "sujet"
 
 msgid "unifr"
-msgstr ""
+msgstr "University of Fribourg"
 
 msgid "unisi"
-msgstr ""
+msgstr "University of Lugano"
 
 msgid "uri"
-msgstr ""
+msgstr "URI"
 
 msgid "user"
 msgstr "utilisateur"

--- a/sonar/translations/it/LC_MESSAGES/messages.po
+++ b/sonar/translations/it/LC_MESSAGES/messages.po
@@ -5,7 +5,6 @@
 #
 # Translators:
 # Nicolas Prongué <n.prongue@outlook.com>, 2020
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
@@ -670,418 +669,418 @@ msgid "Year"
 msgstr ""
 
 msgid "bf:Agent"
-msgstr ""
+msgstr "Agent"
 
 msgid "bf:AudioIssueNumber"
-msgstr ""
+msgstr "Audio issue number"
 
 msgid "bf:ClassificationDdc"
-msgstr ""
+msgstr "DDC Classification"
 
 msgid "bf:ClassificationUdc"
-msgstr ""
+msgstr "UDC Classification"
 
 msgid "bf:Doi"
-msgstr ""
+msgstr "DOI"
 
 msgid "bf:Ean"
-msgstr ""
+msgstr "EAN"
 
 msgid "bf:Gtin14Number"
-msgstr ""
+msgstr "Global Trade Item Number 14"
 
 msgid "bf:Identifier"
-msgstr ""
+msgstr "Identifier"
 
 msgid "bf:Isan"
-msgstr ""
+msgstr "ISAN"
 
 msgid "bf:Isbn"
-msgstr ""
+msgstr "ISBN"
 
 msgid "bf:Ismn"
-msgstr ""
+msgstr "ISMN"
 
 msgid "bf:Isrc"
-msgstr ""
+msgstr "ISRC"
 
 msgid "bf:Issn"
-msgstr ""
+msgstr "ISSN"
 
 msgid "bf:IssnL"
-msgstr ""
+msgstr "ISSN-L"
 
 msgid "bf:Language"
-msgstr ""
+msgstr "Language entity"
 
 msgid "bf:Local"
-msgstr ""
+msgstr "Local identifier"
 
 msgid "bf:Manufacture"
-msgstr ""
+msgstr "Manufacturer"
 
 msgid "bf:MatrixNumber"
-msgstr ""
+msgstr "Audio matrix number"
 
 msgid "bf:Meeting"
-msgstr ""
+msgstr "Meeting"
 
 msgid "bf:MusicDistributorNumber"
-msgstr ""
+msgstr "Music distributor number"
 
 msgid "bf:MusicPlate"
-msgstr ""
+msgstr "Music plate number"
 
 msgid "bf:MusicPublisherNumber"
-msgstr ""
+msgstr "Music publisher number"
 
 msgid "bf:Organization"
-msgstr ""
+msgstr "Organization"
 
 msgid "bf:Person"
-msgstr ""
+msgstr "Person"
 
 msgid "bf:Place"
-msgstr ""
+msgstr "Place"
 
 msgid "bf:Publication"
-msgstr ""
+msgstr "Publisher"
 
 msgid "bf:PublisherNumber"
-msgstr ""
+msgstr "Publisher number"
 
 msgid "bf:ReportNumber"
-msgstr ""
+msgstr "Technical report number"
 
 msgid "bf:Strn"
-msgstr ""
+msgstr "STRN"
 
 msgid "bf:Title"
-msgstr ""
+msgstr "Title entity"
 
 msgid "bf:Upc"
-msgstr ""
+msgstr "UPC"
 
 msgid "bf:Urn"
-msgstr ""
+msgstr "URN"
 
 msgid "bf:VideoRecordingNumber"
-msgstr ""
+msgstr "Video recording number"
 
 msgid "classification_004"
-msgstr ""
+msgstr "Computer science"
 
 msgid "classification_02"
-msgstr ""
+msgstr "Library sciences"
 
 msgid "classification_1"
-msgstr ""
+msgstr "Philosophy"
 
 msgid "classification_159.9"
-msgstr ""
+msgstr "Psychology"
 
 msgid "classification_159.953"
-msgstr ""
+msgstr "Memory and learning"
 
 msgid "classification_16"
-msgstr ""
+msgstr "Logic"
 
 msgid "classification_2"
-msgstr ""
+msgstr "Religion Theology"
 
 msgid "classification_294/299"
-msgstr ""
+msgstr "Orientalism"
 
 msgid "classification_3"
-msgstr ""
+msgstr "Social sciences"
 
 msgid "classification_31"
-msgstr ""
+msgstr "Demography Sociology Statistics"
 
 msgid "classification_32"
-msgstr ""
+msgstr "Political sciences"
 
 msgid "classification_33"
-msgstr ""
+msgstr "Economics"
 
 msgid "classification_34"
-msgstr ""
+msgstr "Law"
 
 msgid "classification_35"
-msgstr ""
+msgstr "Public administration"
 
 msgid "classification_36"
-msgstr ""
+msgstr "Social work"
 
 msgid "classification_37"
-msgstr ""
+msgstr "Education Teaching"
 
 msgid "classification_370"
-msgstr ""
+msgstr "Orthophony"
 
 msgid "classification_376"
-msgstr ""
+msgstr "Special education"
 
 msgid "classification_378.6"
-msgstr ""
+msgstr "Higher Education Institutions"
 
 msgid "classification_39"
-msgstr ""
+msgstr "Anthropology Ethnology"
 
 msgid "classification_51"
-msgstr ""
+msgstr "Mathematics"
 
 msgid "classification_519.2"
-msgstr ""
+msgstr "Probabilites Statistics"
 
 msgid "classification_52"
-msgstr ""
+msgstr "Astronomy Astrophysics"
 
 msgid "classification_524.8"
-msgstr ""
+msgstr "Cosmology"
 
 msgid "classification_53"
-msgstr ""
+msgstr "Physics"
 
 msgid "classification_54"
-msgstr ""
+msgstr "Chemistry"
 
 msgid "classification_543"
-msgstr ""
+msgstr "Analytical chemistry"
 
 msgid "classification_548"
-msgstr ""
+msgstr "Crystallography"
 
 msgid "classification_549"
-msgstr ""
+msgstr "Mineralogy"
 
 msgid "classification_55"
-msgstr ""
+msgstr "Geology"
 
 msgid "classification_55/56"
-msgstr ""
+msgstr "Earth sciences"
 
 msgid "classification_551"
-msgstr ""
+msgstr "Climate"
 
 msgid "classification_556"
-msgstr ""
+msgstr "Hydrology"
 
 msgid "classification_56"
-msgstr ""
+msgstr "Paleontology"
 
 msgid "classification_57"
-msgstr ""
+msgstr "Biology"
 
 msgid "classification_57/59"
-msgstr ""
+msgstr "Biology Life sciences"
 
 msgid "classification_574"
-msgstr ""
+msgstr "Ecology"
 
 msgid "classification_58"
-msgstr ""
+msgstr "Botany"
 
 msgid "classification_59"
-msgstr ""
+msgstr "Zoology"
 
 msgid "classification_6"
-msgstr ""
+msgstr "Engineering"
 
 msgid "classification_60"
-msgstr ""
+msgstr "Biotechnology"
 
 msgid "classification_61"
-msgstr ""
+msgstr "Medicine"
 
 msgid "classification_613.2"
-msgstr ""
+msgstr "Nutrition and Dietetics"
 
 msgid "classification_614.253.5"
-msgstr ""
+msgstr "Midwife"
 
 msgid "classification_615"
-msgstr ""
+msgstr "Therapeutic. Pharmacy Pharmacology"
 
 msgid "classification_615.8"
-msgstr ""
+msgstr "Physiotherapy"
 
 msgid "classification_615.84"
-msgstr ""
+msgstr "Medical Radiation Technology"
 
 msgid "classification_616"
-msgstr ""
+msgstr "Clinical medicine"
 
 msgid "classification_616-083"
-msgstr ""
+msgstr "Nursing"
 
 msgid "classification_616.31"
-msgstr ""
+msgstr "Dental medicine"
 
 msgid "classification_61_2"
-msgstr ""
+msgstr "Health"
 
 msgid "classification_620.1"
-msgstr ""
+msgstr "Materials"
 
 msgid "classification_620.9"
-msgstr ""
+msgstr "Energy"
 
 msgid "classification_621"
-msgstr ""
+msgstr "Industrial Engineering"
 
 msgid "classification_621.01"
-msgstr ""
+msgstr "Mechanics"
 
 msgid "classification_621.3"
-msgstr ""
+msgstr "Electricity"
 
 msgid "classification_621.38"
-msgstr ""
+msgstr "Electronics"
 
 msgid "classification_621.39"
-msgstr ""
+msgstr "Telecommunications"
 
 msgid "classification_621.762"
-msgstr ""
+msgstr "Powder metallurgy"
 
 msgid "classification_63"
-msgstr ""
+msgstr "Agriculture Agronomy"
 
 msgid "classification_65"
-msgstr ""
+msgstr "Information communication and media sciences"
 
 msgid "classification_66"
-msgstr ""
+msgstr "Chemical technology"
 
 msgid "classification_663"
-msgstr ""
+msgstr "Beverage industry"
 
 msgid "classification_664"
-msgstr ""
+msgstr "Food production and preservation"
 
 msgid "classification_681"
-msgstr ""
+msgstr "Microengineering"
 
 msgid "classification_7"
-msgstr ""
+msgstr "Arts"
 
 msgid "classification_7.071"
-msgstr ""
+msgstr "Art history"
 
 msgid "classification_71"
-msgstr ""
+msgstr "Urbanism"
 
 msgid "classification_72"
-msgstr ""
+msgstr "Architecture"
 
 msgid "classification_73/77"
-msgstr ""
+msgstr "Visual arts"
 
 msgid "classification_75"
-msgstr ""
+msgstr "Painting"
 
 msgid "classification_77"
-msgstr ""
+msgstr "Photography"
 
 msgid "classification_78"
-msgstr ""
+msgstr "Music"
 
 msgid "classification_796"
-msgstr ""
+msgstr "Sports sciences"
 
 msgid "classification_81"
-msgstr ""
+msgstr "Language Linguistics"
 
 msgid "classification_81´28"
-msgstr ""
+msgstr "Dialectology"
 
 msgid "classification_82"
-msgstr ""
+msgstr "Literature"
 
 msgid "classification_902"
-msgstr ""
+msgstr "Archeology"
 
 msgid "classification_903"
-msgstr ""
+msgstr "Pre-history"
 
 msgid "classification_91"
-msgstr ""
+msgstr "Geography"
 
 msgid "classification_929.5"
-msgstr ""
+msgstr "Genealogy"
 
 msgid "classification_93/94"
-msgstr ""
+msgstr "History"
 
 msgid "classification_931"
-msgstr ""
+msgstr "Ancient history"
 
 msgid "classification_94"
-msgstr ""
+msgstr "Medieval and modern history"
 
 msgid "classification_root_1"
-msgstr ""
+msgstr "Medicine, Technology, Engineering"
 
 msgid "classification_root_2"
-msgstr ""
+msgstr "Exact and natural sciences"
 
 msgid "classification_root_3"
-msgstr ""
+msgstr "Arts, Human and Social Science"
 
 msgid "contribution_role_cre"
-msgstr ""
+msgstr "Creator"
 
 msgid "contribution_role_ctb"
-msgstr ""
+msgstr "Contributor"
 
 msgid "contribution_role_dgs"
-msgstr ""
+msgstr "Degree supervisor"
 
 msgid "contribution_role_edt"
-msgstr ""
+msgstr "Editor"
 
 msgid "contribution_role_prt"
-msgstr ""
+msgstr "Printer"
 
 msgid "contributor"
 msgstr ""
 
 msgid "csal"
-msgstr ""
+msgstr "National licenses"
 
 msgid "deposit_log_action_approve"
-msgstr ""
+msgstr "Approve"
 
 msgid "deposit_log_action_ask_for_changes"
-msgstr ""
+msgstr "Ask for changes"
 
 msgid "deposit_log_action_reject"
-msgstr ""
+msgstr "Reject"
 
 msgid "deposit_log_action_submit"
-msgstr ""
+msgstr "Submit"
 
 msgid "deposit_status_ask_for_changes"
-msgstr ""
+msgstr "Ask for changes"
 
 msgid "deposit_status_in_progress"
-msgstr ""
+msgstr "In progress"
 
 msgid "deposit_status_rejected"
-msgstr ""
+msgstr "Rejected"
 
 msgid "deposit_status_to_validate"
-msgstr ""
+msgstr "To validate"
 
 msgid "deposit_status_validated"
-msgstr ""
+msgstr "Validated"
 
 msgid "document_type"
-msgstr ""
+msgstr "Document types"
 
 msgid "document_type_advanced_studies_thesis"
-msgstr ""
+msgstr "Advanced studies thesis"
 
 msgid "document_type_coar:c_0640"
 msgstr "rivista"
@@ -1090,52 +1089,52 @@ msgid "document_type_coar:c_12cc"
 msgstr "cartografia"
 
 msgid "document_type_coar:c_15cd"
-msgstr ""
+msgstr "Patent"
 
 msgid "document_type_coar:c_1843"
-msgstr ""
+msgstr "Other"
 
 msgid "document_type_coar:c_186u"
-msgstr ""
+msgstr "Policy report"
 
 msgid "document_type_coar:c_18cc"
 msgstr "suono"
 
 msgid "document_type_coar:c_18co"
-msgstr ""
+msgstr "Conference poster not in proceedings"
 
 msgid "document_type_coar:c_18cp"
-msgstr ""
+msgstr "Conference paper not in proceedings"
 
 msgid "document_type_coar:c_18cw"
 msgstr "partitura"
 
 msgid "document_type_coar:c_18gh"
-msgstr ""
+msgstr "Technical report"
 
 msgid "document_type_coar:c_18hj"
-msgstr ""
+msgstr "Report to funding agency"
 
 msgid "document_type_coar:c_18op"
-msgstr ""
+msgstr "Project deliverable"
 
 msgid "document_type_coar:c_18wq"
-msgstr ""
+msgstr "Other type of report"
 
 msgid "document_type_coar:c_18ws"
 msgstr "rapporto di ricerca"
 
 msgid "document_type_coar:c_18ww"
-msgstr ""
+msgstr "Internal report"
 
 msgid "document_type_coar:c_18wz"
-msgstr ""
+msgstr "Memorandum"
 
 msgid "document_type_coar:c_2659"
-msgstr ""
+msgstr "Periodical"
 
 msgid "document_type_coar:c_2cd9"
-msgstr ""
+msgstr "Magazine"
 
 msgid "document_type_coar:c_2f33"
 msgstr "libro"
@@ -1147,7 +1146,7 @@ msgid "document_type_coar:c_3248"
 msgstr "capitolo di libro"
 
 msgid "document_type_coar:c_3e5a"
-msgstr ""
+msgstr "Contribution to journal"
 
 msgid "document_type_coar:c_46ec"
 msgstr "tesi"
@@ -1156,76 +1155,76 @@ msgid "document_type_coar:c_5794"
 msgstr "articolo de congresso"
 
 msgid "document_type_coar:c_5ce6"
-msgstr ""
+msgstr "Software"
 
 msgid "document_type_coar:c_6501"
 msgstr "articolo scientifico"
 
 msgid "document_type_coar:c_6670"
-msgstr ""
+msgstr "Conference poster"
 
 msgid "document_type_coar:c_7a1f"
 msgstr "tesi di bachelor"
 
 msgid "document_type_coar:c_8042"
-msgstr ""
+msgstr "Working paper"
 
 msgid "document_type_coar:c_816b"
 msgstr "preprint"
 
 msgid "document_type_coar:c_8544"
-msgstr ""
+msgstr "Lecture"
 
 msgid "document_type_coar:c_8a7e"
-msgstr ""
+msgstr "Moving image"
 
 msgid "document_type_coar:c_93fc"
-msgstr ""
+msgstr "Report"
 
 msgid "document_type_coar:c_998f"
-msgstr ""
+msgstr "Newspaper article"
 
 msgid "document_type_coar:c_ba1f"
-msgstr ""
+msgstr "Report part"
 
 msgid "document_type_coar:c_bdcc"
 msgstr "tesi di master"
 
 msgid "document_type_coar:c_beb9"
-msgstr ""
+msgstr "Data paper"
 
 msgid "document_type_coar:c_c94f"
-msgstr ""
+msgstr "Conference object"
 
 msgid "document_type_coar:c_db06"
-msgstr " tesi di dottorato"
+msgstr "tesi di dottorato"
 
 msgid "document_type_coar:c_dcae04bc"
-msgstr ""
+msgstr "Review article"
 
 msgid "document_type_coar:c_ddb1"
-msgstr ""
+msgstr "Dataset"
 
 msgid "document_type_coar:c_ecc8"
 msgstr "immagine"
 
 msgid "document_type_coar:c_f744"
-msgstr ""
+msgstr "Conference proceedings"
 
 msgid "document_type_habilitation_thesis"
-msgstr ""
+msgstr "Habilitation thesis"
 
 msgid "document_type_non_textual_object"
-msgstr ""
+msgstr "Non-textual object"
 
 msgid "document_type_other"
-msgstr ""
+msgstr "Other"
 
 msgid "eduid"
-msgstr ""
+msgstr "Switch edu-ID"
 
 msgid "eduidtest"
-msgstr ""
+msgstr "Switch edu-ID Test"
 
 msgid "lang_aar"
 msgstr "afar"
@@ -2698,22 +2697,22 @@ msgid "pid"
 msgstr ""
 
 msgid "role_admin"
-msgstr ""
+msgstr "Admin"
 
 msgid "role_moderator"
-msgstr ""
+msgstr "Moderator"
 
 msgid "role_publisher"
-msgstr ""
+msgstr "Submitter"
 
 msgid "role_superuser"
-msgstr ""
+msgstr "Super user"
 
 msgid "role_user"
-msgstr ""
+msgstr "User"
 
 msgid "specific_collections"
-msgstr ""
+msgstr "Specific collections"
 
 msgid "status"
 msgstr ""
@@ -2722,13 +2721,13 @@ msgid "subject"
 msgstr ""
 
 msgid "unifr"
-msgstr ""
+msgstr "University of Fribourg"
 
 msgid "unisi"
-msgstr ""
+msgstr "University of Lugano"
 
 msgid "uri"
-msgstr ""
+msgstr "URI"
 
 msgid "user"
 msgstr ""

--- a/tests/api/deposits/test_deposits_permissions.py
+++ b/tests/api/deposits/test_deposits_permissions.py
@@ -1,0 +1,348 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test deposits permissions."""
+
+import json
+
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+
+from sonar.modules.deposits.api import DepositRecord
+
+
+def test_list(client, make_deposit, superuser, admin, moderator, publisher,
+              user):
+    """Test list deposits permissions."""
+    make_deposit('publisher', 'org')
+    make_deposit('admin', 'org')
+    make_deposit('publisher', 'org2')
+
+    # Not logged
+    res = client.get(url_for('invenio_records_rest.depo_list'))
+    assert res.status_code == 401
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.get(url_for('invenio_records_rest.depo_list'))
+    assert res.status_code == 403
+
+    # Logged as publisher
+    login_user_via_session(client, email=publisher['email'])
+    res = client.get(url_for('invenio_records_rest.depo_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total'] == 1
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.get(url_for('invenio_records_rest.depo_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total'] == 2
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.get(url_for('invenio_records_rest.depo_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total'] == 2
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.get(url_for('invenio_records_rest.depo_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total'] == 3
+
+
+def test_create(client, deposit_json, bucket_location, superuser, admin,
+                moderator, publisher, user):
+    """Test create deposits permissions."""
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+    }
+
+    # Not logged
+    res = client.post(url_for('invenio_records_rest.depo_list'),
+                      data=json.dumps(deposit_json),
+                      headers=headers)
+    assert res.status_code == 401
+
+    # User
+    login_user_via_session(client, email=user['email'])
+    deposit_json['user'] = {
+        '$ref': 'https://sonar.ch/api/users/{pid}'.format(pid=user['pid'])
+    }
+    res = client.post(url_for('invenio_records_rest.depo_list'),
+                      data=json.dumps(deposit_json),
+                      headers=headers)
+    assert res.status_code == 403
+
+    # Publisher
+    login_user_via_session(client, email=publisher['email'])
+    deposit_json['user'] = {
+        '$ref': 'https://sonar.ch/api/users/{pid}'.format(pid=publisher['pid'])
+    }
+    res = client.post(url_for('invenio_records_rest.depo_list'),
+                      data=json.dumps(deposit_json),
+                      headers=headers)
+    assert res.status_code == 201
+
+    # Moderator
+    login_user_via_session(client, email=moderator['email'])
+    deposit_json['user'] = {
+        '$ref': 'https://sonar.ch/api/users/{pid}'.format(pid=moderator['pid'])
+    }
+    res = client.post(url_for('invenio_records_rest.depo_list'),
+                      data=json.dumps(deposit_json),
+                      headers=headers)
+    assert res.status_code == 201
+
+    # Admin
+    login_user_via_session(client, email=admin['email'])
+    deposit_json['user'] = {
+        '$ref': 'https://sonar.ch/api/users/{pid}'.format(pid=admin['pid'])
+    }
+    res = client.post(url_for('invenio_records_rest.depo_list'),
+                      data=json.dumps(deposit_json),
+                      headers=headers)
+    assert res.status_code == 201
+
+    # Super user
+    login_user_via_session(client, email=superuser['email'])
+    deposit_json['user'] = {
+        '$ref': 'https://sonar.ch/api/users/{pid}'.format(pid=superuser['pid'])
+    }
+    res = client.post(url_for('invenio_records_rest.depo_list'),
+                      data=json.dumps(deposit_json),
+                      headers=headers)
+    assert res.status_code == 201
+
+
+def test_read(client, make_deposit, make_user, superuser, admin, moderator,
+              publisher, user):
+    """Test read deposits permissions."""
+    deposit1 = make_deposit('publisher', 'org')
+    deposit2 = make_deposit('publisher', 'org2')
+
+    # Not logged
+    res = client.get(
+        url_for('invenio_records_rest.depo_item', pid_value=deposit1['pid']))
+    assert res.status_code == 401
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.get(
+        url_for('invenio_records_rest.depo_item', pid_value=deposit1['pid']))
+    assert res.status_code == 403
+
+    # Logged as publisher
+    login_user_via_session(client, email=publisher['email'])
+    res = client.get(
+        url_for('invenio_records_rest.depo_item', pid_value=deposit1['pid']))
+    assert res.status_code == 200
+
+    res = client.get(
+        url_for('invenio_records_rest.depo_item', pid_value=deposit2['pid']))
+    assert res.status_code == 403
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.get(
+        url_for('invenio_records_rest.depo_item', pid_value=deposit1['pid']))
+    assert res.status_code == 200
+
+    res = client.get(
+        url_for('invenio_records_rest.depo_item', pid_value=deposit2['pid']))
+    assert res.status_code == 403
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.get(
+        url_for('invenio_records_rest.depo_item', pid_value=deposit1['pid']))
+    assert res.status_code == 200
+
+    res = client.get(
+        url_for('invenio_records_rest.depo_item', pid_value=deposit2['pid']))
+    assert res.status_code == 403
+
+    # Logged as admin of other organisation
+    other_admin = make_user('admin', 'org2')
+    login_user_via_session(client, email=other_admin['email'])
+    res = client.get(
+        url_for('invenio_records_rest.depo_item', pid_value=deposit1['pid']))
+    assert res.status_code == 403
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.get(
+        url_for('invenio_records_rest.depo_item', pid_value=deposit1['pid']))
+    assert res.status_code == 200
+
+
+def test_update(client, make_deposit, superuser, admin, moderator, publisher,
+                user):
+    """Test update deposits permissions."""
+    deposit1 = make_deposit('publisher', 'org')
+    deposit2 = make_deposit('publisher', 'org2')
+
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+    }
+
+    # Not logged
+    res = client.put(url_for('invenio_records_rest.depo_item',
+                             pid_value=deposit1['pid']),
+                     data=json.dumps(deposit1.dumps()),
+                     headers=headers)
+    assert res.status_code == 401
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.put(url_for('invenio_records_rest.depo_item',
+                             pid_value=deposit1['pid']),
+                     data=json.dumps(deposit1.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as publisher
+    login_user_via_session(client, email=publisher['email'])
+    res = client.put(url_for('invenio_records_rest.depo_item',
+                             pid_value=deposit1['pid']),
+                     data=json.dumps(deposit1.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+    res = client.put(url_for('invenio_records_rest.depo_item',
+                             pid_value=deposit2['pid']),
+                     data=json.dumps(deposit2.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.put(url_for('invenio_records_rest.depo_item',
+                             pid_value=deposit1['pid']),
+                     data=json.dumps(deposit1.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+    res = client.put(url_for('invenio_records_rest.depo_item',
+                             pid_value=deposit2['pid']),
+                     data=json.dumps(deposit2.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.put(url_for('invenio_records_rest.depo_item',
+                             pid_value=deposit1['pid']),
+                     data=json.dumps(deposit1.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+    res = client.put(url_for('invenio_records_rest.depo_item',
+                             pid_value=deposit2['pid']),
+                     data=json.dumps(deposit2.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.put(url_for('invenio_records_rest.depo_item',
+                             pid_value=deposit1['pid']),
+                     data=json.dumps(deposit1.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+    login_user_via_session(client, email=superuser['email'])
+    res = client.put(url_for('invenio_records_rest.depo_item',
+                             pid_value=deposit2['pid']),
+                     data=json.dumps(deposit2.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+
+def test_delete(client, db, make_deposit, superuser, admin, moderator,
+                publisher, user):
+    """Test delete deposits permissions."""
+    deposit1 = make_deposit('publisher', 'org')
+    deposit2 = make_deposit('publisher', 'org2')
+
+    # Not logged
+    res = client.delete(
+        url_for('invenio_records_rest.depo_item', pid_value=deposit1['pid']))
+    assert res.status_code == 401
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.depo_item', pid_value=deposit1['pid']))
+    assert res.status_code == 403
+
+    # Logged as publisher
+    login_user_via_session(client, email=publisher['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.depo_item', pid_value=deposit2['pid']))
+    assert res.status_code == 403
+
+    deposit1['status'] = DepositRecord.STATUS_VALIDATED
+    deposit1.commit()
+    db.session.commit()
+
+    res = client.delete(
+        url_for('invenio_records_rest.depo_item', pid_value=deposit1['pid']))
+    assert res.status_code == 403
+
+    deposit1['status'] = DepositRecord.STATUS_IN_PROGRESS
+    deposit1.commit()
+    db.session.commit()
+
+    res = client.delete(
+        url_for('invenio_records_rest.depo_item', pid_value=deposit1['pid']))
+    assert res.status_code == 204
+
+    deposit1 = make_deposit('publisher', 'org')
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.depo_item', pid_value=deposit2['pid']))
+    assert res.status_code == 403
+
+    res = client.delete(
+        url_for('invenio_records_rest.depo_item', pid_value=deposit1['pid']))
+    assert res.status_code == 204
+
+    deposit1 = make_deposit('publisher', 'org')
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.depo_item', pid_value=deposit2['pid']))
+    assert res.status_code == 403
+
+    res = client.delete(
+        url_for('invenio_records_rest.depo_item', pid_value=deposit1['pid']))
+    assert res.status_code == 204
+
+    deposit1 = make_deposit('publisher', 'org')
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.depo_item', pid_value=deposit1['pid']))
+    assert res.status_code == 204

--- a/tests/api/documents/test_documents_permissions.py
+++ b/tests/api/documents/test_documents_permissions.py
@@ -1,0 +1,303 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test documents permissions."""
+
+import json
+
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+
+
+def test_list(client, make_document, superuser, admin, moderator, publisher,
+              user):
+    """Test list documents permissions."""
+    make_document(None)
+    make_document('org')
+
+    # Not logged
+    res = client.get(url_for('invenio_records_rest.doc_list'))
+    assert res.status_code == 401
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.get(url_for('invenio_records_rest.doc_list'))
+    assert res.status_code == 403
+
+    # Logged as publisher
+    login_user_via_session(client, email=publisher['email'])
+    res = client.get(url_for('invenio_records_rest.doc_list'))
+    assert res.status_code == 403
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.get(url_for('invenio_records_rest.doc_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total'] == 1
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.get(url_for('invenio_records_rest.doc_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total'] == 1
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.get(url_for('invenio_records_rest.doc_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total'] == 2
+
+    # Public search
+    res = client.get(url_for('invenio_records_rest.doc_list', view='sonar'))
+    assert res.status_code == 200
+    assert res.json['hits']['total'] == 2
+
+    # Public search for organisation
+    res = client.get(url_for('invenio_records_rest.doc_list', view='org'))
+    assert res.status_code == 200
+    assert res.json['hits']['total'] == 1
+
+
+def test_create(client, document_json, superuser, admin, moderator, publisher,
+                user):
+    """Test create documents permissions."""
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+    }
+
+    # Not logged
+    res = client.post(url_for('invenio_records_rest.doc_list'),
+                      data=json.dumps(document_json),
+                      headers=headers)
+    assert res.status_code == 401
+
+    # User
+    login_user_via_session(client, email=user['email'])
+    res = client.post(url_for('invenio_records_rest.doc_list'),
+                      data=json.dumps(document_json),
+                      headers=headers)
+    assert res.status_code == 403
+
+    # Publisher
+    login_user_via_session(client, email=publisher['email'])
+    res = client.post(url_for('invenio_records_rest.doc_list'),
+                      data=json.dumps(document_json),
+                      headers=headers)
+    assert res.status_code == 403
+
+    # Moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.post(url_for('invenio_records_rest.doc_list'),
+                      data=json.dumps(document_json),
+                      headers=headers)
+    assert res.status_code == 201
+    assert res.json['metadata']['organisation'][
+        '$ref'] == 'https://sonar.ch/api/organisations/org'
+
+    # Admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.post(url_for('invenio_records_rest.doc_list'),
+                      data=json.dumps(document_json),
+                      headers=headers)
+    assert res.status_code == 201
+    assert res.json['metadata']['organisation'][
+        '$ref'] == 'https://sonar.ch/api/organisations/org'
+
+    # Super user
+    login_user_via_session(client, email=superuser['email'])
+    res = client.post(url_for('invenio_records_rest.doc_list'),
+                      data=json.dumps(document_json),
+                      headers=headers)
+    assert res.status_code == 201
+    assert res.json['metadata']['organisation'][
+        '$ref'] == 'https://sonar.ch/api/organisations/org'
+
+
+def test_read(client, document, make_user, superuser, admin, moderator,
+              publisher, user):
+    """Test read documents permissions."""
+    # Not logged
+    res = client.get(
+        url_for('invenio_records_rest.doc_item', pid_value=document['pid']))
+    assert res.status_code == 401
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.get(
+        url_for('invenio_records_rest.doc_item', pid_value=document['pid']))
+    assert res.status_code == 403
+
+    # Logged as publisher
+    login_user_via_session(client, email=publisher['email'])
+    res = client.get(
+        url_for('invenio_records_rest.doc_item', pid_value=document['pid']))
+    assert res.status_code == 403
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.get(
+        url_for('invenio_records_rest.doc_item', pid_value=document['pid']))
+    assert res.status_code == 200
+    assert res.json['metadata']['permissions'] == {
+        'delete': False,
+        'read': True,
+        'update': True
+    }
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.get(
+        url_for('invenio_records_rest.doc_item', pid_value=document['pid']))
+    assert res.status_code == 200
+    assert res.json['metadata']['permissions'] == {
+        'delete': True,
+        'read': True,
+        'update': True
+    }
+
+    # Logged as admin of other organisation
+    other_admin = make_user('admin', 'org2')
+    login_user_via_session(client, email=other_admin['email'])
+    res = client.get(
+        url_for('invenio_records_rest.doc_item', pid_value=document['pid']))
+    assert res.status_code == 403
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.get(
+        url_for('invenio_records_rest.doc_item', pid_value=document['pid']))
+    assert res.status_code == 200
+    assert res.json['metadata']['permissions'] == {
+        'delete': True,
+        'read': True,
+        'update': True
+    }
+
+
+def test_update(client, document, make_user, superuser, admin, moderator,
+                publisher, user):
+    """Test update documents permissions."""
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+    }
+
+    # Not logged
+    res = client.put(url_for('invenio_records_rest.doc_item',
+                             pid_value=document['pid']),
+                     data=json.dumps(document.dumps()),
+                     headers=headers)
+    assert res.status_code == 401
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.put(url_for('invenio_records_rest.doc_item',
+                             pid_value=document['pid']),
+                     data=json.dumps(document.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as publisher
+    login_user_via_session(client, email=publisher['email'])
+    res = client.put(url_for('invenio_records_rest.doc_item',
+                             pid_value=document['pid']),
+                     data=json.dumps(document.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.put(url_for('invenio_records_rest.doc_item',
+                             pid_value=document['pid']),
+                     data=json.dumps(document.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.put(url_for('invenio_records_rest.doc_item',
+                             pid_value=document['pid']),
+                     data=json.dumps(document.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+    # Logged as admin of other organisation
+    other_admin = make_user('admin', 'org2')
+    login_user_via_session(client, email=other_admin['email'])
+    res = client.put(url_for('invenio_records_rest.doc_item',
+                             pid_value=document['pid']),
+                     data=json.dumps(document.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.put(url_for('invenio_records_rest.doc_item',
+                             pid_value=document['pid']),
+                     data=json.dumps(document.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+
+def test_delete(client, document, make_document, make_user, superuser, admin,
+                moderator, publisher, user):
+    """Test delete documents permissions."""
+    # Not logged
+    res = client.delete(
+        url_for('invenio_records_rest.doc_item', pid_value=document['pid']))
+    assert res.status_code == 401
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.doc_item', pid_value=document['pid']))
+    assert res.status_code == 403
+
+    # Logged as publisher
+    login_user_via_session(client, email=publisher['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.doc_item', pid_value=document['pid']))
+    assert res.status_code == 403
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.doc_item', pid_value=document['pid']))
+    assert res.status_code == 403
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.doc_item', pid_value=document['pid']))
+    assert res.status_code == 204
+
+    # Create a new document
+    document = make_document()
+
+    # Logged as admin of other organisation
+    other_admin = make_user('admin', 'org2')
+    login_user_via_session(client, email=other_admin['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.doc_item', pid_value=document['pid']))
+    assert res.status_code == 403
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.doc_item', pid_value=document['pid']))
+    assert res.status_code == 204

--- a/tests/api/documents/test_documents_rest.py
+++ b/tests/api/documents/test_documents_rest.py
@@ -30,12 +30,12 @@ def test_put(app, client, document_with_file):
 
     # Retrieve document by doing a get request.
     response = client.get(url_for('invenio_records_rest.doc_item',
-                                  pid_value=10000),
+                                  pid_value=document_with_file['pid']),
                           headers=headers)
 
     # Put data to document
     response = client.put(url_for('invenio_records_rest.doc_item',
-                                  pid_value=10000),
+                                  pid_value=document_with_file['pid']),
                           headers=headers,
                           data=json.dumps(response.json['metadata']))
     assert response.status_code == 200

--- a/tests/api/organisations/test_organisations_permissions.py
+++ b/tests/api/organisations/test_organisations_permissions.py
@@ -1,0 +1,274 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test organisations permissions."""
+
+import json
+
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+
+
+def test_list(client, make_organisation, superuser, admin, moderator,
+              publisher, user):
+    """Test list organisations permissions."""
+    make_organisation('org2')
+
+    # Not logged
+    res = client.get(url_for('invenio_records_rest.org_list'))
+    assert res.status_code == 401
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.get(url_for('invenio_records_rest.org_list'))
+    assert res.status_code == 403
+
+    # Logged as publisher
+    login_user_via_session(client, email=publisher['email'])
+    res = client.get(url_for('invenio_records_rest.org_list'))
+    assert res.status_code == 403
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.get(url_for('invenio_records_rest.org_list'))
+    assert res.status_code == 403
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.get(url_for('invenio_records_rest.org_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total'] == 1
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.get(url_for('invenio_records_rest.org_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total'] == 2
+
+
+def test_create(client, superuser, admin, moderator, publisher, user):
+    """Test create organisations permissions."""
+    data = {'code': 'org2', 'name': 'org2'}
+
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+    }
+
+    # Not logged
+    res = client.post(url_for('invenio_records_rest.org_list'),
+                      data=json.dumps(data),
+                      headers=headers)
+    assert res.status_code == 401
+
+    # User
+    login_user_via_session(client, email=user['email'])
+    res = client.post(url_for('invenio_records_rest.org_list'),
+                      data=json.dumps(data),
+                      headers=headers)
+    assert res.status_code == 403
+
+    # Publisher
+    login_user_via_session(client, email=publisher['email'])
+    res = client.post(url_for('invenio_records_rest.org_list'),
+                      data=json.dumps(data),
+                      headers=headers)
+    assert res.status_code == 403
+
+    # Moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.post(url_for('invenio_records_rest.org_list'),
+                      data=json.dumps(data),
+                      headers=headers)
+    assert res.status_code == 403
+
+    # Admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.post(url_for('invenio_records_rest.org_list'),
+                      data=json.dumps(data),
+                      headers=headers)
+    assert res.status_code == 403
+
+    # Super user
+    login_user_via_session(client, email=superuser['email'])
+    res = client.post(url_for('invenio_records_rest.org_list'),
+                      data=json.dumps(data),
+                      headers=headers)
+    assert res.status_code == 201
+    assert res.json['metadata']['pid'] == 'org2'
+
+
+def test_read(client, make_organisation, superuser, admin, moderator,
+              publisher, user):
+    """Test read organisations permissions."""
+    make_organisation('org2')
+
+    # Not logged
+    res = client.get(url_for('invenio_records_rest.org_item', pid_value='org'))
+    assert res.status_code == 401
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.get(url_for('invenio_records_rest.org_item', pid_value='org'))
+    assert res.status_code == 403
+
+    # Logged as publisher
+    login_user_via_session(client, email=publisher['email'])
+    res = client.get(url_for('invenio_records_rest.org_item', pid_value='org'))
+    assert res.status_code == 403
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.get(url_for('invenio_records_rest.org_item', pid_value='org'))
+    assert res.status_code == 403
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.get(url_for('invenio_records_rest.org_item', pid_value='org'))
+    assert res.status_code == 200
+    assert res.json['metadata']['permissions'] == {
+        'delete': False,
+        'read': True,
+        'update': True
+    }
+
+    # Logged as admin of other organisation
+    res = client.get(url_for('invenio_records_rest.org_item',
+                             pid_value='org2'))
+    assert res.status_code == 403
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.get(url_for('invenio_records_rest.org_item', pid_value='org'))
+    assert res.status_code == 200
+
+    login_user_via_session(client, email=superuser['email'])
+    res = client.get(url_for('invenio_records_rest.org_item',
+                             pid_value='org2'))
+    assert res.status_code == 200
+    assert res.json['metadata']['permissions'] == {
+        'delete': False,
+        'read': True,
+        'update': True
+    }
+
+
+def test_update(client, make_organisation, superuser, admin, moderator,
+                publisher, user):
+    """Test update organisations permissions."""
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+    }
+
+    org = make_organisation('org')
+    org2 = make_organisation('org2')
+
+    # Not logged
+    res = client.put(url_for('invenio_records_rest.org_item', pid_value='org'),
+                     data=json.dumps(org.dumps()),
+                     headers=headers)
+    assert res.status_code == 401
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.put(url_for('invenio_records_rest.org_item', pid_value='org'),
+                     data=json.dumps(org.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as publisher
+    login_user_via_session(client, email=publisher['email'])
+    res = client.put(url_for('invenio_records_rest.org_item', pid_value='org'),
+                     data=json.dumps(org.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.put(url_for('invenio_records_rest.org_item', pid_value='org'),
+                     data=json.dumps(org.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.put(url_for('invenio_records_rest.org_item', pid_value='org'),
+                     data=json.dumps(org.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+    # Logged as admin of other organisation
+    res = client.put(url_for('invenio_records_rest.org_item',
+                             pid_value=org2['pid']),
+                     data=json.dumps(org2.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.put(url_for('invenio_records_rest.org_item',
+                             pid_value=org['pid']),
+                     data=json.dumps(org.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+    login_user_via_session(client, email=superuser['email'])
+    res = client.put(url_for('invenio_records_rest.org_item',
+                             pid_value=org2['pid']),
+                     data=json.dumps(org2.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+
+def test_delete(client, superuser, admin,
+                moderator, publisher, user):
+    """Test delete organisations permissions."""
+    # Not logged
+    res = client.delete(
+        url_for('invenio_records_rest.org_item', pid_value='org'))
+    assert res.status_code == 401
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.org_item', pid_value='org'))
+    assert res.status_code == 403
+
+    # Logged as publisher
+    login_user_via_session(client, email=publisher['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.org_item', pid_value='org'))
+    assert res.status_code == 403
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.org_item', pid_value='org'))
+    assert res.status_code == 403
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.org_item', pid_value='org'))
+    assert res.status_code == 403
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.org_item', pid_value='org'))
+    assert res.status_code == 403

--- a/tests/api/test_api_simple_flow.py
+++ b/tests/api/test_api_simple_flow.py
@@ -21,14 +21,17 @@ import json
 
 import mock
 from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
 from utils import VerifyRecordPermissionPatch
 
 
 @mock.patch('invenio_records_rest.views.verify_record_permission',
             mock.MagicMock(return_value=VerifyRecordPermissionPatch))
-def test_simple_flow(client, document_json):
+def test_simple_flow(client, document_json, admin):
     """Test simple flow using REST API."""
     headers = [('Content-Type', 'application/json')]
+
+    login_user_via_session(client, email=admin['email'])
 
     # create a record
     response = client.post(url_for('invenio_records_rest.doc_list'),
@@ -43,10 +46,13 @@ def test_simple_flow(client, document_json):
         'value'] == 'Title of the document'
 
 
-def test_add_files_restrictions(client, document_with_file):
+def test_add_files_restrictions(client, document_with_file, superuser):
     """Test adding file restrictions before dumping object."""
+    login_user_via_session(client, email=superuser['email'])
     res = client.get(
-        url_for('invenio_records_rest.doc_item', pid_value=10000, resolve=1))
+        url_for('invenio_records_rest.doc_item',
+                pid_value=document_with_file['pid'],
+                resolve=1))
     assert res.status_code == 200
     assert res.json['metadata']['_files'][0]['restriction'] == {
         'restricted': True,

--- a/tests/api/users/test_users_permissions.py
+++ b/tests/api/users/test_users_permissions.py
@@ -1,0 +1,379 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test users permissions."""
+
+import json
+
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+
+
+def test_list(client, make_user, superuser, admin, moderator, publisher, user):
+    """Test list users permissions."""
+    make_user('user', 'org2')
+
+    # Not logged
+    res = client.get(url_for('invenio_records_rest.user_list'))
+    assert res.status_code == 401
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.get(url_for('invenio_records_rest.user_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total'] == 1
+
+    # Test search email, no result
+    res = client.get(
+        url_for('invenio_records_rest.user_list',
+                q='email:"test@gmail.com"%20NOT%20pid:3'))
+    assert res.status_code == 200
+    assert res.json['hits']['total'] == 0
+
+    # Test search email, existing email
+    res = client.get(
+        url_for('invenio_records_rest.user_list',
+                q='email:"orgadmin@rero.ch"%20NOT%20pid:3'))
+    assert res.status_code == 200
+    assert res.json['hits']['total'] == 1
+    assert not res.json['hits']['hits'][0]['metadata'].get('email')
+
+    # Logged as publisher
+    login_user_via_session(client, email=publisher['email'])
+    res = client.get(url_for('invenio_records_rest.user_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total'] == 1
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.get(url_for('invenio_records_rest.user_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total'] == 1
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.get(url_for('invenio_records_rest.user_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total'] == 4
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.get(url_for('invenio_records_rest.user_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total'] == 6
+
+
+def test_create(client, organisation, superuser, admin, moderator, publisher,
+                user):
+    """Test create users permissions."""
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+    }
+
+    user_json = {
+        'email': 'user@rero.ch',
+        'full_name': 'User',
+        'roles': ['user']
+    }
+
+    # Not logged
+    res = client.post(url_for('invenio_records_rest.user_list'),
+                      data=json.dumps(user_json),
+                      headers=headers)
+    assert res.status_code == 401
+
+    # User
+    login_user_via_session(client, email=user['email'])
+    res = client.post(url_for('invenio_records_rest.user_list'),
+                      data=json.dumps(user_json),
+                      headers=headers)
+    assert res.status_code == 403
+
+    # Publisher
+    login_user_via_session(client, email=publisher['email'])
+    res = client.post(url_for('invenio_records_rest.user_list'),
+                      data=json.dumps(user_json),
+                      headers=headers)
+    assert res.status_code == 403
+
+    # Moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.post(url_for('invenio_records_rest.user_list'),
+                      data=json.dumps(user_json),
+                      headers=headers)
+    assert res.status_code == 403
+
+    # Admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.post(url_for('invenio_records_rest.user_list'),
+                      data=json.dumps(user_json),
+                      headers=headers)
+    assert res.status_code == 201
+    assert res.json['metadata']['organisation'][
+        '$ref'] == 'https://sonar.ch/api/organisations/org'
+
+    # Super user
+    user_json['organisation'] = {
+        '$ref':
+        'https://sonar.ch/api/organisations/{organisation}'.format(
+            organisation=organisation['pid'])
+    }
+
+    login_user_via_session(client, email=superuser['email'])
+    res = client.post(url_for('invenio_records_rest.user_list'),
+                      data=json.dumps(user_json),
+                      headers=headers)
+    assert res.status_code == 201
+    assert res.json['metadata']['organisation'][
+        '$ref'] == 'https://sonar.ch/api/organisations/org'
+
+
+def test_read(client, make_user, superuser, admin, moderator, publisher, user):
+    """Test read users permissions."""
+    # Not logged
+    res = client.get(
+        url_for('invenio_records_rest.user_item', pid_value=user['pid']))
+    assert res.status_code == 401
+
+    # Logged as user and read himself
+    login_user_via_session(client, email=user['email'])
+    res = client.get(
+        url_for('invenio_records_rest.user_item', pid_value=user['pid']))
+    assert res.status_code == 200
+    assert res.json['metadata']['permissions'] == {
+        'delete': False,
+        'read': True,
+        'update': True
+    }
+
+    # Logged as user and read other
+    login_user_via_session(client, email=user['email'])
+    res = client.get(
+        url_for('invenio_records_rest.user_item', pid_value=moderator['pid']))
+    assert res.status_code == 403
+
+    # Logged as publisher
+    login_user_via_session(client, email=publisher['email'])
+    res = client.get(
+        url_for('invenio_records_rest.user_item', pid_value=publisher['pid']))
+    assert res.status_code == 200
+    assert res.json['metadata']['permissions'] == {
+        'delete': False,
+        'read': True,
+        'update': True
+    }
+
+    login_user_via_session(client, email=publisher['email'])
+    res = client.get(
+        url_for('invenio_records_rest.user_item', pid_value=user['pid']))
+    assert res.status_code == 403
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.get(
+        url_for('invenio_records_rest.user_item', pid_value=moderator['pid']))
+    assert res.status_code == 200
+    assert res.json['metadata']['permissions'] == {
+        'delete': False,
+        'read': True,
+        'update': True
+    }
+
+    login_user_via_session(client, email=moderator['email'])
+    res = client.get(
+        url_for('invenio_records_rest.user_item', pid_value=user['pid']))
+    assert res.status_code == 403
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.get(
+        url_for('invenio_records_rest.user_item', pid_value=user['pid']))
+    assert res.status_code == 200
+    assert res.json['metadata']['permissions'] == {
+        'delete': True,
+        'read': True,
+        'update': True
+    }
+
+    # Logged as admin, try to read superuser
+    login_user_via_session(client, email=admin['email'])
+    res = client.get(
+        url_for('invenio_records_rest.user_item', pid_value=superuser['pid']))
+    assert res.status_code == 403
+
+    # Logged as admin of other organisation
+    other_admin = make_user('admin', 'org2')
+    login_user_via_session(client, email=other_admin['email'])
+    res = client.get(
+        url_for('invenio_records_rest.user_item', pid_value=user['pid']))
+    assert res.status_code == 403
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.get(
+        url_for('invenio_records_rest.user_item', pid_value=user['pid']))
+    assert res.status_code == 200
+    assert res.json['metadata']['permissions'] == {
+        'delete': True,
+        'read': True,
+        'update': True
+    }
+
+
+def test_update(client, make_user, superuser, admin, moderator, publisher,
+                user):
+    """Test update users permissions."""
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+    }
+
+    # Not logged
+    res = client.put(url_for('invenio_records_rest.user_item',
+                             pid_value=user['pid']),
+                     data=json.dumps(user.dumps()),
+                     headers=headers)
+    assert res.status_code == 401
+
+    # Logged as user and update himself
+    login_user_via_session(client, email=user['email'])
+    res = client.put(url_for('invenio_records_rest.user_item',
+                             pid_value=user['pid']),
+                     data=json.dumps(user.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+    # Logged as user and update other
+    login_user_via_session(client, email=user['email'])
+    res = client.put(url_for('invenio_records_rest.user_item',
+                             pid_value=moderator['pid']),
+                     data=json.dumps(moderator.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as publisher
+    login_user_via_session(client, email=publisher['email'])
+    res = client.put(url_for('invenio_records_rest.user_item',
+                             pid_value=publisher['pid']),
+                     data=json.dumps(publisher.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+    login_user_via_session(client, email=publisher['email'])
+    res = client.put(url_for('invenio_records_rest.user_item',
+                             pid_value=user['pid']),
+                     data=json.dumps(user.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.put(url_for('invenio_records_rest.user_item',
+                             pid_value=moderator['pid']),
+                     data=json.dumps(moderator.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+    login_user_via_session(client, email=moderator['email'])
+    res = client.put(url_for('invenio_records_rest.user_item',
+                             pid_value=user['pid']),
+                     data=json.dumps(user.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.put(url_for('invenio_records_rest.user_item',
+                             pid_value=user['pid']),
+                     data=json.dumps(user.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+    # Logged as admin, try to update super user
+    login_user_via_session(client, email=admin['email'])
+    res = client.put(url_for('invenio_records_rest.user_item',
+                             pid_value=superuser['pid']),
+                     data=json.dumps(superuser.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as admin of other organisation
+    other_admin = make_user('admin', 'org2')
+    login_user_via_session(client, email=other_admin['email'])
+    res = client.put(url_for('invenio_records_rest.user_item',
+                             pid_value=user['pid']),
+                     data=json.dumps(user.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.put(url_for('invenio_records_rest.user_item',
+                             pid_value=user['pid']),
+                     data=json.dumps(user.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+
+def test_delete(client, make_user, superuser, admin, moderator, publisher,
+                user):
+    """Test delete users permissions."""
+    # Not logged
+    res = client.delete(
+        url_for('invenio_records_rest.user_item', pid_value=user['pid']))
+    assert res.status_code == 401
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.user_item', pid_value=user['pid']))
+    assert res.status_code == 403
+
+    # Logged as publisher
+    login_user_via_session(client, email=publisher['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.user_item', pid_value=user['pid']))
+    assert res.status_code == 403
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.user_item', pid_value=user['pid']))
+    assert res.status_code == 403
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.user_item', pid_value=user['pid']))
+    assert res.status_code == 204
+
+    # Create a new user
+    user = make_user('user', 'org3')
+
+    # Logged as admin of other organisation
+    other_admin = make_user('admin', 'org2')
+    login_user_via_session(client, email=other_admin['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.user_item', pid_value=user['pid']))
+    assert res.status_code == 403
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.user_item', pid_value=user['pid']))
+    assert res.status_code == 204

--- a/tests/ui/documents/test_documents_api.py
+++ b/tests/ui/documents/test_documents_api.py
@@ -27,7 +27,7 @@ def test_get_record_by_identifier(app, document):
         'value': '111111',
         'type': 'bf:Local'
     }])
-    assert record['pid'] == '10000'
+    assert record['pid'] == document['pid']
 
     # Record not found
     record = DocumentRecord.get_record_by_identifier([{

--- a/tests/ui/documents/test_documents_tasks.py
+++ b/tests/ui/documents/test_documents_tasks.py
@@ -28,26 +28,23 @@ from sonar.modules.documents.tasks import import_records
 def test_import_records(mock_record_by_identifier, app, document_json,
                         bucket_location):
     """Test import records."""
-    # Successful importing record
-    mock_record_by_identifier.return_value = None
-    document_json['files'] = [{
+    files = [{
         'key': 'test.pdf',
         'url': 'http://some.url/file.pdf'
     }]
-    import_records([document_json])
-    assert DocumentRecord.get_record_by_pid('10000')
+
+    # Successful importing record
+    mock_record_by_identifier.return_value = None
+    document_json['files'] = files
+    ids = import_records([document_json])
+    assert DocumentRecord.get_record(ids[0])
 
     # Error during importation of record
     def exception_side_effect(data):
         raise Exception("No record found for identifier")
 
     mock_record_by_identifier.side_effect = exception_side_effect
-    document_json['pid'] = '10001'
-    document_json['files'] = [{
-        'key': 'test.pdf',
-        'url': 'http://some.url/file.pdf'
-    }]
 
-    import_records([document_json])
+    ids = import_records([document_json])
 
-    assert not DocumentRecord.get_record_by_pid('10001')
+    assert not ids

--- a/tests/ui/documents/test_documents_views.py
+++ b/tests/ui/documents/test_documents_views.py
@@ -20,6 +20,7 @@
 import datetime
 
 import pytest
+from flask import url_for
 
 import sonar.modules.documents.views as views
 
@@ -38,13 +39,16 @@ def test_index(client):
 def test_search(app, client):
     """Test search."""
     assert isinstance(views.search(), str)
-    assert client.get(
-        '/organisation/sonar/search/documents').status_code == 200
+    assert client.get(url_for('documents.search',
+                              resource_type='documents')).status_code == 200
 
 
 def test_detail(app, client, document):
     """Test document detail page."""
-    assert client.get('/organisation/sonar/documents/10000').status_code == 200
+    assert client.get(
+        url_for('invenio_records_ui.document',
+                ir='sonar',
+                pid_value=document['pid'])).status_code == 200
 
 
 def test_title_format(document):

--- a/tests/ui/users/test_users_api.py
+++ b/tests/ui/users/test_users_api.py
@@ -58,10 +58,9 @@ def test_get_user_by_current_user(app, client, user_without_role, user):
     client.get(url_for_security('logout'))
 
     login_user_via_view(client, email=user['email'], password='123456')
-    print(current_user)
     record = UserRecord.get_user_by_current_user(current_user)
     assert 'email' in record
-    assert user['email'] == 'org-user@rero.ch'
+    assert user['email'] == 'orguser@rero.ch'
 
 
 def test_get_reachable_roles(app):
@@ -153,7 +152,7 @@ def test_delete(app, admin):
 
     with app.app_context():
         datastore = app.extensions['security'].datastore
-        user = datastore.find_user(email='org-admin@rero.ch')
+        user = datastore.find_user(email='orgadmin@rero.ch')
         assert not user.roles
         assert not user.is_active
 
@@ -165,7 +164,7 @@ def test_update(app, admin, roles):
 
     with app.app_context():
         datastore = app.extensions['security'].datastore
-        user = datastore.find_user(email='org-admin@rero.ch')
+        user = datastore.find_user(email='orgadmin@rero.ch')
         assert user.roles[0].name == 'superuser'
 
 
@@ -174,7 +173,7 @@ def test_reactivate_user(app, admin):
     with app.app_context():
         datastore = app.extensions['security'].datastore
 
-        user = datastore.find_user(email='org-admin@rero.ch')
+        user = datastore.find_user(email='orgadmin@rero.ch')
         assert user.is_active
 
         datastore.deactivate_user(user)
@@ -184,7 +183,7 @@ def test_reactivate_user(app, admin):
         del admin.__dict__['user']
 
         admin.update({'roles': ['admin']})
-        user = datastore.find_user(email='org-admin@rero.ch')
+        user = datastore.find_user(email='orgadmin@rero.ch')
         assert user.roles[0].name == 'admin'
         assert user.is_active
 


### PR DESCRIPTION
* Creates a factory for managing permissions.
* Adds serializer and loader for deposit resources.
* Adds a deny access permission.
* Adds specific permissions decisions for all resources.
* Adds queries factories for filtering records in lists.
* Adds permissions results when serializing a record.
* Changes path in deposit validation email.
* Guesses user's organisation when creating a user record.
* Guesses user's organisation when creating a document record.
* Removes redirection to documents records when accessing administration.
* Adds permissions checks for adding resources when retrieving logged user by API.
* Removes organisation from user and document schema when logged user is not superuser.
* Improves fixtures in tests.
* Closes #146.
* Closes #217.

## How to test
For each roles (superuser, admin, moderator, publisher, user):
1. Login as user with the current role.
2. Check the access of the different resources. It must correspond to permissions matrix in https://docs.google.com/spreadsheets/d/1GyFbkm3VDCrffbShaFsoMJnkGQYtw65sWbfW25J2Mxk/edit#gid=0.
