### PR TITLE
deposits: add organisation in documents

### DIFF
--- a/sonar/modules/deposits/api.py
+++ b/sonar/modules/deposits/api.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from functools import partial
 
 from sonar.modules.documents.api import DocumentRecord
+from sonar.modules.users.api import current_user_record
 
 from ..api import SonarIndexer, SonarRecord, SonarSearch
 from ..fetchers import id_fetcher
@@ -97,6 +98,10 @@ class DepositRecord(SonarRecord):
     def create_document(self):
         """Create document from deposit."""
         metadata = {}
+
+        # Organisation
+        if current_user_record and current_user_record.get('organisation'):
+            metadata['organisation'] = current_user_record['organisation']
 
         # Document type
         metadata['documentType'] = self['metadata']['documentType']

--- a/tests/ui/deposits/test_deposits_api.py
+++ b/tests/ui/deposits/test_deposits_api.py
@@ -17,10 +17,18 @@
 
 """Test API for deposits."""
 
+from invenio_accounts.testutils import login_user_via_view
 
-def test_create_document(app, deposit):
+
+def test_create_document(app, client, deposit, user):
     """Test create document based on it."""
+    login_user_via_view(client, email=user['email'], password='123456')
+
     document = deposit.create_document()
+
+    assert document['organisation'] == {
+        '$ref': 'https://sonar.ch/api/organisations/org'
+    }
 
     assert document['documentType'] == 'coar:c_816b'
     assert document['title'] == [{


### PR DESCRIPTION
* Adds the organisation of the logged user when a deposit is converted to document.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>

## How to test
1. Login as administrator or moderator.
2. Create and validate a new deposit.
3. Check the document is created after deposit validation and is associated to the user organisation.
