### PR TITLE
search: enhance elasticsearch mappings

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -44,6 +44,7 @@ include babel.ini
 include docker/haproxy/Dockerfile
 include docker/nginx/Dockerfile
 include docker/postgres/Dockerfile
+include docker/elasticsearch/Dockerfile
 include pytest.ini
 include scripts/bootstrap
 include scripts/console

--- a/docker-services.yml
+++ b/docker-services.yml
@@ -73,7 +73,8 @@ services:
       - "15672:15672"
       - "5672:5672"
   es:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.6.0
+    build: ./docker/elasticsearch/
+    image: elasticsearch-icu
     restart: "always"
     environment:
       - bootstrap.memory_lock=true

--- a/docker/elasticsearch/Dockerfile
+++ b/docker/elasticsearch/Dockerfile
@@ -1,0 +1,2 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch-oss:6.6.2
+RUN bin/elasticsearch-plugin install analysis-icu

--- a/sonar/config.py
+++ b/sonar/config.py
@@ -29,7 +29,7 @@ import os
 from datetime import timedelta
 
 from invenio_oauthclient.contrib import orcid
-from invenio_records_rest.facets import range_filter, terms_filter
+from invenio_records_rest.facets import range_filter
 
 from sonar.modules.deposits.api import DepositRecord, DepositSearch
 from sonar.modules.deposits.permissions import DepositPermission
@@ -40,6 +40,7 @@ from sonar.modules.organisations.api import OrganisationRecord, \
 from sonar.modules.organisations.permissions import OrganisationPermission
 from sonar.modules.permissions import record_permission_factory, \
     wiki_edit_permission
+from sonar.modules.query import and_term_filter
 from sonar.modules.users.api import UserRecord, UserSearch
 from sonar.modules.users.permissions import UserPermission
 from sonar.modules.utils import get_current_language
@@ -448,19 +449,19 @@ RECORDS_REST_FACETS = {
         ))),
          filters={
              'organisation':
-             terms_filter('organisation.pid'),
+             and_term_filter('organisation.pid'),
              'language':
-             terms_filter('language.value'),
+             and_term_filter('language.value'),
              'subject':
-             terms_filter('facet_subjects'),
+             and_term_filter('facet_subjects'),
              'specific_collection':
-             terms_filter('specificCollections'),
+             and_term_filter('specificCollections'),
              'document_type':
-             terms_filter('documentType'),
+             and_term_filter('documentType'),
              'controlled_affiliation':
-             terms_filter('contribution.controlledAffiliation.raw'),
+             and_term_filter('contribution.controlledAffiliation.raw'),
              'author':
-             terms_filter('contribution.agent.preferred_name.raw'),
+             and_term_filter('contribution.agent.preferred_name.raw'),
              'year':
              range_filter('provisionActivity.startDate',
                           format='yyyy',
@@ -471,10 +472,10 @@ RECORDS_REST_FACETS = {
                    user=dict(terms=dict(field='user.full_name.keyword')),
                    contributor=dict(terms=dict(field='facet_contributors'))),
          filters={
-             _('pid'): terms_filter('pid'),
-             _('status'): terms_filter('status'),
-             _('user'): terms_filter('user.full_name.keyword'),
-             _('contributor'): terms_filter('facet_contributors'),
+             _('pid'): and_term_filter('pid'),
+             _('status'): and_term_filter('status'),
+             _('user'): and_term_filter('user.full_name.keyword'),
+             _('contributor'): and_term_filter('facet_contributors'),
          })
 }
 """REST search facets."""
@@ -482,14 +483,14 @@ RECORDS_REST_FACETS = {
 RECORDS_REST_SORT_OPTIONS = dict(documents=dict(
     bestmatch=dict(
         title=_('Best match'),
-        fields=['_score'],
-        default_order='desc',
+        fields=['-_score'],
+        default_order='asc',
         order=2,
     ),
     mostrecent=dict(
         title=_('Most recent'),
         fields=['-_created'],
-        default_order='asc',
+        default_order='desc',
         order=1,
     ),
 ))

--- a/sonar/es_templates/v6/record.json
+++ b/sonar/es_templates/v6/record.json
@@ -12,12 +12,13 @@
         }
       },
       "analyzer": {
-        "global_lowercase_asciifolding": {
+        "default": {
           "type": "custom",
           "tokenizer": "char_group_tokenizer",
           "filter": [
             "lowercase",
-            "asciifolding"
+            "icu_folding",
+            "german_normalization"
           ]
         }
       }

--- a/sonar/modules/deposits/mappings/v6/deposits/deposit-v1.0.0.json
+++ b/sonar/modules/deposits/mappings/v6/deposits/deposit-v1.0.0.json
@@ -5,14 +5,63 @@
       "numeric_detection": false,
       "properties": {
         "$schema": {
-          "type": "text",
-          "index": false
+          "type": "keyword"
         },
         "pid": {
           "type": "keyword"
         },
+        "_bucket": {
+          "type": "keyword"
+        },
+        "_files": {
+          "type": "object",
+          "properties": {
+            "bucket": {
+              "type": "keyword"
+            },
+            "file_id": {
+              "type": "keyword"
+            },
+            "version_id": {
+              "type": "keyword"
+            },
+            "key": {
+              "type": "keyword"
+            },
+            "checksum": {
+              "type": "keyword"
+            },
+            "size": {
+              "type": "integer"
+            },
+            "label": {
+              "type": "text"
+            },
+            "category": {
+              "type": "keyword"
+            },
+            "type": {
+              "type": "keyword"
+            },
+            "embargo": {
+              "type": "boolean"
+            },
+            "embargoDate": {
+              "type": "date",
+              "format": "yyyy-MM-dd"
+            },
+            "exceptInOrganisation": {
+              "type": "boolean"
+            }
+          }
+        },
         "user": {
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "$ref": {
+              "type": "keyword"
+            }
+          }
         },
         "status": {
           "type": "keyword"
@@ -20,8 +69,143 @@
         "step": {
           "type": "keyword"
         },
+        "logs": {
+          "type": "object",
+          "properties": {
+            "user": {
+              "type": "object",
+              "properties": {
+                "$ref": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "action": {
+              "type": "keyword"
+            },
+            "date": {
+              "type": "date",
+              "format": "yyyy-MM-dd HH:mm:ss"
+            },
+            "comment": {
+              "type": "text"
+            }
+          }
+        },
         "metadata": {
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "documentType": {
+              "type": "keyword"
+            },
+            "title": {
+              "type": "text"
+            },
+            "subtitle": {
+              "type": "text"
+            },
+            "otherLanguageTitle": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "text"
+                },
+                "language": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "language": {
+              "type": "keyword"
+            },
+            "documentDate": {
+              "type": "date",
+              "format": "yyyy-MM-dd||yyyy"
+            },
+            "publication": {
+              "type": "object",
+              "properties": {
+                "publishedIn": {
+                  "type": "text"
+                },
+                "year": {
+                  "type": "text"
+                },
+                "volume": {
+                  "type": "text"
+                },
+                "number": {
+                  "type": "text"
+                },
+                "pages": {
+                  "type": "text"
+                },
+                "editors": {
+                  "type": "text"
+                },
+                "publisher": {
+                  "type": "text"
+                }
+              }
+            },
+            "otherElectronicVersions": {
+              "type": "object",
+              "properties": {
+                "publicNote": {
+                  "type": "text"
+                },
+                "url": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "specificCollections": {
+              "type": "text"
+            },
+            "classification": {
+              "type": "keyword"
+            },
+            "abstracts": {
+              "type": "object",
+              "properties": {
+                "language": {
+                  "type": "keyword"
+                },
+                "abstract": {
+                  "type": "text"
+                }
+              }
+            },
+            "subjects": {
+              "type": "object",
+              "properties": {
+                "language": {
+                  "type": "keyword"
+                },
+                "subjects": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "dissertation": {
+              "type": "object",
+              "properties": {
+                "degree": {
+                  "type": "text"
+                },
+                "jury_note": {
+                  "type": "text"
+                },
+                "grantingInstitution": {
+                  "type": "text"
+                },
+                "date": {
+                  "type": "date",
+                  "format": "yyyy-MM-dd||yyyy"
+                }
+              }
+            }
+          }
         },
         "contributors": {
           "type": "object",
@@ -29,17 +213,31 @@
             "name": {
               "type": "text",
               "copy_to": "facet_contributors"
+            },
+            "affiliation": {
+              "type": "keyword"
+            },
+            "role": {
+              "type": "keyword"
+            },
+            "orcid": {
+              "type": "keyword"
             }
           }
         },
         "facet_contributors": {
           "type": "keyword"
         },
-        "projects": {
-          "type": "object"
-        },
         "diffusion": {
           "type": "object"
+        },
+        "document": {
+          "type": "object",
+          "properties": {
+            "$ref": {
+              "type": "keyword"
+            }
+          }
         }
       }
     }

--- a/sonar/modules/deposits/marshmallow/json.py
+++ b/sonar/modules/deposits/marshmallow/json.py
@@ -79,3 +79,4 @@ class DepositSchemaV1(StrictKeysMixin):
     created = fields.Str(dump_only=True)
     updated = fields.Str(dump_only=True)
     links = fields.Dict(dump_only=True)
+    explanation = fields.Raw(dump_only=True)

--- a/sonar/modules/deposits/query.py
+++ b/sonar/modules/deposits/query.py
@@ -18,9 +18,9 @@
 """Query for deposits."""
 
 from flask import current_app
-from invenio_records_rest.query import es_search_factory
 
 from sonar.modules.organisations.api import current_organisation
+from sonar.modules.query import default_search_factory
 from sonar.modules.users.api import current_user_record
 
 
@@ -31,7 +31,7 @@ def search_factory(self, search, query_parser=None):
     :param query_parser: Url arguments.
     :returns: Tuple with search instance and URL arguments.
     """
-    search, urlkwargs = es_search_factory(self, search)
+    search, urlkwargs = default_search_factory(self, search)
 
     if current_app.config.get('SONAR_APP_DISABLE_PERMISSION_CHECKS'):
         return (search, urlkwargs)

--- a/sonar/modules/documents/mappings/v6/documents/document-v1.0.0.json
+++ b/sonar/modules/documents/mappings/v6/documents/document-v1.0.0.json
@@ -2,26 +2,7 @@
   "settings": {
     "number_of_shards": 1,
     "number_of_replicas": 0,
-    "max_result_window": 20000,
-    "analysis": {
-      "filter": {
-        "autocomplete_filter": {
-          "type": "edge_ngram",
-          "min_gram": 1,
-          "max_gram": 20
-        }
-      },
-      "analyzer": {
-        "autocomplete": {
-          "type": "custom",
-          "tokenizer": "standard",
-          "filter": [
-            "lowercase",
-            "autocomplete_filter"
-          ]
-        }
-      }
-    }
+    "max_result_window": 20000
   },
   "mappings": {
     "document-v1.0.0": {
@@ -33,15 +14,58 @@
       "date_detection": false,
       "numeric_detection": false,
       "properties": {
+        "fulltext": {
+          "type": "text"
+        },
         "$schema": {
-          "type": "text",
-          "index": false
+          "type": "keyword"
+        },
+        "_bucket": {
+          "type": "keyword"
+        },
+        "_files": {
+          "type": "object",
+          "properties": {
+            "bucket": {
+              "type": "keyword"
+            },
+            "file_id": {
+              "type": "keyword"
+            },
+            "version_id": {
+              "type": "keyword"
+            },
+            "key": {
+              "type": "keyword"
+            },
+            "checksum": {
+              "type": "keyword"
+            },
+            "size": {
+              "type": "integer"
+            },
+            "label": {
+              "type": "text"
+            },
+            "type": {
+              "type": "keyword"
+            },
+            "order": {
+              "type": "short"
+            },
+            "external_url": {
+              "type": "keyword"
+            },
+            "restricted": {
+              "type": "keyword"
+            },
+            "embargo_date": {
+              "type": "date"
+            }
+          }
         },
         "pid": {
           "type": "keyword"
-        },
-        "fulltext": {
-          "type": "text"
         },
         "organisation": {
           "type": "object",
@@ -53,12 +77,42 @@
               "type": "keyword"
             },
             "name": {
-              "type": "keyword"
+              "type": "text"
             }
           }
         },
         "documentType": {
           "type": "keyword"
+        },
+        "title": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "keyword"
+            },
+            "mainTitle": {
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "text"
+                },
+                "language": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "subTitle": {
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "text"
+                },
+                "language": {
+                  "type": "keyword"
+                }
+              }
+            }
+          }
         },
         "language": {
           "type": "object",
@@ -119,75 +173,45 @@
               "format": "yyyy-MM-dd||yyyy"
             },
             "endDate": {
-              "type": "date"
+              "type": "date",
+              "format": "yyyy-MM-dd||yyyy"
             }
           }
         },
         "extent": {
-          "type": "text",
-          "analyzer": "global_lowercase_asciifolding"
+          "type": "text"
         },
         "otherMaterialCharacteristics": {
-          "type": "keyword"
+          "type": "text"
         },
         "formats": {
-          "type": "keyword"
+          "type": "text"
         },
         "additionalMaterials": {
-          "type": "keyword"
+          "type": "text"
         },
         "series": {
           "type": "object",
           "properties": {
             "name": {
-              "type": "text",
-              "analyzer": "global_lowercase_asciifolding",
-              "fields": {
-                "eng": {
-                  "type": "text",
-                  "analyzer": "english"
-                },
-                "fre": {
-                  "type": "text",
-                  "analyzer": "french"
-                },
-                "ger": {
-                  "type": "text",
-                  "analyzer": "german"
-                },
-                "ita": {
-                  "type": "text",
-                  "analyzer": "italian"
-                }
-              }
+              "type": "text"
             },
             "number": {
-              "type": "keyword"
-            },
-            "_text": {
               "type": "text"
             }
           }
         },
         "notes": {
-          "type": "text",
-          "analyzer": "global_lowercase_asciifolding",
-          "fields": {
-            "eng": {
-              "type": "text",
-              "analyzer": "english"
+          "type": "text"
+        },
+        "abstracts": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "text"
             },
-            "fre": {
-              "type": "text",
-              "analyzer": "french"
-            },
-            "ger": {
-              "type": "text",
-              "analyzer": "german"
-            },
-            "ita": {
-              "type": "text",
-              "analyzer": "italian"
+            "language": {
+              "type": "keyword"
             }
           }
         },
@@ -197,23 +221,23 @@
             "type": {
               "type": "keyword"
             },
-            "source": {
-              "type": "keyword"
-            },
             "value": {
-              "type": "keyword"
+              "type": "text"
             },
             "note": {
               "type": "text"
             },
             "qualifier": {
-              "type": "keyword"
+              "type": "text"
             },
             "acquisitionTerms": {
               "type": "text"
             },
-            "status": {
+            "source": {
               "type": "text"
+            },
+            "status": {
+              "type": "keyword"
             }
           }
         },
@@ -233,7 +257,7 @@
               }
             },
             "source": {
-              "type": "keyword"
+              "type": "text"
             }
           }
         },
@@ -242,12 +266,6 @@
         },
         "harvested": {
           "type": "boolean"
-        },
-        "_created": {
-          "type": "date"
-        },
-        "_updated": {
-          "type": "date"
         },
         "otherEdition": {
           "type": "object",
@@ -295,7 +313,8 @@
               "type": "text"
             },
             "date": {
-              "type": "text"
+              "type": "date",
+              "format": "yyyy-MM-dd||yyyy"
             }
           }
         },
@@ -315,7 +334,7 @@
                   "type": "text",
                   "fields": {
                     "raw": {
-                      "type":  "keyword"
+                      "type": "keyword"
                     }
                   }
                 },
@@ -326,7 +345,7 @@
                       "type": "keyword"
                     },
                     "source": {
-                      "type": "keyword"
+                      "type": "text"
                     },
                     "value": {
                       "type": "text"
@@ -346,12 +365,12 @@
                   "type": "keyword"
                 },
                 "number": {
-                  "type": "keyword"
+                  "type": "text"
                 }
               }
             },
             "role": {
-              "type": "text"
+              "type": "keyword"
             },
             "affiliation": {
               "type": "text"
@@ -360,7 +379,7 @@
               "type": "text",
               "fields": {
                 "raw": {
-                  "type":  "keyword"
+                  "type": "keyword"
                 }
               }
             }
@@ -391,7 +410,7 @@
                   "type": "object",
                   "properties": {
                     "startDate": {
-                      "type": "text"
+                      "type": "keyword"
                     },
                     "statement": {
                       "type": "text"
@@ -404,6 +423,12 @@
               }
             }
           }
+        },
+        "_created": {
+          "type": "date"
+        },
+        "_updated": {
+          "type": "date"
         }
       }
     }

--- a/sonar/modules/documents/marshmallow/json.py
+++ b/sonar/modules/documents/marshmallow/json.py
@@ -207,3 +207,4 @@ class DocumentSchemaV1(StrictKeysMixin):
 
     metadata = fields.Nested(DocumentMetadataSchemaV1)
     links = fields.Dict(dump_only=True)
+    explanation = fields.Raw(dump_only=True)

--- a/sonar/modules/organisations/mappings/v6/organisations/organisation-v1.0.0.json
+++ b/sonar/modules/organisations/mappings/v6/organisations/organisation-v1.0.0.json
@@ -5,8 +5,7 @@
       "numeric_detection": false,
       "properties": {
         "$schema": {
-          "type": "text",
-          "index": false
+          "type": "keyword"
         },
         "pid": {
           "type": "keyword"

--- a/sonar/modules/organisations/marshmallow/json.py
+++ b/sonar/modules/organisations/marshmallow/json.py
@@ -75,3 +75,4 @@ class OrganisationSchemaV1(StrictKeysMixin):
     updated = fields.Str(dump_only=True)
     links = fields.Dict(dump_only=True)
     id = PersistentIdentifier()
+    explanation = fields.Raw(dump_only=True)

--- a/sonar/modules/organisations/query.py
+++ b/sonar/modules/organisations/query.py
@@ -18,9 +18,9 @@
 """Query for organisations."""
 
 from flask import current_app
-from invenio_records_rest.query import es_search_factory
 
 from sonar.modules.organisations.api import current_organisation
+from sonar.modules.query import default_search_factory
 from sonar.modules.users.api import current_user_record
 
 
@@ -31,7 +31,7 @@ def search_factory(self, search, query_parser=None):
     :param query_parser: Url arguments.
     :returns: Tuple with search instance and URL arguments.
     """
-    search, urlkwargs = es_search_factory(self, search)
+    search, urlkwargs = default_search_factory(self, search)
 
     if current_app.config.get('SONAR_APP_DISABLE_PERMISSION_CHECKS'):
         return (search, urlkwargs)

--- a/sonar/modules/query.py
+++ b/sonar/modules/query.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Query factories for REST API."""
+
+from __future__ import absolute_import, print_function
+
+from elasticsearch_dsl.query import Q
+from flask import request
+
+
+def get_operator_and_query_type(qstr=None):
+    """Get a tuple with the operator and the query type.
+
+    :param qstr: Query string.
+    :returns: Tuple containing operator and query type.
+    """
+    if not qstr:
+        return None
+
+    # If qstr contains `:` keyword, operator is forced to `AND` and query type
+    # `query_string`.
+    if ':' in qstr:
+        return ('AND', 'query_string')
+
+    # Default to `AND`
+    operator = request.args.get('operator', 'AND')
+
+    if operator.upper() not in ['AND', 'OR']:
+        raise Exception('Only "AND" or "OR" operators allowed')
+
+    # With operator AND, with always use simple query string.
+    query_type = 'simple_query_string' \
+        if operator.upper() == 'AND' else 'query_string'
+
+    return (operator, query_type)
+
+
+def default_search_factory(self, search, query_parser=None):
+    """Parse query using elasticsearch DSL query.
+
+    :param search: Elastic search DSL search instance.
+    :param query_parser: Custom query parser.
+    :returns: Tuple with search instance and URL arguments.
+    """
+
+    def _default_parser(qstr=None):
+        """Default parser that uses the Q() from elasticsearch_dsl.
+
+        :param qstr: Query string.
+        :returns: Query object.
+        """
+        if not qstr:
+            return Q()
+
+        operator, query_type = get_operator_and_query_type(qstr)
+
+        return Q(query_type, query=qstr, default_operator=operator)
+
+    from invenio_records_rest.facets import default_facets_factory
+    from invenio_records_rest.sorter import default_sorter_factory
+
+    query_string = request.values.get('q')
+
+    # Use query parser given to function or the default one.
+    query_parser = query_parser or _default_parser
+
+    # Search query
+    search = search.query(query_parser(query_string))
+
+    # Get index corresponding to record type.
+    search_index = getattr(search, '_original_index', search._index)[0]
+
+    # Build facets
+    search, urlkwargs = default_facets_factory(search, search_index)
+
+    # Sort records
+    search, sortkwargs = default_sorter_factory(search, search_index)
+    for key, value in sortkwargs.items():
+        urlkwargs.add(key, value)
+
+    urlkwargs.add('q', query_string)
+
+    # Add explanation to hits
+    if request.args.get('debug'):
+        search = search.extra(explain=True)
+
+    return search, urlkwargs
+
+
+def and_term_filter(field):
+    """Create a term filter.
+
+    :param field: Field name.
+    :return: Function that returns a boolean AND query between term values.
+    """
+    def inner(values):
+        must = []
+        for value in values:
+            must.append(Q('term', **{field: value}))
+        return Q('bool', must=must)
+    return inner

--- a/sonar/modules/users/mappings/v6/users/user-v1.0.0.json
+++ b/sonar/modules/users/mappings/v6/users/user-v1.0.0.json
@@ -11,7 +11,7 @@
           "type": "keyword"
         },
         "full_name": {
-          "type": "keyword"
+          "type": "text"
         },
         "birth_date": {
           "type": "date"

--- a/sonar/modules/users/marshmallow/json.py
+++ b/sonar/modules/users/marshmallow/json.py
@@ -97,3 +97,4 @@ class UserSchemaV1(StrictKeysMixin):
     updated = fields.Str(dump_only=True)
     links = fields.Dict(dump_only=True)
     id = PersistentIdentifier()
+    explanation = fields.Raw(dump_only=True)

--- a/sonar/modules/users/query.py
+++ b/sonar/modules/users/query.py
@@ -18,9 +18,9 @@
 """Query for users."""
 
 from flask import current_app
-from invenio_records_rest.query import es_search_factory
 
 from sonar.modules.organisations.api import current_organisation
+from sonar.modules.query import default_search_factory
 from sonar.modules.users.api import current_user_record
 
 
@@ -31,7 +31,7 @@ def search_factory(self, search, query_parser=None):
     :param query_parser: Url arguments.
     :returns: Tuple with search instance and URL arguments.
     """
-    search, urlkwargs = es_search_factory(self, search)
+    search, urlkwargs = default_search_factory(self, search)
 
     if current_app.config.get('SONAR_APP_DISABLE_PERMISSION_CHECKS'):
         return (search, urlkwargs)

--- a/tests/api/test_api_query.py
+++ b/tests/api/test_api_query.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test elasticsearch query string."""
+
+import pytest
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+
+
+def test_api_query(client, document, document_json, make_document, superuser):
+    """Test simple flow using REST API."""
+    headers = [('Content-Type', 'application/json')]
+    login_user_via_session(client, email=superuser['email'])
+
+    # get records without query string
+    response = client.get(url_for('invenio_records_rest.doc_list'),
+                          headers=headers)
+    assert response.status_code == 200
+    assert response.json['hits']['total'] == 1
+
+    # with explanation
+    response = client.get(url_for('invenio_records_rest.doc_list', debug=1),
+                          headers=headers)
+    assert response.status_code == 200
+    assert response.json['hits']['total'] == 1
+    assert 'explanation' in response.json['hits']['hits'][0]
+
+    # query string = 'title'
+    response = client.get(url_for('invenio_records_rest.doc_list', q='title'),
+                          headers=headers)
+    assert response.status_code == 200
+    assert response.json['hits']['total'] == 1
+
+    # query string = 'titlé', record found with word "Title"
+    response = client.get(url_for('invenio_records_rest.doc_list', q='titlé'),
+                          headers=headers)
+    assert response.status_code == 200
+    assert response.json['hits']['total'] == 1
+
+    # query string = 'resume', record found with word "Résumé"
+    response = client.get(url_for('invenio_records_rest.doc_list', q='resume'),
+                          headers=headers)
+    assert response.status_code == 200
+    assert response.json['hits']['total'] == 1
+
+    # Multiple words in query string = 'resume title' and operator AND
+    response = client.get(url_for('invenio_records_rest.doc_list',
+                                  q='resume title',
+                                  operator='AND'),
+                          headers=headers)
+    assert response.status_code == 200
+    assert response.json['hits']['total'] == 1
+
+    # Multiple words in query string = 'resume title' and operator AND, but
+    # one word not found
+    response = client.get(url_for('invenio_records_rest.doc_list',
+                                  q='resume fake',
+                                  operator='AND'),
+                          headers=headers)
+    assert response.status_code == 200
+    assert response.json['hits']['total'] == 0
+
+    # Multiple words in query string = 'resume title' and operator OR
+    response = client.get(url_for('invenio_records_rest.doc_list',
+                                  q='resume title',
+                                  operator='OR'),
+                          headers=headers)
+    assert response.status_code == 200
+    assert response.json['hits']['total'] == 1
+
+    # Multiple words in query string = 'resume title' and operator OR and one
+    # word not found
+    response = client.get(url_for('invenio_records_rest.doc_list',
+                                  q='resume fake',
+                                  operator='OR'),
+                          headers=headers)
+    assert response.status_code == 200
+    assert response.json['hits']['total'] == 1
+
+    # Not allowed operator
+    with pytest.raises(Exception) as exception:
+        response = client.get(url_for('invenio_records_rest.doc_list',
+                                      q='title',
+                                      operator='not-allowed'),
+                              headers=headers)
+    assert str(exception.value) == 'Only "AND" or "OR" operators allowed'
+
+    # Error during parsing of query string
+    response = client.get(url_for('invenio_records_rest.doc_list',
+                                  q='i/o',
+                                  operator='OR'),
+                          headers=headers)
+    assert response.status_code == 400
+    assert ('The syntax of the search query is invalid.' in response.get_data(
+        as_text=True))
+
+    # Test facets with AND operator.
+    # Create a new document with only one subject
+    document_json['subjects'] = [{
+        'label': {
+            'language': 'eng',
+            'value': ['GARCH models']
+        },
+        'source': 'RERO'
+    }]
+    make_document('org')
+    response = client.get(url_for(
+        'invenio_records_rest.doc_list',
+        subject=['Time series models', 'GARCH models']),
+                          headers=headers)
+    assert response.status_code == 200
+    assert response.json['hits']['total'] == 1

--- a/tests/api/users/test_users_permissions.py
+++ b/tests/api/users/test_users_permissions.py
@@ -39,7 +39,7 @@ def test_list(app, client, make_user, superuser, admin, moderator, submitter,
     assert res.json['hits']['total'] == 6
     app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=False)
 
-    # Logged as user
+    # # Logged as user
     login_user_via_session(client, email=user['email'])
     res = client.get(url_for('invenio_records_rest.user_list'))
     assert res.status_code == 200
@@ -48,14 +48,14 @@ def test_list(app, client, make_user, superuser, admin, moderator, submitter,
     # Test search email, no result
     res = client.get(
         url_for('invenio_records_rest.user_list',
-                q='email:"test@gmail.com"%20NOT%20pid:3'))
+                q='email:test@gmail.com NOT pid:orguser'))
     assert res.status_code == 200
     assert res.json['hits']['total'] == 0
 
     # Test search email, existing email
     res = client.get(
         url_for('invenio_records_rest.user_list',
-                q='email:"orgadmin@rero.ch"%20NOT%20pid:3'))
+                q='email:orgadmin@rero.ch NOT pid:orguser'))
     assert res.status_code == 200
     assert res.json['hits']['total'] == 1
     assert not res.json['hits']['hits'][0]['metadata'].get('email')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -278,6 +278,9 @@ def document_json(app, db, bucket_location, organisation):
         'abstracts': [{
             'language': 'eng',
             'value': 'Abstract of the document'
+        }, {
+            'language': 'fre',
+            'value': 'Résumé'
         }],
         'subjects': [{
             'label': {

--- a/tests/ui/test_query.py
+++ b/tests/ui/test_query.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test elasticsearch query."""
+
+import pytest
+
+from sonar.modules.query import get_operator_and_query_type
+
+
+def test_get_operator_and_query_type(app):
+    """Test getting the operator and query_type for elasticsarch query."""
+    # No query string
+    assert not get_operator_and_query_type('')
+
+    # Query string with `:`
+    assert get_operator_and_query_type('pid:1') == ('AND', 'query_string')
+
+    with app.test_request_context() as req:
+        # Not allowed operator
+        req.request.args = {'operator': 'not-allowed'}
+        with pytest.raises(Exception) as exception:
+            get_operator_and_query_type('test')
+        assert str(exception.value) == 'Only "AND" or "OR" operators allowed'
+
+        # With OR
+        req.request.args = {'operator': 'OR'}
+        assert get_operator_and_query_type('test') == ('OR', 'query_string')
+
+        # With AND
+        req.request.args = {'operator': 'AND'}
+        assert get_operator_and_query_type('test') == ('AND',
+                                                       'simple_query_string')


### PR DESCRIPTION
For a better user experience, a serie of enhancements have been applied in this PR.

* Creates a custom docker image for elasticsearch with the ICU filter plugin.
* Improves mappings for all records types.
* Changes the way to sort records to put the best scores first.
* Changes the way to sort records to put the most recents first, when no query is specified.
* Sets a default analyzer in elasticsearch template.
* Adds a default search factory applied to all records types.
* Adds property to explain how elasticsearch set the score for a hit, if `debug` parameter is set.
* Creates a custom query parser for documents, to avoid to search in full-text by default.
* Closes #139.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>