### PR TITLE
records: improve date validation

### DIFF
--- a/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
+++ b/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
@@ -94,7 +94,7 @@
             "title": "Embargo date",
             "type": "string",
             "format": "date",
-            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}?$"
+            "pattern": "^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$"
           },
           "exceptInOrganisation": {
             "title": "Except within organisation",
@@ -307,7 +307,7 @@
           "description": "This field corresponds to the exact publication date of the article, if known.",
           "type": "string",
           "minLength": 1,
-          "pattern": "^[0-9]{4}(-[0-9]{2}-[0-9]{2})?$",
+          "pattern": "^[0-9]{4}(-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01]))?$",
           "form": {
             "placeholder": "Example: 2019 or 2019-05-05"
           }
@@ -507,7 +507,7 @@
             "date": {
               "title": "Date",
               "type": "string",
-              "pattern": "^[0-9]{4}(-[0-9]{2}-[0-9]{2})?$",
+              "pattern": "^[0-9]{4}(-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01]))?$",
               "form": {
                 "placeholder": "Example: 2019 or 2019-05-05"
               }

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -400,7 +400,7 @@
             "title": "Start date of publication",
             "type": "string",
             "minLength": 1,
-            "pattern": "^[0-9]{4}(-[0-9]{2}-[0-9]{2})?$",
+            "pattern": "^[0-9]{4}(-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01]))?$",
             "form": {
               "placeholder": "Example: 2019 or 2019-01-01",
               "hideExpression": "model.type !== 'bf:Publication'",
@@ -413,7 +413,7 @@
             "title": "End date of publication",
             "type": "string",
             "minLength": 1,
-            "pattern": "^[0-9]{4}(-[0-9]{2}-[0-9]{2})?$",
+            "pattern": "^[0-9]{4}(-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01]))?$",
             "form": {
               "placeholder": "Example: 2019 or 2019-01-01",
               "hideExpression": "model.type !== 'bf:Publication' || !model.startDate"
@@ -985,7 +985,7 @@
         "date": {
           "title": "Date",
           "type": "string",
-          "pattern": "^[0-9]{4}(-[0-9]{2}-[0-9]{2})?$",
+          "pattern": "^[0-9]{4}(-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01]))?$",
           "form": {
             "placeholder": "Example: 2019 or 2019-05-05"
           }

--- a/sonar/modules/users/jsonschemas/users/user-v1.0.0.json
+++ b/sonar/modules/users/jsonschemas/users/user-v1.0.0.json
@@ -27,7 +27,7 @@
       "description": "Date in yyyy-mm-dd format, ex: 1970-01-01",
       "type": "string",
       "format": "date",
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+      "pattern": "^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$"
     },
     "email": {
       "title": "Email",


### PR DESCRIPTION
The date properties are now validated against a real month and a real day. Before that a date like `2020-19-19` passed the validation.

* Changes the regex for date validation in all date properties of all records types.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>