### PR TITLE
documents: improve editor

### DIFF
--- a/sonar/common/jsonschemas/type-v1.0.0.json
+++ b/sonar/common/jsonschemas/type-v1.0.0.json
@@ -274,6 +274,12 @@
         "label": "document_type_coar:c_1843",
         "value": "coar:c_1843"
       }
-    ]
+    ],
+    "templateOptions": {
+      "cssClass": "editor-title"
+    },
+    "expressionProperties": {
+      "templateOptions.required": "true"
+    }
   }
 }

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -138,9 +138,11 @@
         "$ref"
       ],
       "form": {
-        "hide": true,
-        "navigation": {
-          "essential": true
+        "templateOptions": {
+          "cssClass": "editor-title"
+        },
+        "expressionProperties": {
+          "templateOptions.required": "true"
         }
       }
     },
@@ -159,6 +161,9 @@
           "type": {
             "title": "Type",
             "type": "string",
+            "readOnly": true,
+            "const": "bf:Title",
+            "default": "bf:Title",
             "enum": [
               "bf:Title"
             ],
@@ -198,6 +203,7 @@
           "subtitle": {
             "title": "Subtitles",
             "type": "array",
+            "minItems": 1,
             "items": {
               "title": "Subtitle",
               "type": "object",
@@ -223,14 +229,19 @@
           }
         },
         "propertiesOrder": [
-          "type",
           "mainTitle",
-          "subtitle"
+          "subtitle",
+          "type"
         ],
         "required": [
           "type",
           "mainTitle"
         ]
+      },
+      "form": {
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
       }
     },
     "language": {
@@ -245,6 +256,9 @@
           "type": {
             "title": "Type",
             "type": "string",
+            "readOnly": true,
+            "const": "bf:Language",
+            "default": "bf:Language",
             "enum": [
               "bf:Language"
             ],
@@ -261,15 +275,18 @@
             "$ref": "language-v1.0.0.json"
           }
         },
+        "propertiesOrder": [ "value", "type" ],
         "required": [
           "type",
           "value"
         ]
       },
       "form": {
-        "hide": true,
-        "navigation": {
-          "essential": true
+        "templateOptions": {
+          "cssClass": "editor-title"
+        },
+        "expressionProperties": {
+          "templateOptions.required": "true"
         }
       }
     },
@@ -283,6 +300,7 @@
           "type": "object",
           "properties": {
             "value": {
+              "title": "Value",
               "type": "string",
               "minLength": 1
             }
@@ -296,10 +314,14 @@
           "type": "object",
           "properties": {
             "value": {
+              "title": "Value",
               "type": "string",
               "minLength": 1
             }
-          }
+          },
+          "required": [
+            "value"
+          ]
         }
       },
       "required": [
@@ -309,6 +331,9 @@
         "hide": true,
         "navigation": {
           "essential": true
+        },
+        "templateOptions": {
+          "cssClass": "editor-title"
         }
       }
     },
@@ -386,14 +411,21 @@
                         "type": "string",
                         "minLength": 1
                       }
-                    }
+                    },
+                    "required": ["value"]
                   }
                 }
               },
               "propertiesOrder": [
                 "type",
                 "label"
-              ]
+              ],
+              "required": ["type", "label"]
+            },
+            "form": {
+              "expressionProperties": {
+                "templateOptions.required": "field.parent.model.type && field.parent.model.type !== 'bf:Publication'"
+              }
             }
           },
           "startDate": {
@@ -403,9 +435,8 @@
             "pattern": "^[0-9]{4}(-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01]))?$",
             "form": {
               "placeholder": "Example: 2019 or 2019-01-01",
-              "hideExpression": "model.type !== 'bf:Publication'",
               "expressionProperties": {
-                "templateOptions.required": "model.type === 'bf:Publication'"
+                "templateOptions.required": "true"
               }
             }
           },
@@ -431,7 +462,12 @@
         ]
       },
       "form": {
-        "hideExpression": "!field.parent.model.documentType || ['coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc', 'coar:c_3e5a', 'coar:c_5794', 'coar:c_6670'].includes(field.parent.model.documentType)"
+        "templateOptions": {
+          "cssClass": "editor-title"
+        },
+        "expressionProperties": {
+          "templateOptions.required": "!['coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc', 'coar:c_3e5a', 'coar:c_5794', 'coar:c_6670'].includes(field.parent.model.documentType)"
+        }
       }
     },
     "extent": {
@@ -440,7 +476,10 @@
       "type": "string",
       "minLength": 1,
       "form": {
-        "hide": true
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
       }
     },
     "otherMaterialCharacteristics": {
@@ -449,7 +488,10 @@
       "type": "string",
       "minLength": 1,
       "form": {
-        "hide": true
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
       }
     },
     "formats": {
@@ -463,7 +505,10 @@
         "minLength": 1
       },
       "form": {
-        "hide": true
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
       }
     },
     "additionalMaterials": {
@@ -472,7 +517,10 @@
       "type": "string",
       "minLength": 1,
       "form": {
-        "hide": true
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
       }
     },
     "series": {
@@ -500,7 +548,10 @@
         ]
       },
       "form": {
-        "hide": true
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
       }
     },
     "notes": {
@@ -513,7 +564,10 @@
         "minLength": 1
       },
       "form": {
-        "hide": true
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
       }
     },
     "abstracts": {
@@ -543,6 +597,9 @@
         "hide": true,
         "navigation": {
           "essential": true
+        },
+        "templateOptions": {
+          "cssClass": "editor-title"
         }
       }
     },
@@ -748,6 +805,9 @@
         "hide": true,
         "navigation": {
           "essential": true
+        },
+        "templateOptions": {
+          "cssClass": "editor-title"
         }
       }
     },
@@ -797,6 +857,9 @@
         "hide": true,
         "navigation": {
           "essential": true
+        },
+        "templateOptions": {
+          "cssClass": "editor-title"
         }
       }
     },
@@ -849,7 +912,10 @@
         ]
       },
       "form": {
-        "hide": true
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
       }
     },
     "specificCollections": {
@@ -865,6 +931,9 @@
         "hide": true,
         "navigation": {
           "essential": true
+        },
+        "templateOptions": {
+          "cssClass": "editor-title"
         }
       }
     },
@@ -882,6 +951,9 @@
               "type": {
                 "title": "Type",
                 "type": "string",
+                "readOnly": true,
+                "const": "bf:ClassificationUdc",
+                "default": "bf:ClassificationUdc",
                 "enum": [
                   "bf:ClassificationUdc"
                 ],
@@ -899,8 +971,8 @@
               }
             },
             "propertiesOrder": [
-              "type",
-              "classificationPortion"
+              "classificationPortion",
+              "type"
             ],
             "required": [
               "type",
@@ -913,6 +985,9 @@
               "type": {
                 "title": "Type",
                 "type": "string",
+                "readOnly": true,
+                "const": "bf:ClassificationDdc",
+                "default": "bf:ClassificationDdc",
                 "enum": [
                   "bf:ClassificationDdc"
                 ],
@@ -932,8 +1007,8 @@
               }
             },
             "propertiesOrder": [
-              "type",
-              "classificationPortion"
+              "classificationPortion",
+              "type"
             ],
             "required": [
               "type",
@@ -943,9 +1018,11 @@
         ]
       },
       "form": {
-        "hide": true,
-        "navigation": {
-          "essential": true
+        "templateOptions": {
+          "cssClass": "editor-title"
+        },
+        "expressionProperties": {
+          "templateOptions.required": "true"
         }
       }
     },
@@ -959,7 +1036,10 @@
         "minLength": 1
       },
       "form": {
-        "hide": true
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
       }
     },
     "dissertation": {
@@ -1001,7 +1081,10 @@
         "degree"
       ],
       "form": {
-        "hide": true
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
       },
       "hideExpression": "!['coar:c_46ec', 'coar:c_7a1f', 'coar:c_db06', 'coar:c_bdcc', 'habilitation_thesis', 'advanced_studies_thesis', 'other'].includes(field.parent.model.documentType)"
     },
@@ -1015,7 +1098,10 @@
         "minLength": 1
       },
       "form": {
-        "hide": true
+        "hide": true,
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
       }
     },
     "contribution": {
@@ -1038,8 +1124,7 @@
                 "enum": [
                   "bf:Person",
                   "bf:Organization",
-                  "bf:Meeting",
-                  "bf:Local"
+                  "bf:Meeting"
                 ],
                 "form": {
                   "options": [
@@ -1054,10 +1139,6 @@
                     {
                       "label": "bf:Meeting",
                       "value": "bf:Meeting"
-                    },
-                    {
-                      "label": "bf:Local",
-                      "value": "bf:Local"
                     }
                   ]
                 }
@@ -1249,6 +1330,9 @@
         "hide": true,
         "navigation": {
           "essential": true
+        },
+        "templateOptions": {
+          "cssClass": "editor-title"
         }
       }
     },
@@ -1271,7 +1355,7 @@
             "type": "string",
             "minLength": 1,
             "form": {
-              "hideExpression": "!['coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc'].includes(field.parent.parent.parent.model.documentType)"
+              "hideExpression": "!['coar:c_3e5a', 'coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc'].includes(field.parent.parent.parent.model.documentType)"
             }
           },
           "numberingIssue": {
@@ -1279,7 +1363,7 @@
             "type": "string",
             "minLength": 1,
             "form": {
-              "hideExpression": "!['coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc'].includes(field.parent.parent.parent.model.documentType)"
+              "hideExpression": "!['coar:c_3e5a', 'coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc'].includes(field.parent.parent.parent.model.documentType)"
             }
           },
           "numberingPages": {
@@ -1309,10 +1393,7 @@
                   "startDate": {
                     "title": "Start date",
                     "type": "string",
-                    "minLength": 1,
-                    "form": {
-                      "hide": true
-                    }
+                    "minLength": 1
                   },
                   "statement": {
                     "title": "Statement",
@@ -1368,7 +1449,12 @@
         ]
       },
       "form": {
-        "hideExpression": "!['coar:c_3248', 'coar:c_5794', 'coar:c_6670', 'coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc'].includes(field.parent.model.documentType)"
+        "expressionProperties": {
+          "templateOptions.required": "['coar:c_3248', 'coar:c_5794', 'coar:c_6670', 'coar:c_3e5a', 'coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc'].includes(field.parent.model.documentType)"
+        },
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
       }
     }
   },


### PR DESCRIPTION
Improve document editor by making some changes on fields, listed below.

* Adds CSS class `editor-title` to display a block for each main fields.
* Makes field `title.type` not editable and place it after the value.
* Removes type `bf:Local` for `contribution` field.
* Makes field `classification.type` not editable and place it after the value.
* Shows value when a `subtitle` field is added.
* Makes `language` field required and `language.type` readonly.
* Makes `partof` field required when document type is a contribution to journal.
* Makes `organisation` field required.
* Makes `provisionActivity` field required depending on document type, instead of hiding it.
* Closes #230.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>