### PR TITLE
translations: add context when extracting messages

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ msgid_bugs_address = software@rero.ch
 mapping-file = babel.ini
 output-file = sonar/translations/messages.pot
 add-comments = NOTE
-no-location = True
 sort-output = True
 
 [init_catalog]


### PR DESCRIPTION
* Adds the line number and the file where translation is found when the messages are extracted.
* Closes #302.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>