### PR TITLE
documents: fix permalink

### DIFF
--- a/sonar/modules/documents/config.py
+++ b/sonar/modules/documents/config.py
@@ -29,5 +29,5 @@ SONAR_DOCUMENTS_GENERATE_THUMBNAIL = True
 SONAR_DOCUMENTS_ORGANISATIONS_EXTERNAL_FILES = ['csal']
 """Display external files URL for these organisations."""
 
-SONAR_DOCUMENTS_PERMALINK = '{host}organisation/{org}/documents/{pid}'
+SONAR_DOCUMENTS_PERMALINK = '{host}{org}/documents/{pid}'
 """Permalink for accessing documents details."""


### PR DESCRIPTION
After the simplification of URLs for organisations, the permalink to document's detail is not working anymore. This commit fixes the permalink to match the new URL.

* Changes configuration for `SONAR_DOCUMENTS_PERMALINK` to make permalink work again.
* Closes #282.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>