### PR TITLE
documents: search in full-text

### DIFF
--- a/tests/api/test_api_query.py
+++ b/tests/api/test_api_query.py
@@ -22,7 +22,8 @@ from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 
 
-def test_api_query(client, document, document_json, make_document, superuser):
+def test_api_query(client, document_with_file, document_json, make_document,
+                   superuser):
     """Test simple flow using REST API."""
     headers = [('Content-Type', 'application/json')]
     login_user_via_session(client, email=superuser['email'])
@@ -91,6 +92,15 @@ def test_api_query(client, document, document_json, make_document, superuser):
                           headers=headers)
     assert response.status_code == 200
     assert response.json['hits']['total'] == 1
+
+    # Test search in fulltext
+    response = client.get(url_for('invenio_records_rest.doc_list',
+                                  q='fulltext:the',
+                                  debug=1),
+                          headers=headers)
+    assert response.status_code == 200
+    assert response.json['hits']['total'] == 1
+    assert len(response.json['hits']['hits'][0]['explanation']['details']) == 3
 
     # Not allowed operator
     with pytest.raises(Exception) as exception:


### PR DESCRIPTION
The search in full-text is not exclusive, it means that the search must be done in all fields and the `fulltext` field, not only in the latter.

* Updates the query to search in all fields when a full-text search is triggered.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>