### PR TITLE
help: restrict to superuser roles.

### DIFF
--- a/sonar/modules/permissions.py
+++ b/sonar/modules/permissions.py
@@ -126,9 +126,9 @@ def files_permission_factory(*kwargs):
 def wiki_edit_permission():
     """Wiki edition permission.
 
-    :return: true if the logged user has the admin role.
+    :return: true if the logged user has the superuser role.
     """
-    return has_admin_access()
+    return has_superuser_access()
 
 
 class RecordPermission:

--- a/tests/ui/test_permissions.py
+++ b/tests/ui/test_permissions.py
@@ -179,7 +179,7 @@ def test_admin_permission_factory(app, client, superuser):
     assert admin_permission_factory(None).can()
 
 
-def test_wiki_edit_ui_permission(client, user, admin):
+def test_wiki_edit_ui_permission(client, user, superuser):
     """Test wiki edit ui permission."""
     # No access
     login_user_via_view(client, email=user['email'], password='123456')
@@ -189,5 +189,5 @@ def test_wiki_edit_ui_permission(client, user, admin):
     client.get(url_for_security('logout'))
 
     # OK user has access
-    login_user_via_view(client, email=admin['email'], password='123456')
+    login_user_via_view(client, email=superuser['email'], password='123456')
     assert wiki_edit_permission()


### PR DESCRIPTION
* Restricts the access to wiki management to users having the superuser role.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>