### PR TITLE
users: avoid create user resource

### DIFF
--- a/sonar/modules/users/signals.py
+++ b/sonar/modules/users/signals.py
@@ -30,15 +30,3 @@ def user_registered_handler(app, user, confirm_token):
     role = datastore.find_role(UserRecord.ROLE_USER)
     datastore.add_role_to_user(user, role)
     datastore.commit()
-
-    # Create user record
-    user_record = UserRecord.get_user_by_email(user.email)
-    if not user_record:
-        user_record = UserRecord.create(
-            {
-                'full_name': user.email,
-                'email': user.email,
-                'role': UserRecord.ROLE_USER
-            },
-            dbcommit=True)
-        user_record.reindex()

--- a/sonar/theme/templates/sonar/page_settings.html
+++ b/sonar/theme/templates/sonar/page_settings.html
@@ -23,7 +23,8 @@
     <div class="col-sm-3 col-md-3 col-pad-left-0">
       {%- block settings_menu scoped %}
       <ul class="list-group">
-        {%- for item in current_menu.submenu('settings').children if item.visible %}
+        {% set hideProfileKey = 'record_profile' if not current_user_record else 'profile' %}
+        {%- for item in current_menu.submenu('settings').children if item.visible and item.name != hideProfileKey %}
         {%- block settings_menu_item scoped %}
         <a href="{{ item.url }}" class="list-group-item{% if item.active %} active{% endif %}">
           {{ item.text|safe }}

--- a/sonar/theme/templates/sonar/partial/dropdown_user.html
+++ b/sonar/theme/templates/sonar/partial/dropdown_user.html
@@ -15,21 +15,19 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #}
 
-<div class="dropdown-menu dropdown-menu-right" aria-labelledby="{{dropdownId}}">
-    <h6 class="dropdown-header">{{current_user_record.email}}</h6>
-    <a class="dropdown-item" href="{{ url_for('sonar.profile')}}">
-        {{_('Profile')}}
-    </a>
-    {% if has_superuser_access() %}
-    <a class="dropdown-item" href="{{ url_for('admin.index')}}">
-        {{_('Super administration')}}
-    </a>
-    {% endif %}
-    {% if has_admin_access() %}
-    <a class="dropdown-item" href="{{ url_for('sonar.manage')}}">
-        {{_('Administration')}}
-    </a>
-    {% endif %}
-
-    <a class="dropdown-item" href="{{url_for_security('logout')}}">{{_('Logout')}}</a>
+<div class="dropdown-menu dropdown-menu-right" aria-labelledby="{{ dropdownId }}">
+  {% if current_user_record -%}
+  <h6 class="dropdown-header">{{ current_user_record.email }}</h6>
+  <a class="dropdown-item" href="{{ url_for('sonar.profile', pid=current_user_record.pid) }}">{{ _('Profile') }}</a>
+  {%- else -%}
+  <h6 class="dropdown-header">{{ current_user.email }}</h6>
+  <a class="dropdown-item" href="{{ url_for('invenio_userprofiles.profile') }}">{{ _('Profile') }}</a>
+  {% endif -%}
+  {% if has_superuser_access() %}
+  <a class="dropdown-item" href="{{ url_for('admin.index') }}">{{ _('Super administration') }}</a>
+  {%- endif -%}
+  {% if has_admin_access() %}
+  <a class="dropdown-item" href="{{ url_for('sonar.manage')}}">{{ _('Administration') }}</a>
+  {%- endif %}
+  <a class="dropdown-item" href="{{ url_for_security('logout') }}">{{ _('Logout') }}</a>
 </div>

--- a/sonar/theme/templates/sonar/partial/navbar.html
+++ b/sonar/theme/templates/sonar/partial/navbar.html
@@ -73,7 +73,7 @@
           <a class="nav-link dropdown-toggle" href="#" id="{{ dropdownId }}" role="button" data-toggle="dropdown"
             aria-haspopup="true" aria-expanded="false">
             <i class="fa fa-user mr-2"></i>
-            {{ current_user_record.full_name }}
+            {{ current_user_record.full_name if current_user_record else current_user.email }}
           </a>
           {% include 'sonar/partial/dropdown_user.html' %}
           {% endwith %}

--- a/sonar/theme/views.py
+++ b/sonar/theme/views.py
@@ -54,14 +54,15 @@ def init_view():
     """Do some stuff before rendering any view."""
     current_menu.submenu('settings').submenu('security').hide()
     current_menu.submenu('settings').submenu('applications').hide()
+    current_menu.submenu('settings').submenu('admin').hide()
 
 
 @blueprint.route('/users/profile')
 @blueprint.route('/users/profile/<pid>')
 @login_required
-@register_menu(blueprint, 'settings.profile',
+@register_menu(blueprint, 'settings.record_profile',
                _('%(icon)s Profile', icon='<i class="fa fa-user fa-fw"></i>'))
-@register_breadcrumb(blueprint, 'breadcrumbs.profile', _('Profile'))
+@register_breadcrumb(blueprint, 'breadcrumbs.record_profile', _('Profile'))
 def profile(pid=None):
     """Logged user profile edition page.
 

--- a/tests/ui/users/test_users_signals.py
+++ b/tests/ui/users/test_users_signals.py
@@ -28,5 +28,4 @@ def test_user_registered_handler(app, roles, user_without_role):
     assert user_without_role.roles[0].name == 'user'
 
     user = UserRecord.get_user_by_email(user_without_role.email)
-    assert user
-    assert user['role'] == 'user'
+    assert not user


### PR DESCRIPTION
This commit is a rollback of functionality done before, to avoid user resource to be created when a user registers in public interface.

* Avoids creating user resource when a user registers.
* Hides `Admin` entry from user's menu, as this entry is already available in user's dropdown.
* Shows invenio profiles entry in user's menu only if no user resource is associated to current user.
* Changes dropdown display depending if user resource exists or not.
* Closes #314.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>