### PR TITLE
imports: change PMID identifier

### DIFF
--- a/sonar/modules/documents/dojson/rerodoc/model.py
+++ b/sonar/modules/documents/dojson/rerodoc/model.py
@@ -463,7 +463,11 @@ def marc21_to_identified_by_from_091(self, key, value):
     if not value.get('a') or value.get('b') != 'pmid':
         return None
 
-    identified_by.append({'type': 'pmid', 'value': value.get('a')})
+    identified_by.append({
+        'type': 'bf:Local',
+        'value': value.get('a'),
+        'source': 'PMID'
+    })
 
     return identified_by
 

--- a/tests/ui/documents/dojson/rerodoc/test_rerodoc_model.py
+++ b/tests/ui/documents/dojson/rerodoc/test_rerodoc_model.py
@@ -1257,7 +1257,11 @@ def test_marc21_to_identified_by_from_091():
     """
     marc21json = create_record(marc21xml)
     data = marc21tojson.do(marc21json)
-    assert data.get('identifiedBy') == [{'type': 'pmid', 'value': '24638240'}]
+    assert data.get('identifiedBy') == [{
+        'type': 'bf:Local',
+        'value': '24638240',
+        'source': 'PMID'
+    }]
 
     # Without code $a
     marc21xml = """
@@ -1359,8 +1363,9 @@ def test_marc21_to_identified_by_full():
         'type': 'bf:ReportNumber',
         'value': '25'
     }, {
-        'type': 'pmid',
-        'value': '24638240'
+        'type': 'bf:Local',
+        'value': '24638240',
+        'source': 'PMID'
     }]
 
 


### PR DESCRIPTION
If an identifier is set in field `091` (dedicated to PMID), this value is imported as a `bf:Local` identifier with a `PMID` source.

* Updates import to convert PMID identifier to local identifer with a `PMID` source.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>