### PR TITLE
users: rename role publisher

### DIFF
--- a/data/users.json
+++ b/data/users.json
@@ -43,9 +43,9 @@
   },
   {
     "full_name": "Claude Roussel",
-    "email": "rero.sonar+publisher@gmail.com",
+    "email": "rero.sonar+submitter@gmail.com",
     "password": "123456",
-    "roles": ["publisher"],
+    "roles": ["submitter"],
     "birth_date": "1983-09-14",
     "street": "Kirchstrasse 57",
     "postal_code": "1660",

--- a/scripts/setup
+++ b/scripts/setup
@@ -65,13 +65,13 @@ pipenv run invenio index queue init purge
 pipenv run invenio roles create superuser
 pipenv run invenio roles create admin
 pipenv run invenio roles create moderator
-pipenv run invenio roles create publisher
+pipenv run invenio roles create submitter
 pipenv run invenio roles create user
 pipenv run invenio access allow superuser-access role superuser
 pipenv run invenio access allow admin-access role superuser
 pipenv run invenio access allow admin-access role admin
 pipenv run invenio access allow admin-access role moderator
-pipenv run invenio access allow admin-access role publisher
+pipenv run invenio access allow admin-access role submitter
 
 # Create a default location for depositing files
 pipenv run invenio fixtures deposits create

--- a/sonar/modules/deposits/permissions.py
+++ b/sonar/modules/deposits/permissions.py
@@ -17,13 +17,10 @@
 
 """Permissions for deposits."""
 
-import copy
-
 from sonar.modules.deposits.api import DepositRecord
-from sonar.modules.organisations.api import OrganisationRecord, \
-    current_organisation
+from sonar.modules.organisations.api import current_organisation
 from sonar.modules.permissions import RecordPermission
-from sonar.modules.users.api import UserRecord, current_user_record
+from sonar.modules.users.api import current_user_record
 
 
 class DepositPermission(RecordPermission):
@@ -37,8 +34,8 @@ class DepositPermission(RecordPermission):
         :param recor: Record to check.
         :returns: True is action can be done.
         """
-        # At least for publishers logged users.
-        if not current_user_record or not current_user_record.is_publisher:
+        # At least for submitters logged users.
+        if not current_user_record or not current_user_record.is_submitter:
             return False
 
         return True
@@ -55,7 +52,7 @@ class DepositPermission(RecordPermission):
         if not current_user_record:
             return False
 
-        return current_user_record.is_publisher
+        return current_user_record.is_submitter
 
     @classmethod
     def read(cls, user, record):
@@ -65,8 +62,8 @@ class DepositPermission(RecordPermission):
         :param recor: Record to check.
         :returns: True is action can be done.
         """
-        # At least for publishers logged users.
-        if not current_user_record or not current_user_record.is_publisher:
+        # At least for submitters logged users.
+        if not current_user_record or not current_user_record.is_submitter:
             return False
 
         # Superuser is allowd
@@ -81,7 +78,7 @@ class DepositPermission(RecordPermission):
             return current_organisation['pid'] == deposit['user'][
                 'organisation']['pid']
 
-        # Publishers have only access to their own deposits.
+        # Submitters have only access to their own deposits.
         return current_user_record['pid'] == deposit['user']['pid']
 
     @classmethod

--- a/sonar/modules/deposits/query.py
+++ b/sonar/modules/deposits/query.py
@@ -43,7 +43,7 @@ def search_factory(self, search, query_parser=None):
         return (search, urlkwargs)
 
     # For user, only records that belongs to him.
-    if current_user_record.is_publisher:
+    if current_user_record.is_submitter:
         search = search.filter(
             'term', user__pid=current_user_record['pid'])
 

--- a/sonar/modules/ext.py
+++ b/sonar/modules/ext.py
@@ -25,7 +25,7 @@ from flask_bootstrap import Bootstrap
 from flask_security import user_registered
 from flask_wiki import Wiki
 
-from sonar.modules.permissions import has_admin_access, has_publisher_access, \
+from sonar.modules.permissions import has_admin_access, has_submitter_access, \
     has_superuser_access
 from sonar.modules.users.api import current_user_record
 from sonar.modules.users.signals import user_registered_handler
@@ -37,7 +37,7 @@ from . import config
 def utility_processor():
     """Dictionary for passing data to templates."""
     return dict(
-                has_publisher_access=has_publisher_access,
+                has_submitter_access=has_submitter_access,
                 has_admin_access=has_admin_access,
                 has_superuser_access=has_superuser_access,
                 ui_version=config.SONAR_APP_UI_VERSION,

--- a/sonar/modules/permissions.py
+++ b/sonar/modules/permissions.py
@@ -26,7 +26,7 @@ from invenio_access import Permission
 
 superuser_access_permission = Permission(ActionNeed('superuser-access'))
 admin_access_permission = Permission(ActionNeed('admin-access'))
-publisher_access_permission = Permission(RoleNeed('publisher'),
+submitter_access_permission = Permission(RoleNeed('submitter'),
                                          RoleNeed('moderator'),
                                          RoleNeed('admin'),
                                          RoleNeed('superuser'))
@@ -38,15 +38,15 @@ allow_access = type('Allow', (), {'can': lambda self: True})()
 deny_access = type('Allow', (), {'can': lambda self: False})()
 
 
-def has_publisher_access():
-    """Check if current user has at least role publisher.
+def has_submitter_access():
+    """Check if current user has at least role submitter.
 
     This function is used in app context and can be called in all templates.
     """
     if current_app.config.get('SONAR_APP_DISABLE_PERMISSION_CHECKS'):
         return True
 
-    return publisher_access_permission.can()
+    return submitter_access_permission.can()
 
 
 def has_admin_access():

--- a/sonar/modules/users/api.py
+++ b/sonar/modules/users/api.py
@@ -81,17 +81,17 @@ class UserRecord(SonarRecord):
 
     ROLE_USER = 'user'
     ROLE_MODERATOR = 'moderator'
-    ROLE_PUBLISHER = 'publisher'
+    ROLE_SUBMITTER = 'submitter'
     ROLE_ADMIN = 'admin'
     ROLE_SUPERUSER = 'superuser'
 
     ROLES_HIERARCHY = {
         ROLE_USER: [],
-        ROLE_PUBLISHER: [ROLE_USER],
-        ROLE_MODERATOR: [ROLE_PUBLISHER, ROLE_USER],
-        ROLE_ADMIN: [ROLE_MODERATOR, ROLE_PUBLISHER, ROLE_USER],
+        ROLE_SUBMITTER: [ROLE_USER],
+        ROLE_MODERATOR: [ROLE_SUBMITTER, ROLE_USER],
+        ROLE_ADMIN: [ROLE_MODERATOR, ROLE_SUBMITTER, ROLE_USER],
         ROLE_SUPERUSER:
-        [ROLE_ADMIN, ROLE_MODERATOR, ROLE_PUBLISHER, ROLE_USER],
+        [ROLE_ADMIN, ROLE_MODERATOR, ROLE_SUBMITTER, ROLE_USER],
     }
 
     minter = user_pid_minter
@@ -99,7 +99,7 @@ class UserRecord(SonarRecord):
     provider = UserProvider
     schema = 'users/user-v1.0.0.json'
     available_roles = [
-        ROLE_SUPERUSER, ROLE_ADMIN, ROLE_MODERATOR, ROLE_PUBLISHER, ROLE_USER
+        ROLE_SUPERUSER, ROLE_ADMIN, ROLE_MODERATOR, ROLE_SUBMITTER, ROLE_USER
     ]
 
     @classmethod
@@ -303,9 +303,9 @@ class UserRecord(SonarRecord):
         return self.is_granted(UserRecord.ROLE_MODERATOR)
 
     @property
-    def is_publisher(self):
-        """Check if a user a pulisher."""
-        return self.is_granted(UserRecord.ROLE_PUBLISHER)
+    def is_submitter(self):
+        """Check if a user a submitter."""
+        return self.is_granted(UserRecord.ROLE_SUBMITTER)
 
     @property
     def is_user(self):

--- a/sonar/modules/users/jsonschemas/users/user-v1.0.0.json
+++ b/sonar/modules/users/jsonschemas/users/user-v1.0.0.json
@@ -97,7 +97,7 @@
           "superuser",
           "admin",
           "moderator",
-          "publisher",
+          "submitter",
           "user"
         ],
         "form": {
@@ -115,8 +115,8 @@
               "value": "moderator"
             },
             {
-              "label": "role_publisher",
-              "value": "publisher"
+              "label": "role_submitter",
+              "value": "submitter"
             },
             {
               "label": "role_user",

--- a/sonar/theme/views.py
+++ b/sonar/theme/views.py
@@ -109,7 +109,7 @@ def logged_user():
         data['metadata']['is_superuser'] = user.is_superuser
         data['metadata']['is_admin'] = user.is_admin
         data['metadata']['is_moderator'] = user.is_moderator
-        data['metadata']['is_publisher'] = user.is_publisher
+        data['metadata']['is_submitter'] = user.is_submitter
         data['metadata']['is_user'] = user.is_user
         data['metadata']['permissions'] = {
             'users': {

--- a/sonar/translations/de/LC_MESSAGES/messages.po
+++ b/sonar/translations/de/LC_MESSAGES/messages.po
@@ -2715,7 +2715,7 @@ msgstr "Admin"
 msgid "role_moderator"
 msgstr "Moderator"
 
-msgid "role_publisher"
+msgid "role_submitter"
 msgstr "Submitter"
 
 msgid "role_superuser"

--- a/sonar/translations/en/LC_MESSAGES/messages.po
+++ b/sonar/translations/en/LC_MESSAGES/messages.po
@@ -2715,7 +2715,7 @@ msgstr "Admin"
 msgid "role_moderator"
 msgstr "Moderator"
 
-msgid "role_publisher"
+msgid "role_submitter"
 msgstr "Submitter"
 
 msgid "role_superuser"

--- a/sonar/translations/fr/LC_MESSAGES/messages.po
+++ b/sonar/translations/fr/LC_MESSAGES/messages.po
@@ -2731,7 +2731,7 @@ msgstr "Admin"
 msgid "role_moderator"
 msgstr "Moderator"
 
-msgid "role_publisher"
+msgid "role_submitter"
 msgstr "Submitter"
 
 msgid "role_superuser"

--- a/sonar/translations/it/LC_MESSAGES/messages.po
+++ b/sonar/translations/it/LC_MESSAGES/messages.po
@@ -2715,7 +2715,7 @@ msgstr "Admin"
 msgid "role_moderator"
 msgstr "Moderator"
 
-msgid "role_publisher"
+msgid "role_submitter"
 msgstr "Submitter"
 
 msgid "role_superuser"

--- a/sonar/translations/messages.pot
+++ b/sonar/translations/messages.pot
@@ -2712,7 +2712,7 @@ msgstr ""
 msgid "role_moderator"
 msgstr ""
 
-msgid "role_publisher"
+msgid "role_submitter"
 msgstr ""
 
 msgid "role_superuser"

--- a/tests/api/deposits/test_deposits_permissions.py
+++ b/tests/api/deposits/test_deposits_permissions.py
@@ -25,12 +25,12 @@ from invenio_accounts.testutils import login_user_via_session
 from sonar.modules.deposits.api import DepositRecord
 
 
-def test_list(client, make_deposit, superuser, admin, moderator, publisher,
+def test_list(client, make_deposit, superuser, admin, moderator, submitter,
               user):
     """Test list deposits permissions."""
-    make_deposit('publisher', 'org')
+    make_deposit('submitter', 'org')
     make_deposit('admin', 'org')
-    make_deposit('publisher', 'org2')
+    make_deposit('submitter', 'org2')
 
     # Not logged
     res = client.get(url_for('invenio_records_rest.depo_list'))
@@ -41,8 +41,8 @@ def test_list(client, make_deposit, superuser, admin, moderator, publisher,
     res = client.get(url_for('invenio_records_rest.depo_list'))
     assert res.status_code == 403
 
-    # Logged as publisher
-    login_user_via_session(client, email=publisher['email'])
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
     res = client.get(url_for('invenio_records_rest.depo_list'))
     assert res.status_code == 200
     assert res.json['hits']['total'] == 1
@@ -67,7 +67,7 @@ def test_list(client, make_deposit, superuser, admin, moderator, publisher,
 
 
 def test_create(client, deposit_json, bucket_location, superuser, admin,
-                moderator, publisher, user):
+                moderator, submitter, user):
     """Test create deposits permissions."""
     headers = {
         'Content-Type': 'application/json',
@@ -90,10 +90,10 @@ def test_create(client, deposit_json, bucket_location, superuser, admin,
                       headers=headers)
     assert res.status_code == 403
 
-    # Publisher
-    login_user_via_session(client, email=publisher['email'])
+    # submitter
+    login_user_via_session(client, email=submitter['email'])
     deposit_json['user'] = {
-        '$ref': 'https://sonar.ch/api/users/{pid}'.format(pid=publisher['pid'])
+        '$ref': 'https://sonar.ch/api/users/{pid}'.format(pid=submitter['pid'])
     }
     res = client.post(url_for('invenio_records_rest.depo_list'),
                       data=json.dumps(deposit_json),
@@ -132,10 +132,10 @@ def test_create(client, deposit_json, bucket_location, superuser, admin,
 
 
 def test_read(client, make_deposit, make_user, superuser, admin, moderator,
-              publisher, user):
+              submitter, user):
     """Test read deposits permissions."""
-    deposit1 = make_deposit('publisher', 'org')
-    deposit2 = make_deposit('publisher', 'org2')
+    deposit1 = make_deposit('submitter', 'org')
+    deposit2 = make_deposit('submitter', 'org2')
 
     # Not logged
     res = client.get(
@@ -148,8 +148,8 @@ def test_read(client, make_deposit, make_user, superuser, admin, moderator,
         url_for('invenio_records_rest.depo_item', pid_value=deposit1['pid']))
     assert res.status_code == 403
 
-    # Logged as publisher
-    login_user_via_session(client, email=publisher['email'])
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
     res = client.get(
         url_for('invenio_records_rest.depo_item', pid_value=deposit1['pid']))
     assert res.status_code == 200
@@ -192,11 +192,11 @@ def test_read(client, make_deposit, make_user, superuser, admin, moderator,
     assert res.status_code == 200
 
 
-def test_update(client, make_deposit, superuser, admin, moderator, publisher,
+def test_update(client, make_deposit, superuser, admin, moderator, submitter,
                 user):
     """Test update deposits permissions."""
-    deposit1 = make_deposit('publisher', 'org')
-    deposit2 = make_deposit('publisher', 'org2')
+    deposit1 = make_deposit('submitter', 'org')
+    deposit2 = make_deposit('submitter', 'org2')
 
     headers = {
         'Content-Type': 'application/json',
@@ -218,8 +218,8 @@ def test_update(client, make_deposit, superuser, admin, moderator, publisher,
                      headers=headers)
     assert res.status_code == 403
 
-    # Logged as publisher
-    login_user_via_session(client, email=publisher['email'])
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
     res = client.put(url_for('invenio_records_rest.depo_item',
                              pid_value=deposit1['pid']),
                      data=json.dumps(deposit1.dumps()),
@@ -277,10 +277,10 @@ def test_update(client, make_deposit, superuser, admin, moderator, publisher,
 
 
 def test_delete(client, db, make_deposit, superuser, admin, moderator,
-                publisher, user):
+                submitter, user):
     """Test delete deposits permissions."""
-    deposit1 = make_deposit('publisher', 'org')
-    deposit2 = make_deposit('publisher', 'org2')
+    deposit1 = make_deposit('submitter', 'org')
+    deposit2 = make_deposit('submitter', 'org2')
 
     # Not logged
     res = client.delete(
@@ -293,8 +293,8 @@ def test_delete(client, db, make_deposit, superuser, admin, moderator,
         url_for('invenio_records_rest.depo_item', pid_value=deposit1['pid']))
     assert res.status_code == 403
 
-    # Logged as publisher
-    login_user_via_session(client, email=publisher['email'])
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
     res = client.delete(
         url_for('invenio_records_rest.depo_item', pid_value=deposit2['pid']))
     assert res.status_code == 403
@@ -315,7 +315,7 @@ def test_delete(client, db, make_deposit, superuser, admin, moderator,
         url_for('invenio_records_rest.depo_item', pid_value=deposit1['pid']))
     assert res.status_code == 204
 
-    deposit1 = make_deposit('publisher', 'org')
+    deposit1 = make_deposit('submitter', 'org')
 
     # Logged as moderator
     login_user_via_session(client, email=moderator['email'])
@@ -327,7 +327,7 @@ def test_delete(client, db, make_deposit, superuser, admin, moderator,
         url_for('invenio_records_rest.depo_item', pid_value=deposit1['pid']))
     assert res.status_code == 204
 
-    deposit1 = make_deposit('publisher', 'org')
+    deposit1 = make_deposit('submitter', 'org')
 
     # Logged as admin
     login_user_via_session(client, email=admin['email'])
@@ -339,7 +339,7 @@ def test_delete(client, db, make_deposit, superuser, admin, moderator,
         url_for('invenio_records_rest.depo_item', pid_value=deposit1['pid']))
     assert res.status_code == 204
 
-    deposit1 = make_deposit('publisher', 'org')
+    deposit1 = make_deposit('submitter', 'org')
 
     # Logged as superuser
     login_user_via_session(client, email=superuser['email'])

--- a/tests/api/documents/test_documents_permissions.py
+++ b/tests/api/documents/test_documents_permissions.py
@@ -23,7 +23,7 @@ from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 
 
-def test_list(client, make_document, superuser, admin, moderator, publisher,
+def test_list(client, make_document, superuser, admin, moderator, submitter,
               user):
     """Test list documents permissions."""
     make_document(None)
@@ -38,8 +38,8 @@ def test_list(client, make_document, superuser, admin, moderator, publisher,
     res = client.get(url_for('invenio_records_rest.doc_list'))
     assert res.status_code == 403
 
-    # Logged as publisher
-    login_user_via_session(client, email=publisher['email'])
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
     res = client.get(url_for('invenio_records_rest.doc_list'))
     assert res.status_code == 403
 
@@ -72,7 +72,7 @@ def test_list(client, make_document, superuser, admin, moderator, publisher,
     assert res.json['hits']['total'] == 1
 
 
-def test_create(client, document_json, superuser, admin, moderator, publisher,
+def test_create(client, document_json, superuser, admin, moderator, submitter,
                 user):
     """Test create documents permissions."""
     headers = {
@@ -93,8 +93,8 @@ def test_create(client, document_json, superuser, admin, moderator, publisher,
                       headers=headers)
     assert res.status_code == 403
 
-    # Publisher
-    login_user_via_session(client, email=publisher['email'])
+    # submitter
+    login_user_via_session(client, email=submitter['email'])
     res = client.post(url_for('invenio_records_rest.doc_list'),
                       data=json.dumps(document_json),
                       headers=headers)
@@ -129,7 +129,7 @@ def test_create(client, document_json, superuser, admin, moderator, publisher,
 
 
 def test_read(client, document, make_user, superuser, admin, moderator,
-              publisher, user):
+              submitter, user):
     """Test read documents permissions."""
     # Not logged
     res = client.get(
@@ -142,8 +142,8 @@ def test_read(client, document, make_user, superuser, admin, moderator,
         url_for('invenio_records_rest.doc_item', pid_value=document['pid']))
     assert res.status_code == 403
 
-    # Logged as publisher
-    login_user_via_session(client, email=publisher['email'])
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
     res = client.get(
         url_for('invenio_records_rest.doc_item', pid_value=document['pid']))
     assert res.status_code == 403
@@ -190,7 +190,7 @@ def test_read(client, document, make_user, superuser, admin, moderator,
 
 
 def test_update(client, document, make_user, superuser, admin, moderator,
-                publisher, user):
+                submitter, user):
     """Test update documents permissions."""
     headers = {
         'Content-Type': 'application/json',
@@ -212,8 +212,8 @@ def test_update(client, document, make_user, superuser, admin, moderator,
                      headers=headers)
     assert res.status_code == 403
 
-    # Logged as publisher
-    login_user_via_session(client, email=publisher['email'])
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
     res = client.put(url_for('invenio_records_rest.doc_item',
                              pid_value=document['pid']),
                      data=json.dumps(document.dumps()),
@@ -255,7 +255,7 @@ def test_update(client, document, make_user, superuser, admin, moderator,
 
 
 def test_delete(client, document, make_document, make_user, superuser, admin,
-                moderator, publisher, user):
+                moderator, submitter, user):
     """Test delete documents permissions."""
     # Not logged
     res = client.delete(
@@ -268,8 +268,8 @@ def test_delete(client, document, make_document, make_user, superuser, admin,
         url_for('invenio_records_rest.doc_item', pid_value=document['pid']))
     assert res.status_code == 403
 
-    # Logged as publisher
-    login_user_via_session(client, email=publisher['email'])
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
     res = client.delete(
         url_for('invenio_records_rest.doc_item', pid_value=document['pid']))
     assert res.status_code == 403

--- a/tests/api/organisations/test_organisations_permissions.py
+++ b/tests/api/organisations/test_organisations_permissions.py
@@ -24,7 +24,7 @@ from invenio_accounts.testutils import login_user_via_session
 
 
 def test_list(client, make_organisation, superuser, admin, moderator,
-              publisher, user):
+              submitter, user):
     """Test list organisations permissions."""
     make_organisation('org2')
 
@@ -37,8 +37,8 @@ def test_list(client, make_organisation, superuser, admin, moderator,
     res = client.get(url_for('invenio_records_rest.org_list'))
     assert res.status_code == 403
 
-    # Logged as publisher
-    login_user_via_session(client, email=publisher['email'])
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
     res = client.get(url_for('invenio_records_rest.org_list'))
     assert res.status_code == 403
 
@@ -60,7 +60,7 @@ def test_list(client, make_organisation, superuser, admin, moderator,
     assert res.json['hits']['total'] == 2
 
 
-def test_create(client, superuser, admin, moderator, publisher, user):
+def test_create(client, superuser, admin, moderator, submitter, user):
     """Test create organisations permissions."""
     data = {'code': 'org2', 'name': 'org2'}
 
@@ -82,8 +82,8 @@ def test_create(client, superuser, admin, moderator, publisher, user):
                       headers=headers)
     assert res.status_code == 403
 
-    # Publisher
-    login_user_via_session(client, email=publisher['email'])
+    # submitter
+    login_user_via_session(client, email=submitter['email'])
     res = client.post(url_for('invenio_records_rest.org_list'),
                       data=json.dumps(data),
                       headers=headers)
@@ -113,7 +113,7 @@ def test_create(client, superuser, admin, moderator, publisher, user):
 
 
 def test_read(client, make_organisation, superuser, admin, moderator,
-              publisher, user):
+              submitter, user):
     """Test read organisations permissions."""
     make_organisation('org2')
 
@@ -126,8 +126,8 @@ def test_read(client, make_organisation, superuser, admin, moderator,
     res = client.get(url_for('invenio_records_rest.org_item', pid_value='org'))
     assert res.status_code == 403
 
-    # Logged as publisher
-    login_user_via_session(client, email=publisher['email'])
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
     res = client.get(url_for('invenio_records_rest.org_item', pid_value='org'))
     assert res.status_code == 403
 
@@ -168,7 +168,7 @@ def test_read(client, make_organisation, superuser, admin, moderator,
 
 
 def test_update(client, make_organisation, superuser, admin, moderator,
-                publisher, user):
+                submitter, user):
     """Test update organisations permissions."""
     headers = {
         'Content-Type': 'application/json',
@@ -191,8 +191,8 @@ def test_update(client, make_organisation, superuser, admin, moderator,
                      headers=headers)
     assert res.status_code == 403
 
-    # Logged as publisher
-    login_user_via_session(client, email=publisher['email'])
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
     res = client.put(url_for('invenio_records_rest.org_item', pid_value='org'),
                      data=json.dumps(org.dumps()),
                      headers=headers)
@@ -236,7 +236,7 @@ def test_update(client, make_organisation, superuser, admin, moderator,
 
 
 def test_delete(client, superuser, admin,
-                moderator, publisher, user):
+                moderator, submitter, user):
     """Test delete organisations permissions."""
     # Not logged
     res = client.delete(
@@ -249,8 +249,8 @@ def test_delete(client, superuser, admin,
         url_for('invenio_records_rest.org_item', pid_value='org'))
     assert res.status_code == 403
 
-    # Logged as publisher
-    login_user_via_session(client, email=publisher['email'])
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
     res = client.delete(
         url_for('invenio_records_rest.org_item', pid_value='org'))
     assert res.status_code == 403

--- a/tests/api/users/test_users_permissions.py
+++ b/tests/api/users/test_users_permissions.py
@@ -23,7 +23,7 @@ from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 
 
-def test_list(client, make_user, superuser, admin, moderator, publisher, user):
+def test_list(client, make_user, superuser, admin, moderator, submitter, user):
     """Test list users permissions."""
     make_user('user', 'org2')
 
@@ -52,8 +52,8 @@ def test_list(client, make_user, superuser, admin, moderator, publisher, user):
     assert res.json['hits']['total'] == 1
     assert not res.json['hits']['hits'][0]['metadata'].get('email')
 
-    # Logged as publisher
-    login_user_via_session(client, email=publisher['email'])
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
     res = client.get(url_for('invenio_records_rest.user_list'))
     assert res.status_code == 200
     assert res.json['hits']['total'] == 1
@@ -77,7 +77,7 @@ def test_list(client, make_user, superuser, admin, moderator, publisher, user):
     assert res.json['hits']['total'] == 6
 
 
-def test_create(client, organisation, superuser, admin, moderator, publisher,
+def test_create(client, organisation, superuser, admin, moderator, submitter,
                 user):
     """Test create users permissions."""
     headers = {
@@ -104,8 +104,8 @@ def test_create(client, organisation, superuser, admin, moderator, publisher,
                       headers=headers)
     assert res.status_code == 403
 
-    # Publisher
-    login_user_via_session(client, email=publisher['email'])
+    # submitter
+    login_user_via_session(client, email=submitter['email'])
     res = client.post(url_for('invenio_records_rest.user_list'),
                       data=json.dumps(user_json),
                       headers=headers)
@@ -143,7 +143,7 @@ def test_create(client, organisation, superuser, admin, moderator, publisher,
         '$ref'] == 'https://sonar.ch/api/organisations/org'
 
 
-def test_read(client, make_user, superuser, admin, moderator, publisher, user):
+def test_read(client, make_user, superuser, admin, moderator, submitter, user):
     """Test read users permissions."""
     # Not logged
     res = client.get(
@@ -167,10 +167,10 @@ def test_read(client, make_user, superuser, admin, moderator, publisher, user):
         url_for('invenio_records_rest.user_item', pid_value=moderator['pid']))
     assert res.status_code == 403
 
-    # Logged as publisher
-    login_user_via_session(client, email=publisher['email'])
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
     res = client.get(
-        url_for('invenio_records_rest.user_item', pid_value=publisher['pid']))
+        url_for('invenio_records_rest.user_item', pid_value=submitter['pid']))
     assert res.status_code == 200
     assert res.json['metadata']['permissions'] == {
         'delete': False,
@@ -178,7 +178,7 @@ def test_read(client, make_user, superuser, admin, moderator, publisher, user):
         'update': True
     }
 
-    login_user_via_session(client, email=publisher['email'])
+    login_user_via_session(client, email=submitter['email'])
     res = client.get(
         url_for('invenio_records_rest.user_item', pid_value=user['pid']))
     assert res.status_code == 403
@@ -235,7 +235,7 @@ def test_read(client, make_user, superuser, admin, moderator, publisher, user):
     }
 
 
-def test_update(client, make_user, superuser, admin, moderator, publisher,
+def test_update(client, make_user, superuser, admin, moderator, submitter,
                 user):
     """Test update users permissions."""
     headers = {
@@ -266,15 +266,15 @@ def test_update(client, make_user, superuser, admin, moderator, publisher,
                      headers=headers)
     assert res.status_code == 403
 
-    # Logged as publisher
-    login_user_via_session(client, email=publisher['email'])
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
     res = client.put(url_for('invenio_records_rest.user_item',
-                             pid_value=publisher['pid']),
-                     data=json.dumps(publisher.dumps()),
+                             pid_value=submitter['pid']),
+                     data=json.dumps(submitter.dumps()),
                      headers=headers)
     assert res.status_code == 200
 
-    login_user_via_session(client, email=publisher['email'])
+    login_user_via_session(client, email=submitter['email'])
     res = client.put(url_for('invenio_records_rest.user_item',
                              pid_value=user['pid']),
                      data=json.dumps(user.dumps()),
@@ -330,7 +330,7 @@ def test_update(client, make_user, superuser, admin, moderator, publisher,
     assert res.status_code == 200
 
 
-def test_delete(client, make_user, superuser, admin, moderator, publisher,
+def test_delete(client, make_user, superuser, admin, moderator, submitter,
                 user):
     """Test delete users permissions."""
     # Not logged
@@ -344,8 +344,8 @@ def test_delete(client, make_user, superuser, admin, moderator, publisher,
         url_for('invenio_records_rest.user_item', pid_value=user['pid']))
     assert res.status_code == 403
 
-    # Logged as publisher
-    login_user_via_session(client, email=publisher['email'])
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
     res = client.delete(
         url_for('invenio_records_rest.user_item', pid_value=user['pid']))
     assert res.status_code == 403

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -222,9 +222,9 @@ def moderator(make_user):
 
 
 @pytest.fixture()
-def publisher(make_user):
-    """Create publisher."""
-    return make_user('publisher')
+def submitter(make_user):
+    """Create submitter."""
+    return make_user('submitter')
 
 
 @pytest.fixture()
@@ -456,7 +456,7 @@ def deposit_json():
 def make_deposit(db, deposit_json, bucket_location, pdf_file, make_user):
     """Factory for creating deposit."""
 
-    def _make_deposit(role='publisher', organisation=None):
+    def _make_deposit(role='submitter', organisation=None):
         user = make_user(role, organisation)
 
         deposit_json['user'] = {

--- a/tests/ui/test_permissions.py
+++ b/tests/ui/test_permissions.py
@@ -21,28 +21,28 @@ from flask_security import url_for_security
 from invenio_accounts.testutils import login_user_via_view
 
 from sonar.modules.permissions import admin_permission_factory, \
-    files_permission_factory, has_admin_access, has_publisher_access, \
+    files_permission_factory, has_admin_access, has_submitter_access, \
     has_superuser_access, record_permission_factory, wiki_edit_permission
 
 
-def test_has_publisher_access(app, client, user_without_role, publisher):
-    """Test if user has an publisher access."""
+def test_has_submitter_access(app, client, user_without_role, submitter):
+    """Test if user has an submitter access."""
 
     app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
-    assert has_publisher_access()
+    assert has_submitter_access()
 
     app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=False)
     login_user_via_view(client,
                         email=user_without_role.email,
                         password='123456')
 
-    assert not has_publisher_access()
+    assert not has_submitter_access()
 
     client.get(url_for_security('logout'))
 
-    login_user_via_view(client, email=publisher['email'], password='123456')
+    login_user_via_view(client, email=submitter['email'], password='123456')
 
-    assert has_publisher_access()
+    assert has_submitter_access()
 
 
 def test_has_admin_access(app, client, user_without_role, admin):

--- a/tests/ui/test_views.py
+++ b/tests/ui/test_views.py
@@ -55,7 +55,7 @@ def test_admin_record_page(app, admin, user_without_role):
         assert '<sonar-root>' in str(res.data)
 
 
-def test_logged_user(app, client, superuser, admin, moderator, publisher,
+def test_logged_user(app, client, superuser, admin, moderator, submitter,
                      user):
     """Test logged user page."""
     url = url_for('sonar.logged_user')
@@ -102,10 +102,10 @@ def test_logged_user(app, client, superuser, admin, moderator, publisher,
     assert res.json['metadata']['permissions']['users']['list']
     assert res.json['metadata']['permissions']['deposits']['list']
 
-    # Logged as publisher
-    login_user_via_session(client, email=publisher['email'])
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
     res = client.get(url)
-    assert b'"email":"orgpublisher@rero.ch"' in res.data
+    assert b'"email":"orgsubmitter@rero.ch"' in res.data
     assert not res.json['metadata']['permissions']['documents']['add']
     assert not res.json['metadata']['permissions']['organisations']['add']
     assert not res.json['metadata']['permissions']['users']['add']

--- a/tests/ui/users/test_users_api.py
+++ b/tests/ui/users/test_users_api.py
@@ -68,7 +68,7 @@ def test_get_reachable_roles(app):
     roles = UserRecord.get_reachable_roles(UserRecord.ROLE_MODERATOR)
     assert len(roles) == 3
     assert UserRecord.ROLE_MODERATOR in roles
-    assert UserRecord.ROLE_PUBLISHER in roles
+    assert UserRecord.ROLE_SUBMITTER in roles
     assert UserRecord.ROLE_USER in roles
 
     roles = UserRecord.get_reachable_roles('unknown_role')
@@ -136,7 +136,7 @@ def test_is_role_property(organisation, roles):
         dbcommit=True)
 
     assert user.is_user
-    assert user.is_publisher
+    assert user.is_submitter
     assert user.is_moderator
     assert not user.is_admin
     assert not user.is_superuser
@@ -197,5 +197,5 @@ def test_get_all_reachable_roles(app, db, user):
     assert len(roles) == 4
     assert 'user' in roles
     assert 'moderator' in roles
-    assert 'publisher' in roles
+    assert 'submitter' in roles
     assert 'admin' in roles


### PR DESCRIPTION
* Renames role `publisher` to `submitter`.
* Closes #250.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>