### PR TITLE
users: list users with no organisation

### DIFF
--- a/sonar/modules/users/permissions.py
+++ b/sonar/modules/users/permissions.py
@@ -82,6 +82,9 @@ class UserPermission(RecordPermission):
         user = UserRecord.get_record_by_pid(record['pid'])
         user = user.replace_refs()
 
+        if not user.get('organisation'):
+            return True
+
         return current_organisation['pid'] == user['organisation']['pid']
 
     @classmethod
@@ -113,6 +116,9 @@ class UserPermission(RecordPermission):
 
         # Cannot delete himself
         if current_user_record['pid'] == record['pid']:
+            return False
+
+        if not record.get('organisation'):
             return False
 
         # For admin read is only for logged user organisation

--- a/tests/api/users/test_users_permissions.py
+++ b/tests/api/users/test_users_permissions.py
@@ -93,11 +93,7 @@ def test_create(client, organisation, superuser, admin, moderator, submitter,
         'Accept': 'application/json'
     }
 
-    user_json = {
-        'email': 'user@rero.ch',
-        'full_name': 'User',
-        'role': 'user'
-    }
+    user_json = {'email': 'user@rero.ch', 'full_name': 'User', 'role': 'user'}
 
     # Not logged
     res = client.post(url_for('invenio_records_rest.user_list'),
@@ -238,6 +234,18 @@ def test_read(client, make_user, superuser, admin, moderator, submitter, user):
     assert res.status_code == 200
     assert res.json['metadata']['permissions'] == {
         'delete': True,
+        'read': True,
+        'update': True
+    }
+
+    # Test user without associated organisation
+    new_user = make_user('user', None)
+    login_user_via_session(client, email=admin['email'])
+    res = client.get(
+        url_for('invenio_records_rest.user_item', pid_value=new_user['pid']))
+    assert res.status_code == 200
+    assert res.json['metadata']['permissions'] == {
+        'delete': False,
         'read': True,
         'update': True
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,10 +140,10 @@ def make_user(app, db, make_organisation):
     """Factory for creating user."""
 
     def _make_user(role_name, organisation='org'):
-        make_organisation(organisation)
-
         name = role_name
+
         if organisation:
+            make_organisation(organisation)
             name = organisation + name
 
         email = '{name}@rero.ch'.format(name=name)
@@ -174,19 +174,21 @@ def make_user(app, db, make_organisation):
                               user=user))
         db.session.commit()
 
-        record = UserRecord.create(
-            {
-                'pid': name,
-                'email': email,
-                'full_name': name,
-                'role': role_name,
-                'organisation': {
-                    '$ref':
-                    'https://sonar.ch/api/organisations/{organisation}'.format(
-                        organisation=organisation)
-                }
-            },
-            dbcommit=True)
+        data = {
+            'pid': name,
+            'email': email,
+            'full_name': name,
+            'role': role_name
+        }
+
+        if organisation:
+            data['organisation'] = {
+                '$ref':
+                'https://sonar.ch/api/organisations/{organisation}'.format(
+                    organisation=organisation)
+            }
+
+        record = UserRecord.create(data, dbcommit=True)
         record.reindex()
         db.session.commit()
 


### PR DESCRIPTION
The admin users must be able to list users not associated to an organisation.

* Modifies the query for retrieving users to include users without organisation.
* Tests the existence of the organisation in user records to avoid an error if it not exists.
* Closes #273.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>