### PR TITLE
organisations: access records with specific URL

### DIFF
--- a/sonar/config.py
+++ b/sonar/config.py
@@ -243,11 +243,6 @@ SECURITY_RESET_PASSWORD_TEMPLATE = 'sonar/accounts/reset_password.html'
 SECURITY_REGISTER_USER_TEMPLATE = 'sonar/accounts/signup.html'
 
 RECORDS_UI_ENDPOINTS = {
-    'document': {
-        'pid_type': 'doc',
-        'route': '/organisation/<ir>/documents/<pid_value>',
-        'view_imp': 'sonar.modules.documents.views:detail'
-    },
     'doc_previewer': {
         'pid_type': 'doc',
         'route': '/documents/<pid_value>/preview/<filename>',

--- a/sonar/modules/documents/dojson/rerodoc/overdo.py
+++ b/sonar/modules/documents/dojson/rerodoc/overdo.py
@@ -47,7 +47,9 @@ class Overdo(BaseOverdo):
             organisation = OrganisationRecord.create(
                 {
                     'code': organisation_key,
-                    'name': organisation_key
+                    'name': organisation_key,
+                    'isShared': False,
+                    'isDedicated': False
                 },
                 dbcommit=True)
             organisation.reindex()

--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -226,7 +226,7 @@
           {% endif %}
 
           <!-- PERMANENT LINK -->
-          {% set link = url_for('invenio_records_ui.document', pid_value=record.pid, ir=g.ir|default('sonar'), _external=True) %}
+          {% set link = url_for('documents.detail', pid_value=record.pid, view=view_code, _external=True) %}
           {{ dl(_('Permalink'), '<a href="' + link + '">' + link + '</a>') }}
         </dl>
       </div>

--- a/sonar/modules/ext.py
+++ b/sonar/modules/ext.py
@@ -26,7 +26,7 @@ from flask_wiki import Wiki
 
 from sonar.modules.permissions import has_admin_access, has_publisher_access, \
     has_superuser_access
-from sonar.modules.utils import get_switch_aai_providers
+from sonar.modules.utils import get_switch_aai_providers, get_view_code
 
 from . import config
 
@@ -38,7 +38,8 @@ def utility_processor():
                 has_admin_access=has_admin_access,
                 has_superuser_access=has_superuser_access,
                 ui_version=config.SONAR_APP_UI_VERSION,
-                aai_providers=get_switch_aai_providers)
+                aai_providers=get_switch_aai_providers,
+                view_code=get_view_code())
 
 
 class Sonar(object):

--- a/sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0.json
+++ b/sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0.json
@@ -33,11 +33,28 @@
       "title": "Name",
       "type": "string",
       "minLength": 1
+    },
+    "isShared": {
+      "title": "Is shared",
+      "description": "Organisation records can be accessed by a specific URL.",
+      "type": "boolean",
+      "default": false
+    },
+    "isDedicated": {
+      "title": "Is dedicated",
+      "description": "Organisation has a specific theme for his view.",
+      "type": "boolean",
+      "default": false,
+      "form": {
+        "hideExpression": "!field.model.isShared"
+      }
     }
   },
   "propertiesOrder": [
     "code",
-    "name"
+    "name",
+    "isShared",
+    "isDedicated"
   ],
   "required": [
     "pid",

--- a/sonar/modules/organisations/mappings/v6/organisations/organisation-v1.0.0.json
+++ b/sonar/modules/organisations/mappings/v6/organisations/organisation-v1.0.0.json
@@ -14,8 +14,11 @@
         "code": {
           "type": "keyword"
         },
-        "name": {
-          "type": "text"
+        "isShared": {
+          "type": "boolean"
+        },
+        "isDedicated": {
+          "type": "boolean"
         },
         "_created": {
           "type": "date"

--- a/sonar/modules/organisations/marshmallow/json.py
+++ b/sonar/modules/organisations/marshmallow/json.py
@@ -41,6 +41,8 @@ class OrganisationMetadataSchemaV1(StrictKeysMixin):
     pid = PersistentIdentifier()
     code = SanitizedUnicode(required=True)
     name = SanitizedUnicode(required=True)
+    isShared = fields.Boolean()
+    isDedicated = fields.Boolean()
     # When loading, if $schema is not provided, it's retrieved by
     # Record.schema property.
     schema = GenFunction(load_only=True,

--- a/sonar/modules/utils.py
+++ b/sonar/modules/utils.py
@@ -19,7 +19,7 @@
 
 import re
 
-from flask import current_app
+from flask import current_app, g
 from invenio_i18n.ext import current_i18n
 from invenio_mail.api import TemplatedMessage
 from wand.color import Color
@@ -118,3 +118,14 @@ def remove_trailing_punctuation(data,
 def get_current_language():
     """Return the current selected locale."""
     return current_i18n.locale.language
+
+
+def get_view_code():
+    """Return view code corresponding to organisation.
+
+    :returns: View code as string.
+    """
+    if g.get('organisation'):
+        return g.organisation['code']
+
+    return current_app.config.get('SONAR_APP_DEFAULT_ORGANISATION')

--- a/sonar/theme/assets/scss/common/_theme.scss
+++ b/sonar/theme/assets/scss/common/_theme.scss
@@ -24,8 +24,8 @@
   background-color: #15334D;
 }
 
-.bg-ir {
-    background-color: $bg-ir;
+.bg-organisation {
+    background-color: $bg-organisation;
 }
 
 img.logo {
@@ -33,7 +33,7 @@ img.logo {
     max-height: 90px;
 }
 
-.text-ir {
+.text-organisation {
     @extend .text-light
 }
 

--- a/sonar/theme/assets/scss/common/_variables.scss
+++ b/sonar/theme/assets/scss/common/_variables.scss
@@ -20,6 +20,6 @@ $fa-font-path: "~font-awesome/fonts";
 $primary: #205078 !default;
 $secondary: rgb(246, 130, 17) !default;
 
-$bg-ir: $primary !default;
+$bg-organisation: $primary !default;
 
 $font-family-base: 'Roboto', sans-serif;

--- a/sonar/theme/templates/sonar/frontpage.html
+++ b/sonar/theme/templates/sonar/frontpage.html
@@ -20,13 +20,14 @@
 {%- extends config.BASE_TEMPLATE %}
 
 {% block header %}
-<div class="bg-ir p-4">
+<div class="bg-organisation p-4">
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-8 col-xs-6 col-lg-4 py-3 py-sm-5">
-            <a href="{{ url_for('documents.index', ir=g.ir|default('sonar')) }}">
+            <a href="{{ url_for('documents.index', view=view_code) }}">
                 {%- if config.THEME_LOGO %}
-                  <img src="{{ url_for('static', filename='images/' ~ g.ir|default('sonar') ~ '-logo.svg')}}" alt="{{_(config.THEME_SITENAME)}}" class="logo"/>
+                  {% set logo_code = view_code if g.get('organisation', {}).get('isDedicated') else config.SONAR_APP_DEFAULT_ORGANISATION %}
+                  <img src="{{ url_for('static', filename='images/' ~ logo_code ~ '-logo.svg')}}" alt="{{_(config.THEME_SITENAME)}}" class="logo"/>
                 {%- else %}
                   {{_(config.THEME_SITENAME)}}
                 {%- endif %}
@@ -35,14 +36,14 @@
       </div>
       <div class="row justify-content-center">
           <div class="col-sm-12 col-lg-8 text-right my-4">
-            <form class="justify-content-end" action="{{ url_for('documents.search', ir=g.ir|default('sonar'), resource_type='documents') }}" role="search">
+            <form class="justify-content-end" action="{{ url_for('documents.search', view=view_code) }}" role="search">
               <div class="row">
                 <div class="col-12 col-sm-11">
                     <input class="form-control form-control-lg mr-2" type="search" placeholder="{{_('Search publications, authors, projects, ...')}}" aria-label="Search" name="q">
                 </div>
                 <div class="col-2 col-sm-1 d-none d-sm-block">
                   <button class="btn btn-link btn-lg" type="submit">
-                    <i class="fa fa-search fa-lg text-ir"></i>
+                    <i class="fa fa-search fa-lg text-organisation"></i>
                   </button>
                 </div>
               </div>

--- a/sonar/theme/templates/sonar/page.html
+++ b/sonar/theme/templates/sonar/page.html
@@ -67,7 +67,11 @@
       {%- endblock head_links %}
 
       {%- block css %}
-        {{ webpack[g.ir|default('sonar') ~ '-theme.css'] }}
+        {% if g.get('organisation', {}).get('isDedicated') %}
+          {{ webpack[view_code ~ '-theme.css'] }}
+        {% else %}
+          {{ webpack['sonar-theme.css'] }}
+        {% endif %}
         {# assets "invenio_theme_css" %}<link href="{{ ASSET_URL }}" rel="stylesheet">{% endassets #}
         <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
         <!--[if lt IE 9]>

--- a/sonar/theme/templates/sonar/partial/navbar.html
+++ b/sonar/theme/templates/sonar/partial/navbar.html
@@ -15,86 +15,100 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #}
 
-<nav class="navbar navbar-expand-lg navbar-dark bg-{{ 'header' if page == 'home' else 'ir' }}">
+{% if g.get('organisation') and not g.organisation['isDedicated'] %}
+  <div class="bg-secondary text-light p-1">
     <div class="container">
-        {%- if not current_user.is_authenticated %}
-            <a href="{{url_for_security('login', next=request.path)}}" class="btn btn-light ml-auto mr-2 d-block d-lg-none">
-                <i class="fa fa-lock"></i>
-            </a>
-        {% else %}
-            <div class="dropdown ml-auto mr-2 d-block d-lg-none">
-            {% with dropdownId='userButtonDropdown' %}
-                <button class="btn btn-light" type="button" id="{{dropdownId}}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                    <i class="fa fa-user"></i>
-                </button>
-                {% include 'sonar/partial/dropdown_user.html' %}
-            {% endwith %}
-            </div>
-        {% endif%}
-        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <i class="fa fa-bars p-1"></i>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
-            {% if page != 'home' %}
-            <a class="navbar-brand" href="{{ url_for('documents.index', ir=g.ir|default('sonar')) }}">
-                <img src="{{ url_for('static', filename='images/' ~ g.ir|default('sonar') ~ '-logo.svg')}}" height="50" class="d-inline-block align-top mr-3 my-4" alt="">
-            </a>
-                {% if not admin %}
-                <form action="{{ url_for('documents.search', ir=g.ir|default('sonar'), resource_type='documents') }}" class="form-inline my-2 my-lg-0 ml-lg-5">
-                    <input name="q" class="form-control mr-sm-2" type="search" placeholder="{{_('Search')}}" aria-label="{{_('Search')}}" value="{{ request.args.get('q', '') }}">
-                    <button class="btn btn-outline-light my-2 my-sm-0" type="submit">
-                        <i class="fa fa-search"></i>
-                    </button>
-                </form>
-                {% else %}
-                    <span class="navbar-text text-secondary">{{ _('Administration')|upper }}</span>
-                {% endif %}
-            {% endif %}
-            {% if g.ir|default('sonar') != 'sonar' %}
-                <ul class="navbar-nav mr-auto ml-4">
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{url_for('invenio_theme_frontpage.index')}}">
-                            {{_('Back to SONAR')}}
-                        </a>
-                    </li>
-                </ul>
-            {% endif %}
-            <ul class="navbar-nav ml-auto">
-                {%- if not current_user.is_authenticated %}
-                    <li class="nav-item px-3 d-none d-lg-block">
-                        <a class="nav-link" href="{{url_for_security('login', next=request.path)}}" title="{{ _('Log in') }}">
-                            <i class="fa fa-lock"></i>
-                        </a>
-                    </li>
-                    {% if security.registerable %}
-                    <li class="nav-item">
-                        <a class="nav-link text-uppercase" href="{{ url_for_security('register') }}">{{ _('Sign up') }}</a>
-                    </li>
-                    {% endif %}
-                {% else %}
-                    <li class="nav-item dropdown d-none d-lg-block px-3">
-                    {% with dropdownId='userLinkDropdown' %}
-                        <a class="nav-link text-uppercase" href="#" id="{{ dropdownId }}" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            <i class="fa fa-user mr-2"></i>
-                            {{ current_user.profile.full_name if current_user.profile.full_name else current_user.email }}
-                        </a>
-                        {% include 'sonar/partial/dropdown_user.html' %}
-                    {% endwith %}
-                    </li>
-                {% endif %}
-                {%- if config.I18N_LANGUAGES %}
-                    <li class="nav-item dropdown pl-3">
-                        <a class="nav-link" href="#" id="languageDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            {{ current_i18n.language|upper }}
-                        </a>
-                        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="languageDropdown">
-                        {% for l in current_i18n.get_locales() %}
-                            <a class="dropdown-item" href="{{ url_for('invenio_i18n.set_lang', lang_code=l.language) }}">{{ l.get_display_name()|capitalize }}</a>
-                        {% endfor %}
-                        </div>
-                    </li>
-                {% endif %}
-            </ul>
+      <div class="row">
+        <div class="col">{{ g.organisation.name }}</div>
+        <div class="col text-right">
+          <a class="text-light" href="{{url_for('documents.index', view=config.SONAR_APP_DEFAULT_ORGANISATION)}}">
+            {{_('Back to SONAR')}}
+          </a>
         </div>
+      </div>
     </div>
+  </div>
+{% endif %}
+<nav class="navbar navbar-expand-lg navbar-dark bg-{{ 'header' if page == 'home' else 'organisation' }}">
+  <div class="container">
+    {%- if not current_user.is_authenticated %}
+    <a href="{{url_for_security('login', next=request.path)}}" class="btn btn-light ml-auto mr-2 d-block d-lg-none">
+      <i class="fa fa-lock"></i>
+    </a>
+    {% else %}
+    <div class="dropdown ml-auto mr-2 d-block d-lg-none">
+      {% with dropdownId='userButtonDropdown' %}
+      <button class="btn btn-light" type="button" id="{{dropdownId}}" data-toggle="dropdown" aria-haspopup="true"
+        aria-expanded="false">
+        <i class="fa fa-user"></i>
+      </button>
+      {% include 'sonar/partial/dropdown_user.html' %}
+      {% endwith %}
+    </div>
+    {% endif%}
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
+      aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+      <i class="fa fa-bars p-1"></i>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+      {% if page != 'home' %}
+      <a class="navbar-brand" href="{{ url_for('documents.index', view=view_code) }}">
+        {% set logo_code = view_code if g.get('organisation', {}).get('isDedicated') else config.SONAR_APP_DEFAULT_ORGANISATION %}
+        <img src="{{ url_for('static', filename='images/' ~ logo_code ~ '-logo.svg')}}" height="50"
+          class="d-inline-block align-top mr-3 my-4" alt="">
+      </a>
+      {% if not admin %}
+      <form action="{{ url_for('documents.search', view=view_code) }}"
+        class="form-inline my-2 my-lg-0 ml-lg-5">
+        <input name="q" class="form-control mr-sm-2" type="search" placeholder="{{_('Search')}}"
+          aria-label="{{_('Search')}}" value="{{ request.args.get('q', '') }}">
+        <button class="btn btn-outline-light my-2 my-sm-0" type="submit">
+          <i class="fa fa-search"></i>
+        </button>
+      </form>
+      {% else %}
+      <span class="navbar-text text-secondary">{{ _('Administration')|upper }}</span>
+      {% endif %}
+      {% endif %}
+      <ul class="navbar-nav ml-auto">
+        {%- if not current_user.is_authenticated %}
+        <li class="nav-item px-3 d-none d-lg-block">
+          <a class="nav-link" href="{{url_for_security('login', next=request.path)}}" title="{{ _('Log in') }}">
+            <i class="fa fa-lock"></i>
+          </a>
+        </li>
+        {% if security.registerable %}
+        <li class="nav-item">
+          <a class="nav-link text-uppercase" href="{{ url_for_security('register') }}">{{ _('Sign up') }}</a>
+        </li>
+        {% endif %}
+        {% else %}
+        <li class="nav-item dropdown d-none d-lg-block px-3">
+          {% with dropdownId='userLinkDropdown' %}
+          <a class="nav-link text-uppercase" href="#" id="{{ dropdownId }}" role="button" data-toggle="dropdown"
+            aria-haspopup="true" aria-expanded="false">
+            <i class="fa fa-user mr-2"></i>
+            {{ current_user.profile.full_name if current_user.profile.full_name else current_user.email }}
+          </a>
+          {% include 'sonar/partial/dropdown_user.html' %}
+          {% endwith %}
+        </li>
+        {% endif %}
+        {%- if config.I18N_LANGUAGES %}
+        <li class="nav-item dropdown pl-3">
+          <a class="nav-link" href="#" id="languageDropdown" role="button" data-toggle="dropdown" aria-haspopup="true"
+            aria-expanded="false">
+            {{ current_i18n.language|upper }}
+          </a>
+          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="languageDropdown">
+            {% for l in current_i18n.get_locales() %}
+            <a class="dropdown-item"
+              href="{{ url_for('invenio_i18n.set_lang', lang_code=l.language) }}">{{ l.get_display_name()|capitalize }}</a>
+            {% endfor %}
+          </div>
+        </li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
 </nav>

--- a/sonar/translations/de/LC_MESSAGES/messages.po
+++ b/sonar/translations/de/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-06-04 14:40+0200\n"
+"POT-Creation-Date: 2020-06-05 10:30+0200\n"
 "PO-Revision-Date: 2020-05-13 05:58+0000\n"
 "Last-Translator: Nicolas Prongué <n.prongue@outlook.com>, 2020\n"
 "Language: de\n"
@@ -292,7 +292,13 @@ msgstr ""
 msgid "Invenio"
 msgstr ""
 
+msgid "Is dedicated"
+msgstr ""
+
 msgid "Is part of"
+msgstr ""
+
+msgid "Is shared"
 msgstr ""
 
 msgid "Issue"
@@ -374,6 +380,12 @@ msgid "Numbering"
 msgstr ""
 
 msgid "Organisation"
+msgstr ""
+
+msgid "Organisation has a specific theme for his view."
+msgstr ""
+
+msgid "Organisation records can be accessed by a specific URL."
 msgstr ""
 
 msgid "Other Material Characteristics"

--- a/sonar/translations/en/LC_MESSAGES/messages.po
+++ b/sonar/translations/en/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-06-04 14:40+0200\n"
+"POT-Creation-Date: 2020-06-05 10:30+0200\n"
 "PO-Revision-Date: 2020-05-13 05:58+0000\n"
 "Last-Translator: Nicolas Prongué <n.prongue@outlook.com>, 2020\n"
 "Language: en\n"
@@ -292,7 +292,13 @@ msgstr ""
 msgid "Invenio"
 msgstr ""
 
+msgid "Is dedicated"
+msgstr ""
+
 msgid "Is part of"
+msgstr ""
+
+msgid "Is shared"
 msgstr ""
 
 msgid "Issue"
@@ -374,6 +380,12 @@ msgid "Numbering"
 msgstr ""
 
 msgid "Organisation"
+msgstr ""
+
+msgid "Organisation has a specific theme for his view."
+msgstr ""
+
+msgid "Organisation records can be accessed by a specific URL."
 msgstr ""
 
 msgid "Other Material Characteristics"

--- a/sonar/translations/fr/LC_MESSAGES/messages.po
+++ b/sonar/translations/fr/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-06-04 14:40+0200\n"
+"POT-Creation-Date: 2020-06-05 10:30+0200\n"
 "PO-Revision-Date: 2020-05-13 05:58+0000\n"
 "Last-Translator: MarionRERO <marion.davis@rero.ch>, 2020\n"
 "Language: fr\n"
@@ -299,8 +299,14 @@ msgstr "En format \\"
 msgid "Invenio"
 msgstr "Invenio"
 
+msgid "Is dedicated"
+msgstr ""
+
 msgid "Is part of"
 msgstr "Fait partie de"
+
+msgid "Is shared"
+msgstr ""
 
 msgid "Issue"
 msgstr ""
@@ -382,6 +388,12 @@ msgstr "Numérotation"
 
 msgid "Organisation"
 msgstr "Organisation"
+
+msgid "Organisation has a specific theme for his view."
+msgstr ""
+
+msgid "Organisation records can be accessed by a specific URL."
+msgstr ""
 
 msgid "Other Material Characteristics"
 msgstr "Autres caractéristiques matérielles"

--- a/sonar/translations/it/LC_MESSAGES/messages.po
+++ b/sonar/translations/it/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-06-04 14:40+0200\n"
+"POT-Creation-Date: 2020-06-05 10:30+0200\n"
 "PO-Revision-Date: 2020-05-13 05:58+0000\n"
 "Last-Translator: Nicolas Prongué <n.prongue@outlook.com>, 2020\n"
 "Language: it\n"
@@ -292,7 +292,13 @@ msgstr ""
 msgid "Invenio"
 msgstr ""
 
+msgid "Is dedicated"
+msgstr ""
+
 msgid "Is part of"
+msgstr ""
+
+msgid "Is shared"
 msgstr ""
 
 msgid "Issue"
@@ -374,6 +380,12 @@ msgid "Numbering"
 msgstr ""
 
 msgid "Organisation"
+msgstr ""
+
+msgid "Organisation has a specific theme for his view."
+msgstr ""
+
+msgid "Organisation records can be accessed by a specific URL."
 msgstr ""
 
 msgid "Other Material Characteristics"

--- a/sonar/translations/messages.pot
+++ b/sonar/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-06-04 14:40+0200\n"
+"POT-Creation-Date: 2020-06-05 10:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -289,7 +289,13 @@ msgstr ""
 msgid "Invenio"
 msgstr ""
 
+msgid "Is dedicated"
+msgstr ""
+
 msgid "Is part of"
+msgstr ""
+
+msgid "Is shared"
 msgstr ""
 
 msgid "Issue"
@@ -371,6 +377,12 @@ msgid "Numbering"
 msgstr ""
 
 msgid "Organisation"
+msgstr ""
+
+msgid "Organisation has a specific theme for his view."
+msgstr ""
+
+msgid "Organisation records can be accessed by a specific URL."
 msgstr ""
 
 msgid "Other Material Characteristics"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,7 +96,12 @@ def make_organisation(app, db):
     """Factory for creating organisation."""
 
     def _make_organisation(code):
-        data = {'code': code, 'name': code}
+        data = {
+            'code': code,
+            'name': code,
+            'isShared': True,
+            'isDedicated': False
+        }
 
         record = OrganisationRecord.get_record_by_pid(code)
 

--- a/tests/ui/test_utils.py
+++ b/tests/ui/test_utils.py
@@ -20,10 +20,12 @@
 import os
 
 import pytest
+from flask import g
 
+from sonar.modules.documents.views import store_organisation
 from sonar.modules.utils import change_filename_extension, \
     create_thumbnail_from_file, get_current_language, \
-    get_switch_aai_providers
+    get_switch_aai_providers, get_view_code
 
 
 def test_change_filename_extension(app):
@@ -83,3 +85,12 @@ def test_get_current_language(app):
 
     with app.test_request_context(headers=[('Accept-Language', 'fr')]):
         assert get_current_language() == 'fr'
+
+
+def test_get_view_code(organisation):
+    """Test get view code stored in organisation."""
+    store_organisation(None, {'view': 'org'})
+    assert get_view_code() == 'org'
+
+    g.pop('organisation', None)
+    assert get_view_code() == 'sonar'


### PR DESCRIPTION
* Adds a property `isShared` in organisation to allow access to records by a specific URL.
* Adds a property `isDedicated` in organisation to allow organisation to have a specific theme and logo.
* Adds a specific route to document details instead of built-in invenio view.
* Adds a method to get current view code in templates.
* Renames `ir` query parameter to `view` for consistency.
* Stores current organisation record in Flask globals.
* Adds a header containing current organisation information in templates.
* Checks if organisation is flagged as dedicated for including custom logo and styles.
* Closes #216.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>

## How to test

### Shared repository
1. Try to access /organisation/unisi --> Error is thrown.
2. Login as superuser.
3. Edit unisi organisation and check option "Is shared".
4. Try to access /organisation/unisi --> Is accessible.

### Dedicated.
1. Login as superuser.
2. Edit unisi organisation and check option "Is shared" and "Is dedicated".
3. Go to /organisation/unisi --> Page should have a custom theme.