### PR TITLE
users: create user record on registration

### DIFF
--- a/sonar/config.py
+++ b/sonar/config.py
@@ -128,7 +128,7 @@ ACCOUNTS_REGISTER_BLUEPRINT = True
 
 # User profiles
 # =============
-USERPROFILES_EXTEND_SECURITY_FORMS = True
+USERPROFILES = False
 
 # Celery configuration
 # ====================

--- a/sonar/modules/ext.py
+++ b/sonar/modules/ext.py
@@ -22,10 +22,13 @@ from __future__ import absolute_import, print_function
 import jinja2
 from flask_assets import Bundle, Environment
 from flask_bootstrap import Bootstrap
+from flask_security import user_registered
 from flask_wiki import Wiki
 
 from sonar.modules.permissions import has_admin_access, has_publisher_access, \
     has_superuser_access
+from sonar.modules.users.api import current_user_record
+from sonar.modules.users.signals import user_registered_handler
 from sonar.modules.utils import get_switch_aai_providers, get_view_code
 
 from . import config
@@ -39,7 +42,8 @@ def utility_processor():
                 has_superuser_access=has_superuser_access,
                 ui_version=config.SONAR_APP_UI_VERSION,
                 aai_providers=get_switch_aai_providers,
-                view_code=get_view_code())
+                view_code=get_view_code(),
+                current_user_record=current_user_record)
 
 
 class Sonar(object):
@@ -81,6 +85,9 @@ class Sonar(object):
                    output='sonar_ui.%(version)s.js'))
 
         app.context_processor(utility_processor)
+
+        # Connect to signal sent when a user is created in Flask-Security.
+        user_registered.connect(user_registered_handler, weak=False)
 
     def init_config(self, app):
         """Initialize configuration."""

--- a/sonar/modules/users/cli.py
+++ b/sonar/modules/users/cli.py
@@ -67,9 +67,15 @@ def import_users(infile):
             password = hash_password(password)
             del user_data['password']
 
+            if not user_data.get('roles'):
+                user_data['roles'] = [UserRecord.ROLE_USER]
+
             roles = user_data.get('roles', []).copy()
-            if not roles or not isinstance(roles, list):
-                roles = []
+
+            for role in roles:
+                if not datastore.find_role(role):
+                    datastore.create_role(name=role)
+                    datastore.commit()
 
             # Create account and activate it
             datastore.create_user(email=email, password=password, roles=roles)

--- a/sonar/modules/users/jsonschemas/users/user-v1.0.0.json
+++ b/sonar/modules/users/jsonschemas/users/user-v1.0.0.json
@@ -142,7 +142,6 @@
     "full_name",
     "email",
     "roles",
-    "organisation",
     "$schema"
   ]
 }

--- a/sonar/modules/users/signals.py
+++ b/sonar/modules/users/signals.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Signals for users."""
+
+from sonar.modules.users.api import UserRecord, datastore
+
+
+def user_registered_handler(app, user, confirm_token):
+    """Called when a new user is registered.
+
+    :param app: App context.
+    :param user: User account.
+    """
+    # Add a default role to user
+    role = datastore.find_role(UserRecord.ROLE_USER)
+    datastore.add_role_to_user(user, role)
+    datastore.commit()
+
+    # Create user record
+    user_record = UserRecord.get_user_by_email(user.email)
+    if not user_record:
+        user_record = UserRecord.create(
+            {
+                'full_name': user.email,
+                'email': user.email,
+                'roles': [UserRecord.ROLE_USER]
+            },
+            dbcommit=True)
+        user_record.reindex()

--- a/sonar/theme/assets/scss/common/_theme.scss
+++ b/sonar/theme/assets/scss/common/_theme.scss
@@ -37,25 +37,8 @@ img.logo {
     @extend .text-light
 }
 
-// CSS code to allow `ng-csp="no-inline-css"`
-[ng\:cloak],
-[ng-cloak],
-[data-ng-cloak],
-[x-ng-cloak],
-.ng-cloak,
-.x-ng-cloak,
-.ng-hide:not(.ng-hide-animate) {
-  display: none !important;
-}
-
-ng\:form {
-  display: block;
-}
-
-.ng-animate-shim {
-  visibility:hidden;
-}
-
-.ng-anchor {
-  position:absolute;
+.standalone-editor {
+  legend, button.btn-outline-danger {
+    display: none;
+  }
 }

--- a/sonar/theme/templates/sonar/accounts/profile.html
+++ b/sonar/theme/templates/sonar/accounts/profile.html
@@ -1,0 +1,36 @@
+{# -*- coding: utf-8 -*-
+  Swiss Open Access Repository
+  Copyright (C) 2019 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#}
+
+{% extends 'sonar/page_settings.html' %}
+
+{%- block settings_body scoped %}
+<div class="standalone-editor">
+  <sonar-root></sonar-root>
+</div>
+{%- endblock settings_body %}
+
+{%- block javascript %}
+<script src="/static/sonar-ui/runtime.js?{{ ui_version }}"></script>
+<script src="/static/sonar-ui/polyfills.js?{{ ui_version }}"></script>
+<script src="/static/sonar-ui/main.js?{{ ui_version }}"></script>
+<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+  integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
+  integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
+  integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+{%- endblock javascript %}

--- a/sonar/theme/templates/sonar/accounts/signup.html
+++ b/sonar/theme/templates/sonar/accounts/signup.html
@@ -30,8 +30,6 @@
       <form action="{{ url_for_security('register') }}" method="POST" name="register_user_form">
         {{ form_errors(form) }}
         {{ form.hidden_tag() }}
-        {{ render_field(form.profile.full_name, errormsg=False) }}
-        {{ render_field(form.profile.username, errormsg=False) }}
         {{ render_field(form.email, autofocus=True, errormsg=False) }}
         {{ render_field(form.password, errormsg=False) }}
         {%- if form.password_confirm %}

--- a/sonar/theme/templates/sonar/page_settings.html
+++ b/sonar/theme/templates/sonar/page_settings.html
@@ -20,48 +20,43 @@
 {%- block body scoped %}
 <div class="container">
   <div class="row">
-      <div class="col-sm-3 col-md-3 col-pad-left-0">
-        {%- block settings_menu scoped %}
-        <div class="panel-group">
-          <div class="panel panel-default">
-            <div class="panel-heading"><strong>{{ _('Settings') }}</strong></div>
-            <ul class="list-group">
-            {%- for item in current_menu.submenu('settings').children if item.visible %}
-            {%- block settings_menu_item scoped %}
-              <a href="{{ item.url }}" class="list-group-item{% if item.active %} active{% endif %}">
-                {{ item.text|safe }}
-              </a>
+    <div class="col-sm-3 col-md-3 col-pad-left-0">
+      {%- block settings_menu scoped %}
+      <ul class="list-group">
+        {%- for item in current_menu.submenu('settings').children if item.visible %}
+        {%- block settings_menu_item scoped %}
+        <a href="{{ item.url }}" class="list-group-item{% if item.active %} active{% endif %}">
+          {{ item.text|safe }}
+        </a>
+        {%- endblock %}
+        {%- endfor %}
+      </ul>
+      {%- endblock %}
+    </div>
+    <div class="col-sm-9 col-md-9 col-pad-right-0">
+      {%- block settings_content scoped %}
+      <div class="panel-group panel-bot-margin">
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            {%- block settings_content_title scoped %}
+            {%- if panel_icon %}
+            {%- block settings_content_title_icon scoped %}
+            <i class="{{panel_icon}}"></i>
             {%- endblock %}
-            {%- endfor %}
-            </ul>
+            {%- endif %}
+            <strong>{{ panel_title|default("") }}</strong>
+            {%- endblock %}
           </div>
-        </div>
-        {%- endblock %}
-      </div>
-      <div class="col-sm-9 col-md-9 col-pad-right-0">
-        {%- block settings_content scoped %}
-        <div class="panel-group panel-bot-margin">
-          <div class="panel panel-default">
-            <div class="panel-heading">
-              {%- block settings_content_title scoped %}
-              {%- if panel_icon %}
-              {%- block settings_content_title_icon scoped %}
-              <i class="{{panel_icon}}"></i>
-              {%- endblock %}
-              {%- endif %}
-              <strong>{{ panel_title|default("") }}</strong>
-              {%- endblock %}
-            </div>
-            {%- block settings_body scoped %}
-            <div class="panel-body">
-              {%- block settings_form scoped %}
-              {%- endblock settings_form %}
-            </div>
-            {%- endblock settings_body %}
+          {%- block settings_body scoped %}
+          <div class="panel-body">
+            {%- block settings_form scoped %}
+            {%- endblock settings_form %}
           </div>
+          {%- endblock settings_body %}
         </div>
-        {%- endblock %}
       </div>
+      {%- endblock %}
+    </div>
   </div>
 </div>
 {%- endblock %}

--- a/sonar/theme/templates/sonar/partial/dropdown_user.html
+++ b/sonar/theme/templates/sonar/partial/dropdown_user.html
@@ -16,12 +16,10 @@
 #}
 
 <div class="dropdown-menu dropdown-menu-right" aria-labelledby="{{dropdownId}}">
-    <h6 class="dropdown-header">{{current_user.email}}</h6>
-    {%- if config.USERPROFILES %}
-    <a class="dropdown-item" href="{{ url_for('invenio_userprofiles.profile')}}">
+    <h6 class="dropdown-header">{{current_user_record.email}}</h6>
+    <a class="dropdown-item" href="{{ url_for('sonar.profile')}}">
         {{_('Profile')}}
     </a>
-    {% endif %}
     {% if has_superuser_access() %}
     <a class="dropdown-item" href="{{ url_for('admin.index')}}">
         {{_('Super administration')}}

--- a/sonar/theme/templates/sonar/partial/navbar.html
+++ b/sonar/theme/templates/sonar/partial/navbar.html
@@ -88,7 +88,7 @@
           <a class="nav-link text-uppercase" href="#" id="{{ dropdownId }}" role="button" data-toggle="dropdown"
             aria-haspopup="true" aria-expanded="false">
             <i class="fa fa-user mr-2"></i>
-            {{ current_user.profile.full_name if current_user.profile.full_name else current_user.email }}
+            {{ current_user_record.full_name }}
           </a>
           {% include 'sonar/partial/dropdown_user.html' %}
           {% endwith %}

--- a/sonar/translations/de/LC_MESSAGES/messages.po
+++ b/sonar/translations/de/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-06-05 10:30+0200\n"
+"POT-Creation-Date: 2020-06-05 10:32+0200\n"
 "PO-Revision-Date: 2020-05-13 05:58+0000\n"
 "Last-Translator: Nicolas Prongué <n.prongue@outlook.com>, 2020\n"
 "Language: de\n"
@@ -19,6 +19,10 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
+
+#, python-format
+msgid "%(icon)s Profile"
+msgstr ""
 
 msgid "Abstract"
 msgstr ""
@@ -512,9 +516,6 @@ msgid "Series"
 msgstr ""
 
 msgid "Series to which belongs the resource."
-msgstr ""
-
-msgid "Settings"
 msgstr ""
 
 msgid "Sign Up"
@@ -2746,4 +2747,7 @@ msgstr ""
 
 msgid "vol."
 msgstr ""
+
+#~ msgid "Settings"
+#~ msgstr ""
 

--- a/sonar/translations/en/LC_MESSAGES/messages.po
+++ b/sonar/translations/en/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-06-05 10:30+0200\n"
+"POT-Creation-Date: 2020-06-05 10:32+0200\n"
 "PO-Revision-Date: 2020-05-13 05:58+0000\n"
 "Last-Translator: Nicolas Prongué <n.prongue@outlook.com>, 2020\n"
 "Language: en\n"
@@ -19,6 +19,10 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
+
+#, python-format
+msgid "%(icon)s Profile"
+msgstr ""
 
 msgid "Abstract"
 msgstr ""
@@ -512,9 +516,6 @@ msgid "Series"
 msgstr ""
 
 msgid "Series to which belongs the resource."
-msgstr ""
-
-msgid "Settings"
 msgstr ""
 
 msgid "Sign Up"
@@ -2746,4 +2747,7 @@ msgstr ""
 
 msgid "vol."
 msgstr ""
+
+#~ msgid "Settings"
+#~ msgstr ""
 

--- a/sonar/translations/fr/LC_MESSAGES/messages.po
+++ b/sonar/translations/fr/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-06-05 10:30+0200\n"
+"POT-Creation-Date: 2020-06-05 10:32+0200\n"
 "PO-Revision-Date: 2020-05-13 05:58+0000\n"
 "Last-Translator: MarionRERO <marion.davis@rero.ch>, 2020\n"
 "Language: fr\n"
@@ -20,6 +20,10 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
+
+#, python-format
+msgid "%(icon)s Profile"
+msgstr ""
 
 msgid "Abstract"
 msgstr "Résumé"
@@ -522,9 +526,6 @@ msgstr "Série"
 
 msgid "Series to which belongs the resource."
 msgstr "Série à laquelle appartient la ressource."
-
-msgid "Settings"
-msgstr "Paramètres"
 
 msgid "Sign Up"
 msgstr "S'inscrire"
@@ -2762,4 +2763,7 @@ msgstr "utilisateur"
 
 msgid "vol."
 msgstr "vol."
+
+#~ msgid "Settings"
+#~ msgstr "Paramètres"
 

--- a/sonar/translations/it/LC_MESSAGES/messages.po
+++ b/sonar/translations/it/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-06-05 10:30+0200\n"
+"POT-Creation-Date: 2020-06-05 10:32+0200\n"
 "PO-Revision-Date: 2020-05-13 05:58+0000\n"
 "Last-Translator: Nicolas Prongué <n.prongue@outlook.com>, 2020\n"
 "Language: it\n"
@@ -19,6 +19,10 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
+
+#, python-format
+msgid "%(icon)s Profile"
+msgstr ""
 
 msgid "Abstract"
 msgstr ""
@@ -512,9 +516,6 @@ msgid "Series"
 msgstr ""
 
 msgid "Series to which belongs the resource."
-msgstr ""
-
-msgid "Settings"
 msgstr ""
 
 msgid "Sign Up"
@@ -2746,4 +2747,7 @@ msgstr ""
 
 msgid "vol."
 msgstr ""
+
+#~ msgid "Settings"
+#~ msgstr ""
 

--- a/sonar/translations/messages.pot
+++ b/sonar/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-06-05 10:30+0200\n"
+"POT-Creation-Date: 2020-06-05 10:32+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,10 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
+
+#, python-format
+msgid "%(icon)s Profile"
+msgstr ""
 
 msgid "Abstract"
 msgstr ""
@@ -509,9 +513,6 @@ msgid "Series"
 msgstr ""
 
 msgid "Series to which belongs the resource."
-msgstr ""
-
-msgid "Settings"
 msgstr ""
 
 msgid "Sign Up"

--- a/tests/ui/shibboleth_authenticator/test_shibboleth_handlers.py
+++ b/tests/ui/shibboleth_authenticator/test_shibboleth_handlers.py
@@ -23,7 +23,7 @@ from sonar.modules.shibboleth_authenticator.handlers import \
     authorized_signup_handler
 
 
-def test_authorized_signup_handler(app, valid_sp_configuration,
+def test_authorized_signup_handler(app, roles, valid_sp_configuration,
                                    valid_attributes, monkeypatch):
     """Test signup handler."""
     app.config.update(SHIBBOLETH_SERVICE_PROVIDER=valid_sp_configuration)

--- a/tests/ui/shibboleth_authenticator/test_shibboleth_views_client.py
+++ b/tests/ui/shibboleth_authenticator/test_shibboleth_views_client.py
@@ -43,7 +43,7 @@ def test_login(app, client, valid_sp_configuration):
     assert client.get('/shibboleth/login/idp').status_code == 500
 
 
-def test_authorized(monkeypatch, app, client, user_without_role,
+def test_authorized(monkeypatch, app, client, roles, user_without_role,
                     valid_attributes):
     """Test authorized view."""
     # Test unexisting identity provider

--- a/tests/ui/users/test_users_cli.py
+++ b/tests/ui/users/test_users_cli.py
@@ -55,3 +55,4 @@ def test_import_users(app, script_info, organisation):
                            obj=script_info)
     user = datastore.find_user(email='rero.sonar+user@gmail.com')
     assert user
+    assert user.roles[0].name == 'user'

--- a/tests/ui/users/test_users_signals.py
+++ b/tests/ui/users/test_users_signals.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test signals for users."""
+
+from sonar.modules.users.api import UserRecord
+from sonar.modules.users.signals import user_registered_handler
+
+
+def test_user_registered_handler(app, roles, user_without_role):
+    """Test user confirmed signal."""
+    assert not user_without_role.roles
+    user_registered_handler(app, user_without_role, None)
+    assert user_without_role.roles[0].name == 'user'
+
+    user = UserRecord.get_user_by_email(user_without_role.email)
+    assert user
+    assert user['roles'] == ['user']


### PR DESCRIPTION
* Creates a user record when a new account is registered.
* Disables `invenio-userprofiles` module.
* Exposes and uses user record for displaying user information in templates.
* Gives role `user` by default when a new record is created.
* Removes `organisation` from required fields for users.
* Hides `applications` and `security` menu entries.
* Creates a new page for editing user data.
* Removes useless CSS rules
* Adds CSS rules for standalone editor.
* Customizes settings page.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>

## How to test 
### Standard registration form
1. Register as new user with standard registration form.
2. Login as superuser.
3. Check a user record is created with same email and roles as user account.

### Switch edu-ID
1. Login with Switch edu-ID account to create a new account.
2. Login as superuser.
3. Check a user record is created with same email and roles as user account.

### ORCID
1. Login with ORCID account to create a new account.
2. Login as superuser.
3. Check a user record is created with same email and roles as user account.