### PR TITLE
documents: create an associated bucket by default

### DIFF
--- a/sonar/modules/documents/api.py
+++ b/sonar/modules/documents/api.py
@@ -112,6 +112,16 @@ class DocumentRecord(SonarRecord):
             host=host, org=org, pid=pid)
 
     @classmethod
+    def create(cls, data, id_=None, dbcommit=False, with_bucket=True,
+               **kwargs):
+        """Create document record."""
+        return super(DocumentRecord, cls).create(data,
+                                                 id_=id_,
+                                                 dbcommit=dbcommit,
+                                                 with_bucket=with_bucket,
+                                                 **kwargs)
+
+    @classmethod
     def get_record_by_identifier(cls, identifiers):
         """Get a record by its identifier.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -238,7 +238,7 @@ def superuser(make_user):
 
 
 @pytest.fixture()
-def document_json(app, db, organisation):
+def document_json(app, db, bucket_location, organisation):
     """JSON document fixture."""
     data = {
         'identifiedBy': [{
@@ -355,8 +355,7 @@ def document_json(app, db, organisation):
 
 
 @pytest.fixture()
-def make_document(db, document_json, make_organisation, bucket_location,
-                  pdf_file):
+def make_document(db, document_json, make_organisation, pdf_file):
     """Factory for creating document."""
 
     def _make_document(organisation='org', with_file=False, pid=None):


### PR DESCRIPTION
When creating a document from scratch, it's necessary to create an associated bucket, otherwise REST endpoints for files are not available for the document.

* Sets `with_bucket` to `true` when a document is created, to have a bucket associated with it.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>