### PR TITLE
documents: import start date from field `502$9`.

### DIFF
--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -85,9 +85,13 @@
       {% for provision_activity in record.provisionActivity %}
       <ul class="list-unstyled my-2">
         {% set statement = provision_activity | create_publication_statement %}
+        {% if statement is string %}
+        {{ statement }}
+        {% else %}
         {% for element in statement %}
         <li>{{ statement[element] }}</li>
         {% endfor %}
+        {% endif %}
       </ul>
       {% endfor %}
 

--- a/sonar/modules/documents/utils.py
+++ b/sonar/modules/documents/utils.py
@@ -19,7 +19,7 @@
 
 from __future__ import absolute_import, print_function
 
-from sonar.modules.utils import remove_trailing_punctuation
+from sonar.modules.utils import format_date, remove_trailing_punctuation
 
 
 def publication_statement_text(provision_activity):
@@ -27,7 +27,7 @@ def publication_statement_text(provision_activity):
     # Only if provision activity is imported from field 269 (no statement,
     # but start date)
     if 'statement' not in provision_activity:
-        return provision_activity['startDate']
+        return format_date(provision_activity['startDate'])
 
     punctuation = {'bf:Place': ' ; ', 'bf:Agent': ', '}
 

--- a/sonar/modules/utils.py
+++ b/sonar/modules/utils.py
@@ -17,6 +17,7 @@
 
 """Utils functions for application."""
 
+import datetime
 import re
 
 from flask import current_app, g
@@ -131,3 +132,18 @@ def get_view_code():
         return g.organisation['code']
 
     return current_app.config.get('SONAR_APP_DEFAULT_ORGANISATION')
+
+
+def format_date(date):
+    """Format date to given format.
+
+    :param date: String representing the date.
+    :param format: Format of the ouput.
+    :returns: The formatted date.
+    """
+    # Complete date (eg. 2020-12-31)
+    if re.match(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}$', date):
+        return datetime.datetime.strptime(date,
+                                          '%Y-%m-%d').strftime('%d.%m.%Y')
+
+    return date

--- a/tests/ui/documents/dojson/rerodoc/test_rerodoc_model.py
+++ b/tests/ui/documents/dojson/rerodoc/test_rerodoc_model.py
@@ -383,10 +383,7 @@ def test_marc21_to_language(app):
     """
     marc21json = create_record(marc21xml)
     data = marc21tojson.do(marc21json)
-    assert data.get('language') == [{
-        'type': 'bf:Language',
-        'value': 'fre'
-    }]
+    assert data.get('language') == [{'type': 'bf:Language', 'value': 'fre'}]
 
     # Multiple $a
     marc21xml = """
@@ -472,8 +469,7 @@ def test_marc21_to_provision_activity_field_260(app):
             "label": [{
                 "value": "Bulletin officiel du Directoire"
             }],
-            "type":
-            "bf:Agent"
+            "type": "bf:Agent"
         }, {
             "label": [{
                 "value": "1798-1799"
@@ -636,11 +632,38 @@ def test_marc21_to_provision_activity_all():
         <datafield tag="269" ind1=" " ind2=" ">
             <subfield code="c">1700</subfield>
         </datafield>
+        <datafield tag="502" ind1=" " ind2=" ">
+            <subfield code="a">Thèse 2</subfield>
+            <subfield code="9">2020</subfield>
+        </datafield>
     </record>
     """
     marc21json = create_record(marc21xml)
     data = marc21tojson.do(marc21json)
     assert data.get('provisionActivity') == [{
+        "type":
+        "bf:Publication",
+        "startDate":
+        "1798",
+        "endDate":
+        "1799",
+        "statement": [{
+            "label": [{
+                "value": "Lausanne"
+            }],
+            "type": "bf:Place"
+        }, {
+            "label": [{
+                "value": "Bulletin officiel du Directoire"
+            }],
+            "type": "bf:Agent"
+        }, {
+            "label": [{
+                "value": "1798-1799"
+            }],
+            "type": "Date"
+        }]
+    }, {
         "type":
         "bf:Manufacture",
         "statement": [{
@@ -653,30 +676,6 @@ def test_marc21_to_provision_activity_all():
                 "value": "Henri Vincent"
             }],
             "type": "bf:Agent"
-        }]
-    }, {
-        "type":
-        "bf:Publication",
-        "startDate":
-        "1700",
-        "endDate":
-        "1799",
-        "statement": [{
-            "label": [{
-                "value": "Lausanne"
-            }],
-            "type": "bf:Place"
-        }, {
-            "label": [{
-                "value": "Bulletin officiel du Directoire"
-            }],
-            "type":
-            "bf:Agent"
-        }, {
-            "label": [{
-                "value": "1798-1799"
-            }],
-            "type": "Date"
         }]
     }]
 
@@ -1580,12 +1579,10 @@ def test_marc21_to_classification_from_field_080():
     """
     marc21json = create_record(marc21xml)
     data = marc21tojson.do(marc21json)
-    assert data.get('classification') == [
-        {
-            "type": "bf:ClassificationUdc",
-            "classificationPortion": "82"
-        }
-    ]
+    assert data.get('classification') == [{
+        "type": "bf:ClassificationUdc",
+        "classificationPortion": "82"
+    }]
 
     # Not $a record
     marc21xml = """
@@ -1612,12 +1609,10 @@ def test_marc21_to_classification_from_field_084():
     """
     marc21json = create_record(marc21xml)
     data = marc21tojson.do(marc21json)
-    assert data.get('classification') == [
-        {
-            "type": "bf:ClassificationDdc",
-            "classificationPortion": "610"
-        }
-    ]
+    assert data.get('classification') == [{
+        "type": "bf:ClassificationDdc",
+        "classificationPortion": "610"
+    }]
 
     # Not $a record
     marc21xml = """
@@ -1659,16 +1654,13 @@ def test_marc21_to_classification_from_all():
     """
     marc21json = create_record(marc21xml)
     data = marc21tojson.do(marc21json)
-    assert data.get('classification') == [
-        {
-            "type": "bf:ClassificationUdc",
-            "classificationPortion": "82"
-        },
-        {
-            "type": "bf:ClassificationDdc",
-            "classificationPortion": "610"
-        }
-    ]
+    assert data.get('classification') == [{
+        "type": "bf:ClassificationUdc",
+        "classificationPortion": "82"
+    }, {
+        "type": "bf:ClassificationDdc",
+        "classificationPortion": "610"
+    }]
 
 
 def test_marc21_to_content_note():
@@ -2222,7 +2214,7 @@ def test_marc21_to_contribution_field_711():
     assert not data.get('contribution')
 
 
-def test_marc21_to_part_of():
+def test_marc21_to_part_of(app):
     """Test extracting is part of from field 773."""
     # With sub type of ART INBOOK
     marc21xml = """
@@ -2250,6 +2242,10 @@ def test_marc21_to_part_of():
                 'startDate': '2015'
             }
         }
+    }]
+    assert data.get('provisionActivity') == [{
+        'startDate': '2015',
+        'type': 'bf:Publication'
     }]
 
     # With sub type is not ART INBOOK
@@ -2279,6 +2275,10 @@ def test_marc21_to_part_of():
             }
         }
     }]
+    assert data.get('provisionActivity') == [{
+        'startDate': '2020',
+        'type': 'bf:Publication'
+    }]
 
     # Without $g
     marc21xml = """
@@ -2296,6 +2296,7 @@ def test_marc21_to_part_of():
     marc21json = create_record(marc21xml)
     data = marc21tojson.do(marc21json)
     assert not data.get('partOf')
+    assert not data.get('provisionActivity')
 
     # Without empty numbering year
     marc21xml = """
@@ -2314,6 +2315,7 @@ def test_marc21_to_part_of():
     marc21json = create_record(marc21xml)
     data = marc21tojson.do(marc21json)
     assert not data.get('partOf')
+    assert not data.get('provisionActivity')
 
     # Without numbering year
     marc21xml = """
@@ -2332,6 +2334,7 @@ def test_marc21_to_part_of():
     marc21json = create_record(marc21xml)
     data = marc21tojson.do(marc21json)
     assert not data.get('partOf')
+    assert not data.get('provisionActivity')
 
     # Without title
     marc21xml = """
@@ -2357,6 +2360,10 @@ def test_marc21_to_part_of():
                 'statement': 'Stämpfli Verlag, Bern'
             }
         }
+    }]
+    assert data.get('provisionActivity') == [{
+        'startDate': '2015',
+        'type': 'bf:Publication'
     }]
 
     # Without $c
@@ -2384,6 +2391,10 @@ def test_marc21_to_part_of():
             }
         }
     }]
+    assert data.get('provisionActivity') == [{
+        'startDate': '2015',
+        'type': 'bf:Publication'
+    }]
 
     # Without document
     marc21xml = """
@@ -2398,6 +2409,163 @@ def test_marc21_to_part_of():
     """
     marc21json = create_record(marc21xml)
     data = marc21tojson.do(marc21json)
-    assert data.get('partOf') == [{
-        'numberingYear': '2015'
+    assert data.get('partOf') == [{'numberingYear': '2015'}]
+    assert data.get('provisionActivity') == [{
+        'startDate': '2015',
+        'type': 'bf:Publication'
     }]
+
+
+def test_start_date_priorities(app):
+    """Test start date priorities for provision activity."""
+    # Four potential start dates.
+    marc21xml = """
+    <record>
+        <datafield tag="260" ind1=" " ind2=" ">
+            <subfield code="a">Lausanne</subfield>
+            <subfield code="c">1798-1799</subfield>
+            <subfield code="b">Bulletin officiel du Directoire,</subfield>
+        </datafield>
+        <datafield tag="773" ind1=" " ind2=" ">
+            <subfield code="g">2015///</subfield>
+        </datafield>
+        <datafield tag="269" ind1=" " ind2=" ">
+            <subfield code="c">1966</subfield>
+        </datafield>
+        <datafield tag="502" ind1=" " ind2=" ">
+            <subfield code="a">Thèse 1</subfield>
+            <subfield code="9">2020</subfield>
+        </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21tojson.do(marc21json)
+    assert data['provisionActivity'][0]['startDate'] == '1798'
+
+    # Start dates from 269$c must be taken.
+    marc21xml = """
+    <record>
+        <datafield tag="269" ind1=" " ind2=" ">
+            <subfield code="c">1966</subfield>
+        </datafield>
+        <datafield tag="502" ind1=" " ind2=" ">
+            <subfield code="a">Thèse 1</subfield>
+            <subfield code="9">2020</subfield>
+        </datafield>
+        <datafield tag="773" ind1=" " ind2=" ">
+            <subfield code="g">2015///</subfield>
+        </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21tojson.do(marc21json)
+    assert data['provisionActivity'][0]['startDate'] == '1966'
+
+    # Start dates from 773$g must be taken.
+    marc21xml = """
+    <record>
+        <datafield tag="502" ind1=" " ind2=" ">
+            <subfield code="a">Thèse 1</subfield>
+            <subfield code="9">2020</subfield>
+        </datafield>
+        <datafield tag="773" ind1=" " ind2=" ">
+            <subfield code="g">2015///</subfield>
+        </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21tojson.do(marc21json)
+    assert data['provisionActivity'][0]['startDate'] == '2015'
+
+    # Only 502$9
+    marc21xml = """
+    <record>
+        <datafield tag="502" ind1=" " ind2=" ">
+            <subfield code="a">Thèse 1</subfield>
+            <subfield code="9">2020</subfield>
+        </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21tojson.do(marc21json)
+    assert data['provisionActivity'][0]['startDate'] == '2020'
+
+
+def test_marc21_to_provision_activity_field_502(app):
+    """Test provision activity with field 502."""
+    # One field
+    marc21xml = """
+    <record>
+        <datafield tag="502" ind1=" " ind2=" ">
+            <subfield code="a">Thèse 1</subfield>
+            <subfield code="9">2020</subfield>
+        </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21tojson.do(marc21json)
+    assert data.get('provisionActivity') == [{
+        'startDate': '2020',
+        'type': 'bf:Publication'
+    }]
+
+    # One field with full date
+    marc21xml = """
+    <record>
+        <datafield tag="502" ind1=" " ind2=" ">
+            <subfield code="a">Thèse 1</subfield>
+            <subfield code="9">2020-09-09</subfield>
+        </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21tojson.do(marc21json)
+    assert data.get('provisionActivity') == [{
+        'startDate': '2020-09-09',
+        'type': 'bf:Publication'
+    }]
+
+    # Date does not match "YYYY" OR "YYYY-MM-DD"
+    marc21xml = """
+    <record>
+        <datafield tag="502" ind1=" " ind2=" ">
+            <subfield code="a">Thèse 1</subfield>
+            <subfield code="9">2010-2020</subfield>
+        </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21tojson.do(marc21json)
+    assert not data.get('provisionActivity')
+
+    # Multiple fields
+    marc21xml = """
+    <record>
+        <datafield tag="502" ind1=" " ind2=" ">
+            <subfield code="a">Thèse 1</subfield>
+            <subfield code="9">2010</subfield>
+        </datafield>
+        <datafield tag="502" ind1=" " ind2=" ">
+            <subfield code="a">Thèse 2</subfield>
+            <subfield code="9">2020</subfield>
+        </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21tojson.do(marc21json)
+    assert data.get('provisionActivity') == [{
+        'startDate': '2020',
+        'type': 'bf:Publication'
+    }]
+
+    # No field $9
+    marc21xml = """
+    <record>
+        <datafield tag="502" ind1=" " ind2=" ">
+            <subfield code="a">Thèse 2</subfield>
+        </datafield>
+    </record>
+    """
+    marc21json = create_record(marc21xml)
+    data = marc21tojson.do(marc21json)
+    assert not data.get('provisionActivity')

--- a/tests/ui/documents/test_documents_utils.py
+++ b/tests/ui/documents/test_documents_utils.py
@@ -53,3 +53,9 @@ def test_publication_statement_text():
         'type': 'bf:Publication',
         'startDate': '1990'
     }) == '1990'
+
+    # Without statement, complete date
+    assert utils.publication_statement_text({
+        'type': 'bf:Publication',
+        'startDate': '1990-12-31'
+    }) == '31.12.1990'

--- a/tests/ui/test_utils.py
+++ b/tests/ui/test_utils.py
@@ -24,7 +24,7 @@ from flask import g
 
 from sonar.modules.documents.views import store_organisation
 from sonar.modules.utils import change_filename_extension, \
-    create_thumbnail_from_file, get_current_language, \
+    create_thumbnail_from_file, format_date, get_current_language, \
     get_switch_aai_providers, get_view_code
 
 
@@ -94,3 +94,15 @@ def test_get_view_code(organisation):
 
     g.pop('organisation', None)
     assert get_view_code() == 'global'
+
+
+def test_format_date():
+    """Test date formatting."""
+    # Just year
+    assert format_date('2020') == '2020'
+
+    # Complete date
+    assert format_date('2020-01-01') == '01.01.2020'
+
+    # No processing
+    assert format_date('July 31, 2020') == 'July 31, 2020'


### PR DESCRIPTION
* Imports start date in provision activity from field `502$9`.
* Prioritizes fields for retreiving start date: 1. 260$c, 2. 269$c, 3. 773$g, 4. 502$9.
* Closes #254.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>