### PR TITLE
organisation: 404 instead of raising an exception

### DIFF
--- a/sonar/modules/documents/views.py
+++ b/sonar/modules/documents/views.py
@@ -51,35 +51,35 @@ def default_view_code(endpoint, values):
                       current_app.config.get('SONAR_APP_DEFAULT_ORGANISATION'))
 
 
-@blueprint.url_value_preprocessor
-def store_organisation(endpoint, values):
+@blueprint.before_request
+def store_organisation():
     """Add organisation record to global variables."""
-    view = values.pop('view',
-                      current_app.config.get('SONAR_APP_DEFAULT_ORGANISATION'))
+    view = request.view_args.get(
+        'view', current_app.config.get('SONAR_APP_DEFAULT_ORGANISATION'))
 
     if view != current_app.config.get('SONAR_APP_DEFAULT_ORGANISATION'):
         organisation = OrganisationRecord.get_record_by_pid(view)
 
-        if not organisation or not organisation['isShared']:
-            raise Exception('Organisation\'s view is not accessible')
+        if not organisation or not organisation.get('isShared'):
+            abort(404)
 
         g.organisation = organisation.dumps()
 
 
 @blueprint.route('/')
-def index():
+def index(view='global'):
     """Homepage."""
     return render_template('sonar/frontpage.html')
 
 
 @blueprint.route('/search/documents')
-def search():
+def search(view='global'):
     """Search results page."""
     return render_template('sonar/search.html')
 
 
 @blueprint.route('/documents/<pid_value>')
-def detail(pid_value):
+def detail(pid_value, view='global'):
     """Document detail page."""
     record = DocumentRecord.get_record_by_pid(pid_value)
 

--- a/tests/ui/test_utils.py
+++ b/tests/ui/test_utils.py
@@ -87,9 +87,12 @@ def test_get_current_language(app):
         assert get_current_language() == 'fr'
 
 
-def test_get_view_code(organisation):
+def test_get_view_code(app, organisation):
     """Test get view code stored in organisation."""
-    store_organisation(None, {'view': 'org'})
+    with app.test_request_context() as req:
+        req.request.view_args['view'] = 'org'
+        store_organisation()
+
     assert get_view_code() == 'org'
 
     g.pop('organisation', None)


### PR DESCRIPTION
When an organisation is not existing or has not a shared view, instead of raising an exception, a 404 is returned as response.

* Stores current organisation in `before_request` hook instead of in `url_value_preprocessor` to have access to abort function.
* Throws a 404 instead of raising an exception when the organisation is not found.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>