### PR TITLE
users: facet for users without organisation

### DIFF
--- a/sonar/config.py
+++ b/sonar/config.py
@@ -40,7 +40,7 @@ from sonar.modules.organisations.api import OrganisationRecord, \
 from sonar.modules.organisations.permissions import OrganisationPermission
 from sonar.modules.permissions import record_permission_factory, \
     wiki_edit_permission
-from sonar.modules.query import and_term_filter
+from sonar.modules.query import and_term_filter, missing_field_filter
 from sonar.modules.users.api import UserRecord, UserSearch
 from sonar.modules.users.permissions import UserPermission
 from sonar.modules.utils import get_current_language
@@ -502,7 +502,25 @@ RECORDS_REST_FACETS = {
              _('status'): and_term_filter('status'),
              _('user'): and_term_filter('user.full_name.keyword'),
              _('contributor'): and_term_filter('facet_contributors'),
-         })
+         }),
+    'users': {
+        'aggs': {
+            'missing_organisation': {
+                'filter': {
+                    'bool': {
+                        'must_not': {
+                            'exists': {
+                                'field': 'organisation'
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        'filters': {
+            'missing_organisation': missing_field_filter('organisation')
+        }
+    }
 }
 """REST search facets."""
 

--- a/sonar/modules/query.py
+++ b/sonar/modules/query.py
@@ -114,3 +114,14 @@ def and_term_filter(field):
             must.append(Q('term', **{field: value}))
         return Q('bool', must=must)
     return inner
+
+
+def missing_field_filter(field):
+    """Filter to search data which does not contain the specified field.
+
+    :param field: Property that must not exist.
+    :returns: elasticsearch DSL query.
+    """
+    def inner(values):
+        return Q('bool', must_not=[Q('exists', field=field)])
+    return inner

--- a/tests/api/users/test_users_query.py
+++ b/tests/api/users/test_users_query.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test users queries."""
+
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+
+
+def test_queries(client, superuser, make_user):
+    """."""
+    login_user_via_session(client, email=superuser['email'])
+
+    headers = [('Content-Type', 'application/json')]
+
+    # No user found
+    response = client.get(url_for('invenio_records_rest.user_list',
+                                  missing_organisation='1'),
+                          headers=headers)
+    assert response.status_code == 200
+    assert response.json['hits']['total'] == 0
+
+    # 1 user found
+    make_user('user', None)
+    response = client.get(url_for('invenio_records_rest.user_list',
+                                  missing_organisation='1'),
+                          headers=headers)
+    assert response.status_code == 200
+    assert response.json['hits']['total'] == 1


### PR DESCRIPTION
This commit allows to show a checkbox in SONAR UI that filters users no attached to an organisation. The implementation in user interface has been done in rero/sonar-ui#142.

* Configures aggregation and filter for filtering users not attached to any organisation.
* Adds a new filter for querying records not having a specific field.
* Closes #305.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>