### PR TITLE
deposits: improve form

### DIFF
--- a/sonar/modules/deposits/api.py
+++ b/sonar/modules/deposits/api.py
@@ -188,7 +188,7 @@ class DepositRecord(SonarRecord):
                 'document': {
                     'electronicLocator': link['url']
                 },
-                'publicNote': link['type']
+                'publicNote': link['publicNote']
             } for link in self['metadata']['otherElectronicVersions']]
 
         # Specific collections
@@ -231,9 +231,17 @@ class DepositRecord(SonarRecord):
                     'type': 'bf:Person',
                     'preferred_name': contributor['name']
                 },
-                'role': ['cre'],
+                'role': [contributor['role']],
                 'affiliation': contributor.get('affiliation')
             }
+
+            # ORCID for contributor
+            if contributor.get('orcid'):
+                data['agent']['identifiedBy'] = {
+                    'type': 'bf:Doi',
+                    'source': 'ORCID',
+                    'value': contributor['orcid']
+                }
 
             # Resolve controlled affiliations
             if data.get('affiliation'):

--- a/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
+++ b/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
@@ -272,7 +272,11 @@
         "title": {
           "title": "Title",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "form": {
+            "type": "textarea",
+            "rows": 2
+          }
         },
         "subtitle": {
           "title": "Subtitle",
@@ -382,15 +386,18 @@
             "title": "Other electronic version",
             "type": "object",
             "required": [
-              "type",
+              "publicNote",
               "url"
             ],
             "additionalProperties": false,
             "properties": {
-              "type": {
-                "title": "Type",
+              "publicNote": {
+                "title": "Public note",
                 "type": "string",
-                "minLength": 1
+                "minLength": 1,
+                "form": {
+                  "placeholder": "Example: Published version"
+                }
               },
               "url": {
                 "title": "URL",
@@ -489,11 +496,14 @@
         "title": "Contributor",
         "type": "object",
         "required": [
-          "name"
+          "name",
+          "role"
         ],
         "propertiesOrder": [
           "name",
-          "affiliation"
+          "affiliation",
+          "role",
+          "orcid"
         ],
         "properties": {
           "name": {
@@ -506,6 +516,51 @@
             "title": "Affiliation",
             "type": "string",
             "minLength": 1
+          },
+          "role": {
+            "title": "Role",
+            "type": "string",
+            "default": "cre",
+            "enum": [
+              "dgs",
+              "prt",
+              "cre",
+              "edt",
+              "ctb"
+            ],
+            "form": {
+              "options": [
+                {
+                  "label": "contribution_role_cre",
+                  "value": "cre"
+                },
+                {
+                  "label": "contribution_role_ctb",
+                  "value": "ctb"
+                },
+                {
+                  "label": "contribution_role_edt",
+                  "value": "edt"
+                },
+                {
+                  "label": "contribution_role_dgs",
+                  "value": "dgs"
+                },
+                {
+                  "label": "contribution_role_prt",
+                  "value": "prt"
+                }
+              ]
+            }
+          },
+          "orcid": {
+            "title": "ORCID",
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{4}$",
+            "form": {
+              "placeholder": "Example: 1111-2222-3333-4444"
+            }
           }
         }
       }

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -1065,7 +1065,17 @@
                   "type": {
                     "title": "Type",
                     "type": "string",
-                    "minLength": 1
+                    "enum": [
+                      "bf:Doi"
+                    ],
+                    "form": {
+                      "options": [
+                        {
+                          "label": "bf:Doi",
+                          "value": "bf:Doi"
+                        }
+                      ]
+                    }
                   },
                   "source": {
                     "title": "Source",

--- a/sonar/modules/pdf_extractor/utils.py
+++ b/sonar/modules/pdf_extractor/utils.py
@@ -91,6 +91,7 @@ def format_extracted_data(data):
 
                 if len(name) > 1:
                     author_data['name'] = ', '.join(name)
+                    author_data['role'] = 'cre'
 
             if author_data.get('name'):
                 author_data['affiliation'] = None

--- a/sonar/translations/de/LC_MESSAGES/messages.po
+++ b/sonar/translations/de/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-06-24 10:12+0200\n"
+"POT-Creation-Date: 2020-06-24 09:43+0200\n"
 "PO-Revision-Date: 2020-05-13 05:58+0000\n"
 "Last-Translator: Nicolas Prongué <n.prongue@outlook.com>, 2020\n"
 "Language: de\n"
@@ -202,6 +202,9 @@ msgid ""
 "password."
 msgstr ""
 
+msgid "Example: 1111-2222-3333-4444"
+msgstr ""
+
 msgid "Example: 2019 or 2019-01-01"
 msgstr ""
 
@@ -381,6 +384,9 @@ msgid "Number"
 msgstr ""
 
 msgid "Numbering"
+msgstr ""
+
+msgid "ORCID"
 msgstr ""
 
 msgid "Organisation"

--- a/sonar/translations/en/LC_MESSAGES/messages.po
+++ b/sonar/translations/en/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-06-24 10:12+0200\n"
+"POT-Creation-Date: 2020-06-24 09:43+0200\n"
 "PO-Revision-Date: 2020-05-13 05:58+0000\n"
 "Last-Translator: Nicolas Prongué <n.prongue@outlook.com>, 2020\n"
 "Language: en\n"
@@ -202,6 +202,9 @@ msgid ""
 "password."
 msgstr ""
 
+msgid "Example: 1111-2222-3333-4444"
+msgstr ""
+
 msgid "Example: 2019 or 2019-01-01"
 msgstr ""
 
@@ -381,6 +384,9 @@ msgid "Number"
 msgstr ""
 
 msgid "Numbering"
+msgstr ""
+
+msgid "ORCID"
 msgstr ""
 
 msgid "Organisation"

--- a/sonar/translations/fr/LC_MESSAGES/messages.po
+++ b/sonar/translations/fr/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-06-24 10:12+0200\n"
+"POT-Creation-Date: 2020-06-24 09:43+0200\n"
 "PO-Revision-Date: 2020-05-13 05:58+0000\n"
 "Last-Translator: MarionRERO <marion.davis@rero.ch>, 2020\n"
 "Language: fr\n"
@@ -207,6 +207,9 @@ msgstr ""
 "Saisissez votre adresse e-mail ci-dessous et nous vous enverrons un lien "
 "pour réinitialiser votre mot de passe."
 
+msgid "Example: 1111-2222-3333-4444"
+msgstr ""
+
 msgid "Example: 2019 or 2019-01-01"
 msgstr ""
 
@@ -389,6 +392,9 @@ msgstr "Numéro"
 
 msgid "Numbering"
 msgstr "Numérotation"
+
+msgid "ORCID"
+msgstr ""
 
 msgid "Organisation"
 msgstr "Organisation"

--- a/sonar/translations/it/LC_MESSAGES/messages.po
+++ b/sonar/translations/it/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-06-24 10:12+0200\n"
+"POT-Creation-Date: 2020-06-24 09:43+0200\n"
 "PO-Revision-Date: 2020-05-13 05:58+0000\n"
 "Last-Translator: Nicolas Prongué <n.prongue@outlook.com>, 2020\n"
 "Language: it\n"
@@ -202,6 +202,9 @@ msgid ""
 "password."
 msgstr ""
 
+msgid "Example: 1111-2222-3333-4444"
+msgstr ""
+
 msgid "Example: 2019 or 2019-01-01"
 msgstr ""
 
@@ -381,6 +384,9 @@ msgid "Number"
 msgstr ""
 
 msgid "Numbering"
+msgstr ""
+
+msgid "ORCID"
 msgstr ""
 
 msgid "Organisation"

--- a/sonar/translations/messages.pot
+++ b/sonar/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2020-06-24 10:12+0200\n"
+"POT-Creation-Date: 2020-06-24 09:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -199,6 +199,9 @@ msgid ""
 "password."
 msgstr ""
 
+msgid "Example: 1111-2222-3333-4444"
+msgstr ""
+
 msgid "Example: 2019 or 2019-01-01"
 msgstr ""
 
@@ -378,6 +381,9 @@ msgid "Number"
 msgstr ""
 
 msgid "Numbering"
+msgstr ""
+
+msgid "ORCID"
 msgstr ""
 
 msgid "Organisation"

--- a/tests/ui/deposits/test_deposits_api.py
+++ b/tests/ui/deposits/test_deposits_api.py
@@ -98,7 +98,12 @@ def test_create_document(app, client, deposit, user):
         'University of Bern, Switzerland',
         'agent': {
             'preferred_name': 'Takayoshi, Shintaro',
-            'type': 'bf:Person'
+            'type': 'bf:Person',
+            'identifiedBy': {
+                'source': 'ORCID',
+                'type': 'bf:Doi',
+                'value': '1234-5678-1234-5678'
+            }
         },
         'controlledAffiliation': ['Uni of Bern and Hospital'],
         'role': ['cre']
@@ -114,7 +119,12 @@ def test_create_document(app, client, deposit, user):
     assert document['contribution'] == [{
         'agent': {
             'preferred_name': 'Takayoshi, Shintaro',
-            'type': 'bf:Person'
+            'type': 'bf:Person',
+            'identifiedBy': {
+                'source': 'ORCID',
+                'type': 'bf:Doi',
+                'value': '1234-5678-1234-5678'
+            }
         },
         'role': ['cre']
     }]

--- a/tests/ui/pdf_extractor/test_pdf_extractor_utils.py
+++ b/tests/ui/pdf_extractor/test_pdf_extractor_utils.py
@@ -40,14 +40,16 @@ def test_format_extracted_data(app):
         assert formatted_data['authors'] == [{
             'affiliation':
             'Swiss Institute of Bioinformatics, Lausanne, Switzerland',
-            'name': 'Komljenovic, Andrea'
+            'name': 'Komljenovic, Andrea',
+            'role': 'cre'
         }, {
             'affiliation':
             'Institute of Bioengineering, Laboratory of Integrative Systems '
             'Physiology, École Polytechnique Fédérale de Lausanne, Lausanne, '
             'Lausanne, Switzerland',
             'name':
-            'Sleiman, Maroun Bou'
+            'Sleiman, Maroun Bou',
+            'role': 'cre'
         }]
 
         # Test authors


### PR DESCRIPTION
* Adds `role` and `orcid` fields in JSON schema.
* Sets form type to `textarea` for title field.
* Adds enumeration list for agent type in documents JSON schema.
* Converts role and ORCID value when creating a document from deposit.
* Add a `creator` role when extracting contributors from PDF.
* Closes #248.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>