### PR TITLE
documents: configure `_files` in JSON schema

### DIFF
--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -22,8 +22,6 @@
       "description": "List of files attached to the record.",
       "type": "array",
       "items": {
-        "title": "File item",
-        "description": "Describes the information of a single file in the record.",
         "type": "object",
         "additionalProperties": false,
         "properties": {
@@ -64,7 +62,6 @@
           },
           "label": {
             "title": "Label",
-            "description": "Label of the file",
             "type": "string",
             "minLength": 1
           },
@@ -81,28 +78,30 @@
           },
           "order": {
             "title": "Position",
-            "description": "Position of the file",
+            "description": "Position of the file, The lowest position means file is the main file.",
             "type": "integer",
             "default": 1,
             "minimum": 1
           },
           "external_url": {
             "title": "URL to file",
-            "description": "URL to file hosted in an external platform.",
             "type": "string",
             "minLength": 1,
-            "pattern": "^https?://"
+            "pattern": "^https?://.*"
           },
           "restricted": {
             "title": "Restricted",
+            "description": "Type of restriction. 'organisation': the file is only available inside organisation view. 'internal': file is only available with a referenced IP.",
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "pattern": "^(organisation|internal)$"
           },
           "embargo_date": {
             "title": "Embargo date",
+            "description": "Example: 2019-05-05",
             "type": "string",
             "minLength": 1,
-            "format": "date"
+            "pattern": "^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$"
           }
         },
         "required": [
@@ -110,7 +109,8 @@
           "file_id",
           "version_id",
           "key"
-        ]
+        ],
+        "propertiesOrder": ["label", "order", "external_url", "restricted", "embargo_date"]
       }
     },
     "pid": {

--- a/sonar/modules/documents/mappings/v6/documents/document-v1.0.0.json
+++ b/sonar/modules/documents/mappings/v6/documents/document-v1.0.0.json
@@ -60,7 +60,8 @@
               "type": "keyword"
             },
             "embargo_date": {
-              "type": "date"
+              "type": "date",
+              "format": "yyyy-MM-dd"
             }
           }
         },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -386,7 +386,7 @@ def make_document(db, document_json, make_organisation, pdf_file):
                 record.add_file(file.read(),
                                 'test1.pdf',
                                 order=1,
-                                restricted='institution',
+                                restricted='organisation',
                                 embargo_date='2021-01-01')
                 record.commit()
 


### PR DESCRIPTION
* Configures `_files` property in JSON schema for editing files metadata.
* Adds a date format for `embargo_date` in elasticsearch mapping.
* Closes #280.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>