### PR TITLE
users: limit to only one role

### DIFF
--- a/sonar/modules/users/jsonschemas/users/user-v1.0.0.json
+++ b/sonar/modules/users/jsonschemas/users/user-v1.0.0.json
@@ -90,7 +90,7 @@
       "type": "array",
       "uniqueItems": true,
       "minItems": 1,
-      "maxItems": 4,
+      "maxItems": 1,
       "items": {
         "type": "string",
         "enum": [


### PR DESCRIPTION
* Limits users to only one role.
* Closes #241.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>

## How to test

1. Login as admin
2. Go to Users / Add.
3. Try to select multiple roles --> Form cannot be saved.