### PR TITLE
editor: do not sort hierarchical options

### DIFF
--- a/sonar/common/jsonschemas/classification-v1.0.0.json
+++ b/sonar/common/jsonschemas/classification-v1.0.0.json
@@ -91,6 +91,7 @@
     "931"
   ],
   "form": {
+    "type": "enum",
     "options": [
       {
         "label": "classification_root_1",

--- a/sonar/common/jsonschemas/language-v1.0.0.json
+++ b/sonar/common/jsonschemas/language-v1.0.0.json
@@ -489,6 +489,7 @@
     "zza"
   ],
   "form": {
+    "type": "enum",
     "options": [
       {
         "label": "lang_eng",

--- a/sonar/common/jsonschemas/type-v1.0.0.json
+++ b/sonar/common/jsonschemas/type-v1.0.0.json
@@ -51,6 +51,7 @@
     "coar:c_1843"
   ],
   "form": {
+    "type": "enum",
     "options": [
       {
         "label": "document_type_coar:c_2f33",


### PR DESCRIPTION
For instance, document's types are hierarchically classified and for that reason, the options must not be ordered by alphabetical order. To avoid this behavior, the type of form field must be set explicitly.

* Sets form type to `enum` for `documentType` field.
* Sets form type to `enum` for `classification` field.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>