### PR TITLE
styles: avoid to load styles twice.

### DIFF
--- a/sonar/theme/templates/sonar/manage.html
+++ b/sonar/theme/templates/sonar/manage.html
@@ -6,10 +6,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="/static/favicon.ico" />
-    {{
-      webpack["sonar-theme.css"]
-    }}
-    <link rel="stylesheet" href="/static/sonar-ui/styles.css">
+    <link rel="stylesheet" href="/static/sonar-ui/styles.css?{{ ui_version }}">
   </head>
 
   <body>


### PR DESCRIPTION
Remove the inclusion of backend styles in administration panel, as styles are already included by frontend user interface.

* Removes backend styles inclusion.
* Adds a parameter containing the UI version to avoid cache on styles.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>