### PR TITLE
documents: order files

### DIFF
--- a/sonar/modules/documents/api.py
+++ b/sonar/modules/documents/api.py
@@ -278,6 +278,20 @@ class DocumentRecord(SonarRecord):
 
         return max(positions) + 1
 
+    def get_files_list(self):
+        """Return the list of files.
+
+        The files are ordered by `order` property and filtered by `type` with
+        value `file`.
+
+        :returns: Formatted list of files.
+        """
+        files = [
+            file for file in self.get('_files', [])
+            if file.get('type') == 'file'
+        ]
+        return sorted(files, key=lambda file: file.get('order', 100))
+
 
 class DocumentIndexer(SonarIndexer):
     """Indexing documents in Elasticsearch."""

--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -22,7 +22,7 @@
 {%- block body %}
 {% set record = record.replace_refs() %}
 {% set title = record.title[0] | title_format(current_i18n.language) %}
-{% set files = record._files | files_by_type %}
+{% set files = record.get_files_list() %}
 
 <section class="mt-3">
   <div class="row">

--- a/sonar/modules/documents/views.py
+++ b/sonar/modules/documents/views.py
@@ -139,17 +139,6 @@ def create_publication_statement(provision_activity):
 
 
 @blueprint.app_template_filter()
-def files_by_type(files, file_type='file'):
-    """Return only files corresponding to type.
-
-    :param files: List of files associated with record
-    :param file_type: Type of the files to return.
-    :return Filtered list
-    """
-    return [file for file in files if file.get('type') == file_type]
-
-
-@blueprint.app_template_filter()
 def file_size(size):
     """Return file size human readable.
 

--- a/tests/ui/documents/test_documents_api.py
+++ b/tests/ui/documents/test_documents_api.py
@@ -77,3 +77,14 @@ def test_get_next_file_order(document_with_file, document):
 
     # No files
     assert document.get_next_file_order() == 1
+
+
+def test_get_files_list(document, pdf_file):
+    """Test getting the list of files, filtered and orderd."""
+    document.add_file(b'file 1', 'test1.pdf', order=2)
+    document.add_file(b'file 2', 'test2.pdf', order=1)
+    document.add_file(b'file 3', 'test3.pdf', order=3)
+    document.add_file(b'file 4', 'test4.pdf', order=4, type="not-file")
+    files = document.get_files_list()
+    assert len(files) == 3
+    assert files[0]['order'] == 1

--- a/tests/ui/documents/test_documents_views.py
+++ b/tests/ui/documents/test_documents_views.py
@@ -166,37 +166,6 @@ def test_file_size(app):
     assert views.file_size(2889638) == '2.76Mb'
 
 
-def test_files_by_type(app):
-    """Test filtering files with a specific type."""
-    files = [{
-        'bucket': '18126249-6eb7-4fa5-b0b5-f8599e3c2bf0',
-        'checksum': 'md5:e73223fe5c54532ebfd3e101cb6527ce',
-        'file_id': 'd953c07c-5e7f-4636-bc81-3627f947c494',
-        'key': '1_2004ECO001.pdf',
-        'label': 'Texte intégral',
-        'order': 1,
-        'size': 2889638,
-        'type': 'file',
-        'version_id': '1c9705d3-8a9c-489e-adaf-d7d741b205ba'
-    }, {
-        'bucket': '18126249-6eb7-4fa5-b0b5-f8599e3c2bf0',
-        'checksum': 'md5:519bd9463e54f681d73861e7e17e2050',
-        'file_id': '722264a3-b6d4-459c-a88d-2aca6fe34a0e',
-        'key': '1_2004ECO001.txt',
-        'size': 160659,
-        'type': 'fulltext',
-        'version_id': '1194512e-7c99-42e1-b320-a15ccb2ac946'
-    }]
-
-    filtered_files = views.files_by_type(files)
-    assert len(filtered_files) == 1
-    assert filtered_files[0][
-        'file_id'] == 'd953c07c-5e7f-4636-bc81-3627f947c494'
-
-    filtered_files = views.files_by_type(files, 'fake')
-    assert not filtered_files
-
-
 def test_file_title():
     """Test getting the caption of a file."""
     assert views.file_title({


### PR DESCRIPTION
This commit ensures that files are ordered correctly, for having the main file at first position. The sort is based on `order` property from files.

* Adds a method to order and filter files in DocumentRecord.
* Removes useless `files_by_type` filter.
* Sorts files before dumping them in REST API.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>