### PR TITLE
records: refactor file handling

### DIFF
--- a/sonar/modules/documents/api.py
+++ b/sonar/modules/documents/api.py
@@ -19,8 +19,13 @@
 
 import csv
 from functools import partial
+from io import BytesIO
 
 from flask import current_app
+
+from sonar.modules.pdf_extractor.utils import extract_text_from_content
+from sonar.modules.utils import change_filename_extension, \
+    create_thumbnail_from_file
 
 from ..api import SonarIndexer, SonarRecord, SonarSearch
 from ..fetchers import id_fetcher
@@ -137,6 +142,141 @@ class DocumentRecord(SonarRecord):
                     return cls.get_record_by_pid(results[0]['pid'])
 
         return None
+
+    def add_file(self, data, key, **kwargs):
+        """Create file and add it to record.
+
+        kwargs may contain some additional data such as: file label, file type,
+        order and url.
+
+        :param data: Binary data of file
+        :param str key: File key
+        :returns: File object created.
+        """
+        if not kwargs.get('type'):
+            kwargs['type'] = 'file'
+
+        if not kwargs.get('order'):
+            kwargs['order'] = self.get_next_file_order()
+
+        if not kwargs.get('label'):
+            kwargs['label'] = key
+
+        added_file = super(DocumentRecord, self).add_file(data, key, **kwargs)
+
+        if not added_file:
+            return None
+
+        self.create_fulltext_file(self.files[key])
+        self.create_thumbnail(self.files[key])
+
+        return self.files[key]
+
+    def sync_files(self, file, deleted=False):
+        """Sync files between bucket and records.
+
+        This operation is necessary to make files available in record detail
+        and be indexed.
+
+        :param file: File object.
+        :param deleted: Wether the given file has been deleted or not.
+        """
+        # For documents, a thumbnail and a fulltext file is generated.
+        if not deleted:
+            self.create_fulltext_file(self.files[file.key])
+            self.create_thumbnail(self.files[file.key])
+
+        if not self.files[file.key].get('type'):
+            self.files[file.key]['type'] = 'file'
+
+        if not self.files[file.key].get('label'):
+            self.files[file.key]['label'] = file.key
+
+        if not self.files[file.key].get('order'):
+            self.files[file.key]['order'] = self.get_next_file_order()
+
+        super(DocumentRecord, self).sync_files(file, deleted)
+
+    def create_fulltext_file(self, file):
+        """Create fulltext file corresponding to give file object.
+
+        :param file: File object.
+        """
+        # If extract fulltext is disabled or file is not a PDF
+        if not current_app.config.get(
+                'SONAR_DOCUMENTS_EXTRACT_FULLTEXT_ON_IMPORT'
+        ) or file.mimetype != 'application/pdf':
+            return
+
+        # Try to extract full text from file data, and generate a warning if
+        # it's not possible. For several cases, file is locked against fulltext
+        # copy.
+        try:
+            with file.file.storage().open() as pdf_file:
+                fulltext = extract_text_from_content(pdf_file.read())
+
+            key = change_filename_extension(file.key, 'txt')
+            self.files[key] = BytesIO(fulltext.encode())
+            self.files[key]['type'] = 'fulltext'
+        except Exception as exception:
+            current_app.logger.warning(
+                'Error during fulltext extraction of {file} of record '
+                '{record}: {error}'.format(file=file.key,
+                                           error=exception,
+                                           record=self['identifiedBy']))
+
+    def create_thumbnail(self, file):
+        """Create a thumbnail for record.
+
+        This is done by getting the file with order 1 or the first file
+        instead.
+
+        :param file: File from which thumbnail is created.
+        """
+        try:
+            # Create thumbnail
+            image_blob = create_thumbnail_from_file(file.file.uri,
+                                                    file.mimetype)
+
+            thumbnail_key = change_filename_extension(file['key'], 'jpg')
+
+            # Store thumbnail in record's files
+            self.files[thumbnail_key] = BytesIO(image_blob)
+            self.files[thumbnail_key]['type'] = 'thumbnail'
+        except Exception as exception:
+            current_app.logger.warning(
+                'Error during thumbnail generation of {file} of record '
+                '{record}: {error}'.format(file=file['key'],
+                                           error=exception,
+                                           record=self.get(
+                                               'identifiedBy', self['pid'])))
+
+    def get_main_file(self):
+        """Get the main file of record."""
+        files = [file for file in self.files if file.get('type') == 'file']
+
+        if not files:
+            return None
+
+        for file in files:
+            if file.get('order') == 1:
+                return file
+
+        return files[0]
+
+    def get_next_file_order(self):
+        """Get position for the next file.
+
+        :returns: Integer representing the new position.
+        """
+        files = [file for file in self.files if file.get('type') == 'file']
+
+        if not files:
+            return 1
+
+        positions = [file.get('order', 1) for file in files]
+
+        return max(positions) + 1
 
 
 class DocumentIndexer(SonarIndexer):

--- a/sonar/modules/documents/dojson/rerodoc/model.py
+++ b/sonar/modules/documents/dojson/rerodoc/model.py
@@ -516,7 +516,6 @@ def marc21_to_files(self, key, value):
     """Get files."""
     key = value.get('f')
     url = value.get('u')
-    size = int(value.get('s', 0))
     mime_type = value.get('q', 'text/plain')
 
     if not key or not url:
@@ -546,8 +545,7 @@ def marc21_to_files(self, key, value):
         'url': url,
         'label': value.get('z', key),
         'type': 'file',
-        'order': order,
-        'size': size
+        'order': order
     }
 
     return data

--- a/sonar/modules/ext.py
+++ b/sonar/modules/ext.py
@@ -28,7 +28,8 @@ from invenio_files_rest.signals import file_deleted, file_uploaded
 
 from sonar.modules.permissions import has_admin_access, has_submitter_access, \
     has_superuser_access
-from sonar.modules.receivers import file_listener
+from sonar.modules.receivers import file_deleted_listener, \
+    file_uploaded_listener
 from sonar.modules.users.api import current_user_record
 from sonar.modules.users.signals import user_registered_handler
 from sonar.modules.utils import get_switch_aai_providers, get_view_code
@@ -89,8 +90,8 @@ class Sonar(object):
         user_registered.connect(user_registered_handler, weak=False)
 
         # Connect to signal sent when a file is uploaded or deleted
-        file_uploaded.connect(file_listener, weak=False)
-        file_deleted.connect(file_listener, weak=False)
+        file_uploaded.connect(file_uploaded_listener, weak=False)
+        file_deleted.connect(file_deleted_listener, weak=False)
 
     def init_config(self, app):
         """Initialize configuration."""

--- a/sonar/modules/receivers.py
+++ b/sonar/modules/receivers.py
@@ -20,12 +20,37 @@
 from sonar.modules.api import SonarRecord
 
 
-def file_listener(obj):
-    """Function executed when a file is uploaded or deleted.
+def file_uploaded_listener(obj):
+    """Function executed when a file is uploaded.
 
     :param obj: Object version.
     """
     try:
-        SonarRecord.update_files(obj.bucket_id)
+        sync_record_files(obj, False)
     except Exception:
         pass
+
+
+def file_deleted_listener(obj):
+    """Function executed when a file is deleted.
+
+    :param obj: Object version.
+    """
+    try:
+        sync_record_files(obj, True)
+    except Exception:
+        pass
+
+
+def sync_record_files(file, deleted=False):
+    """Sync files in record corresponding to bucket.
+
+    :param file: File object
+    :param delete: Wether file is deleted or not.
+    """
+    record = SonarRecord.get_record_by_bucket(file.bucket_id)
+
+    if not record:
+        return
+
+    record.sync_files(file, deleted)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -386,7 +386,7 @@ def make_document(db, document_json, make_organisation, pdf_file):
                 record.add_file(file.read(),
                                 'test1.pdf',
                                 order=1,
-                                restricted='insitution',
+                                restricted='institution',
                                 embargo_date='2021-01-01')
                 record.commit()
 

--- a/tests/ui/documents/test_documents_api.py
+++ b/tests/ui/documents/test_documents_api.py
@@ -59,3 +59,21 @@ def test_load_affiliations():
     """Test load affiliations from file."""
     DocumentRecord.load_affiliations()
     assert len(DocumentRecord.affiliations) == 77
+
+
+def test_get_next_file_order(document_with_file, document):
+    """Test getting next file position."""
+    # One file with order 1
+    assert document_with_file.get_next_file_order() == 2
+
+    # Adding a new file
+    document_with_file.add_file(b'File content', 'file2.pdf')
+    assert document_with_file.get_next_file_order() == 3
+
+    # No order properties
+    for file in document_with_file.files:
+        document_with_file.files[file.key].data.pop('order', None)
+    assert document_with_file.get_next_file_order() == 2
+
+    # No files
+    assert document.get_next_file_order() == 1


### PR DESCRIPTION
This commit aims to refactor the way files are handled when added to a record, to be more generalistic and have specific treatment for documents without affecting others records types.

* Moves specific methods `create_thumbnail` and `create_fulltext_file` in `DocumentRecord`
* Tests file existence to determine if file have to be processed.
* Handles files metadata in a more generalistic way.
* Connects to `file_uploaded` and `file_deleted` signals with to different functions, to know if the file is deleted when processing.
* Removes `size` property when harvesting from RERODOC, as this property is calculated when the file is created.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>