### PR TITLE
documents: add dissertation property

### DIFF
--- a/sonar/common/jsonschemas/type-v1.0.0.json
+++ b/sonar/common/jsonschemas/type-v1.0.0.json
@@ -40,7 +40,7 @@
     "coar:c_18hj",
     "coar:c_18ws",
     "coar:c_18gh",
-    "coar:c_46ec2",
+    "coar:c_46ec",
     "coar:c_7a1f",
     "coar:c_db06",
     "coar:c_bdcc",

--- a/sonar/modules/deposits/api.py
+++ b/sonar/modules/deposits/api.py
@@ -214,6 +214,10 @@ class DepositRecord(SonarRecord):
                 abstract['abstract']
             } for abstract in self['metadata']['abstracts']]
 
+        # Dissertation
+        if self['metadata'].get('dissertation'):
+            metadata['dissertation'] = self['metadata']['dissertation']
+
         # Subjects
         if self['metadata'].get('subjects'):
             metadata['subjects'] = [{

--- a/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
+++ b/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
@@ -259,6 +259,7 @@
         "language",
         "documentDate",
         "publication",
+        "dissertation",
         "otherElectronicVersions",
         "specificCollections",
         "classification",
@@ -482,6 +483,46 @@
               }
             }
           }
+        },
+        "dissertation": {
+          "title": "Dissertation",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "degree": {
+              "title": "Degree",
+              "type": "string",
+              "minLength": 1
+            },
+            "jury_note": {
+              "title": "Jury note",
+              "type": "string",
+              "minLength": 1
+            },
+            "grantingInstitution": {
+              "title": "Granting institution",
+              "type": "string",
+              "minLength": 1
+            },
+            "date": {
+              "title": "Date",
+              "type": "string",
+              "pattern": "^[0-9]{4}(-[0-9]{2}-[0-9]{2})?$",
+              "form": {
+                "placeholder": "Example: 2019 or 2019-05-05"
+              }
+            }
+          },
+          "propertiesOrder": [
+            "degree",
+            "grantingInstitution",
+            "date",
+            "jury_note"
+          ],
+          "required": [
+            "degree"
+          ],
+          "hideExpression": "!['coar:c_46ec', 'coar:c_7a1f', 'coar:c_db06', 'coar:c_bdcc', 'habilitation_thesis', 'advanced_studies_thesis', 'other'].includes(field.parent.model.documentType)"
         }
       }
     },

--- a/sonar/modules/documents/dojson/rerodoc/model.py
+++ b/sonar/modules/documents/dojson/rerodoc/model.py
@@ -655,10 +655,7 @@ def marc21_to_dissertation_field_508(self, key, value):
         return None
 
     dissertation = self.get('dissertation', {})
-
-    note = dissertation.get('note', [])
-    note.append(value.get('a'))
-    dissertation['note'] = note
+    dissertation['jury_note'] = value.get('a')
 
     self['dissertation'] = dissertation
 

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -972,23 +972,38 @@
           "type": "string",
           "minLength": 1
         },
-        "note": {
-          "title": "Notes",
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "title": "Note",
-            "type": "string",
-            "minLength": 1
+        "jury_note": {
+          "title": "Jury note",
+          "type": "string",
+          "minLength": 1
+        },
+        "grantingInstitution": {
+          "title": "Granting institution",
+          "type": "string",
+          "minLength": 1
+        },
+        "date": {
+          "title": "Date",
+          "type": "string",
+          "pattern": "^[0-9]{4}(-[0-9]{2}-[0-9]{2})?$",
+          "form": {
+            "placeholder": "Example: 2019 or 2019-05-05"
           }
         }
       },
+      "propertiesOrder": [
+        "degree",
+        "grantingInstitution",
+        "date",
+        "jury_note"
+      ],
       "required": [
         "degree"
       ],
       "form": {
         "hide": true
-      }
+      },
+      "hideExpression": "!['coar:c_46ec', 'coar:c_7a1f', 'coar:c_db06', 'coar:c_bdcc', 'habilitation_thesis', 'advanced_studies_thesis', 'other'].includes(field.parent.model.documentType)"
     },
     "usageAndAccessPolicy": {
       "title": "Usage and access policies",

--- a/sonar/modules/documents/mappings/v6/documents/document-v1.0.0.json
+++ b/sonar/modules/documents/mappings/v6/documents/document-v1.0.0.json
@@ -288,7 +288,13 @@
             "degree": {
               "type": "text"
             },
-            "notes": {
+            "jury_note": {
+              "type": "text"
+            },
+            "grantingInstitution": {
+              "type": "text"
+            },
+            "date": {
               "type": "text"
             }
           }

--- a/sonar/modules/documents/marshmallow/json.py
+++ b/sonar/modules/documents/marshmallow/json.py
@@ -31,7 +31,7 @@ from marshmallow import fields, pre_dump, pre_load
 from sonar.modules.documents.api import DocumentRecord
 from sonar.modules.documents.permissions import DocumentPermission
 from sonar.modules.documents.views import create_publication_statement, \
-    is_file_restricted, part_of_format
+    dissertation, is_file_restricted, part_of_format
 from sonar.modules.serializers import schema_from_context
 from sonar.modules.users.api import current_user_record
 
@@ -164,6 +164,9 @@ class DocumentMetadataSchemaV1(StrictKeysMixin):
             item['partOf'][index][
                 'text'] = part_of_format(part_of)
 
+        if item.get('dissertation'):
+            item['dissertation']['text'] = dissertation(item)
+
         return item
 
     @pre_load
@@ -185,7 +188,7 @@ class DocumentMetadataSchemaV1(StrictKeysMixin):
 
     @pre_load
     def remove_formatted_texts(self, data):
-        """Removes formatted texts from `provisionActivity` and `partOf` fields.
+        """Removes formatted texts from fields.
 
         :param data: Dict of record data.
         :returns: Modified data.
@@ -195,6 +198,8 @@ class DocumentMetadataSchemaV1(StrictKeysMixin):
 
         for part_of in data.get('partOf', []):
             part_of.pop('text', None)
+
+        data.get('dissertation', {}).pop('text', None)
 
 
 class DocumentSchemaV1(StrictKeysMixin):

--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -100,6 +100,12 @@
       <p class="my-2">{{ record.extent }}</p>
       {% endif %}
 
+      <!-- DISSERTATION -->
+      {% set dissertation = record | dissertation %}
+      {% if dissertation %}
+      <p class="my-2">{{ dissertation }}</p>
+      {% endif %}
+
       <!-- PART OF -->
       {% if record.partOf and record.partOf | length > 0 %}
       <div class="d-flex flex-row mb-3">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -342,6 +342,12 @@ def document_json(app, db, organisation):
             'responsibility': {
                 'value': 'Zeng Lingliang zhu bian'
             }
+        },
+        'dissertation': {
+            'degree': 'Doctoral thesis',
+            'grantingInstitution': 'Università della Svizzera italiana',
+            'date': '2010-12-01',
+            'jury_note': 'Jury note'
         }
     }
 
@@ -457,7 +463,13 @@ def deposit_json():
             }, {
                 'language': 'fre',
                 'subjects': ['Sujet 1', 'Sujet 2']
-            }]
+            }],
+            'dissertation': {
+                'degree': 'Doctoral thesis',
+                'grantingInstitution': 'Università della Svizzera italiana',
+                'date': '2010-12-01',
+                'jury_note': 'Jury note'
+            }
         },
         'status':
         'in_progress',

--- a/tests/ui/deposits/test_deposits_api.py
+++ b/tests/ui/deposits/test_deposits_api.py
@@ -108,6 +108,14 @@ def test_create_document(app, client, deposit, user):
         'controlledAffiliation': ['Uni of Bern and Hospital'],
         'role': ['cre']
     }]
+
+    assert document['dissertation'] == {
+        'degree': 'Doctoral thesis',
+        'grantingInstitution': 'Università della Svizzera italiana',
+        'date': '2010-12-01',
+        'jury_note': 'Jury note'
+    }
+
     assert document.files['main.pdf']['restricted'] == 'organisation'
     assert document.files['main.pdf']['embargo_date'] == '2021-01-01'
     assert len(document.files) == 6

--- a/tests/ui/documents/dojson/rerodoc/test_rerodoc_model.py
+++ b/tests/ui/documents/dojson/rerodoc/test_rerodoc_model.py
@@ -1746,7 +1746,7 @@ def test_marc21_to_dissertation_field_508():
     """
     marc21json = create_record(marc21xml)
     data = marc21tojson.do(marc21json)
-    assert data.get('dissertation') == {'note': ['Magna cum laude']}
+    assert data.get('dissertation') == {'jury_note': 'Magna cum laude'}
 
     # Multiple
     marc21xml = """
@@ -1761,7 +1761,7 @@ def test_marc21_to_dissertation_field_508():
     """
     marc21json = create_record(marc21xml)
     data = marc21tojson.do(marc21json)
-    assert data.get('dissertation') == {'note': ['Note 1', 'Note 2']}
+    assert data.get('dissertation') == {'jury_note': 'Note 2'}
 
     # Without $a
     marc21xml = """
@@ -1791,7 +1791,7 @@ def test_marc21_to_dissertation_all():
     data = marc21tojson.do(marc21json)
     assert data.get('dissertation') == {
         'degree': 'Thèse de doctorat',
-        'note': ['Magna cum laude']
+        'jury_note': 'Magna cum laude'
     }
 
 

--- a/tests/ui/documents/test_documents_views.py
+++ b/tests/ui/documents/test_documents_views.py
@@ -482,3 +482,48 @@ def test_contributors():
 
     # No contributors
     assert views.contributors({}) == []
+
+
+def test_dissertation():
+    """Test formatting of dissertation text."""
+    # No dissertation
+    assert not views.dissertation({})
+
+    # Only degree property
+    assert views.dissertation(
+        {'dissertation': {
+            'degree': 'Thèse de doctorat'
+        }}) == 'Thèse de doctorat'
+
+    #  With jury notes
+    assert views.dissertation({
+        'dissertation': {
+            'degree': 'Thèse de doctorat',
+            'jury_note': 'Jury note'
+        }
+    }) == 'Thèse de doctorat (jury note: Jury note)'
+
+    # With granting institution
+    assert views.dissertation(
+        {
+            'dissertation': {
+                'degree': 'Thèse de doctorat',
+                'jury_note': 'Jury note',
+                'grantingInstitution': 'Università della Svizzera italiana'
+            }
+        }
+    ) == 'Thèse de doctorat: Università della Svizzera italiana (jury note: ' \
+         'Jury note)'
+
+    # With date
+    assert views.dissertation(
+        {
+            'dissertation': {
+                'degree': 'Thèse de doctorat',
+                'jury_note': 'Jury note',
+                'grantingInstitution': 'Università della Svizzera italiana',
+                'date': '2010-01-01'
+            }
+        }
+    ) == 'Thèse de doctorat: Università della Svizzera italiana, 01.01.2010 ' \
+         '(jury note: Jury note)'


### PR DESCRIPTION
* Adds dissertation property in deposits JSON schema.
* Adds `grantingInstitution` and `date` properties in dissertation in documents JSON schema.
* Adds `grantingInstitution` and `date` properties in elasticsearch mapping.
* Renames `note` to `jury_note` in dissertation property.
* Populates dissertation property in document when a deposit is validated.
* Creates a filter for getting dissertation's text.
* Adds dissertation's text when document is serialized and remove it when it is loaded.
* Displays dissertation in documents detail views.
* Corrects a typo in thesis `COAR` value.
* Closes #265.
    
Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>