### PR TITLE
account: customize welcome e-mail

### DIFF
--- a/sonar/config.py
+++ b/sonar/config.py
@@ -116,7 +116,8 @@ COLLECT_STORAGE = 'flask_collect.storage.file'
 #: Email address used as sender of account registration emails.
 SECURITY_EMAIL_SENDER = SUPPORT_EMAIL
 #: Email subject for account registration emails.
-SECURITY_EMAIL_SUBJECT_REGISTER = _("Welcome to Swiss Open Access Repository!")
+SECURITY_EMAIL_SUBJECT_REGISTER = _(
+    'Welcome to SONAR, the Swiss Open Access Repository!')
 #: Redis session storage URL.
 ACCOUNTS_SESSION_REDIS_URL = 'redis://localhost:6379/1'
 #: Enable session/user id request tracing. This feature will add X-Session-ID
@@ -453,8 +454,7 @@ RECORDS_REST_FACETS = {
         document_type=dict(terms=dict(field='documentType')),
         controlled_affiliation=dict(terms=dict(
             field='contribution.controlledAffiliation.raw')),
-        author=dict(terms=dict(
-            field='contribution.agent.preferred_name.raw')),
+        author=dict(terms=dict(field='contribution.agent.preferred_name.raw')),
         year=dict(date_histogram=dict(
             field='provisionActivity.startDate',
             interval='year',

--- a/sonar/templates/security/email/welcome.html
+++ b/sonar/templates/security/email/welcome.html
@@ -1,0 +1,14 @@
+<p>{{ _('Dear %(email)s', email=user.email) }},</p>
+
+{% if security.confirmable %}
+<p>
+  {{ _('Please confirm your e-mail by clicking here') }}: <a href="{{ confirmation_link }}">{{ _('Confirm e-mail') }}</a>
+</p>
+{% endif %}
+<p>{{ _('To be able to deposit publications, you must be registered against a SONAR institution. For now, your account does not provide additional features, but in the future you will be able to create document lists and save requests.') }}</p>
+<p>{{ _('Best regards') }}</p>
+<p>{{ _('The SONAR team at RERO') }}</p>
+
+{{ _('E-mail') }}: <a href="mailto:info.sonar@rero.ch">info.sonar@rero.ch</a><br>
+<a href="https://www.sonar.ch/" target="_blank">https://www.sonar.ch/</a><br>
+<a href="https://www.rero.ch" target="_blank">https://www.rero.ch</a>


### PR DESCRIPTION
* Customizes welcome e-mail by overriding default template from `flask-security`.
* Closes #272.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>