### PR TITLE
deposits: add license

### DIFF
--- a/sonar/common/jsonschemas/license-v1.0.0.json
+++ b/sonar/common/jsonschemas/license-v1.0.0.json
@@ -1,0 +1,55 @@
+{
+  "title": "License",
+  "type": "string",
+  "enum": [
+    "CC0",
+    "CC BY",
+    "CC BY-NC",
+    "CC BY-NC-ND",
+    "CC BY-NC-SA",
+    "CC BY-ND",
+    "CC BY-SA",
+    "Other OA / license undefined",
+    "Not OA / Rights reserved"
+  ],
+  "form": {
+    "options": [
+      {
+        "label": "CC0",
+        "value": "CC0"
+      },
+      {
+        "label": "CC BY",
+        "value": "CC BY"
+      },
+      {
+        "label": "CC BY-NC",
+        "value": "CC BY-NC"
+      },
+      {
+        "label": "CC BY-NC-ND",
+        "value": "CC BY-NC-ND"
+      },
+      {
+        "label": "CC BY-NC-SA",
+        "value": "CC BY-NC-SA"
+      },
+      {
+        "label": "CC BY-ND",
+        "value": "CC BY-ND"
+      },
+      {
+        "label": "CC BY-SA",
+        "value": "CC BY-SA"
+      },
+      {
+        "label": "Other OA / license undefined",
+        "value": "Other OA / license undefined"
+      },
+      {
+        "label": "Not OA / Rights reserved",
+        "value": "Not OA / Rights reserved"
+      }
+    ]
+  }
+}

--- a/sonar/modules/deposits/api.py
+++ b/sonar/modules/deposits/api.py
@@ -285,6 +285,11 @@ class DepositRecord(SonarRecord):
         if contributors:
             metadata['contribution'] = contributors
 
+        # License
+        metadata['usageAndAccessPolicy'] = {
+            'license': self['diffusion']['license']
+        }
+
         document = DocumentRecord.create(metadata,
                                          dbcommit=True,
                                          with_bucket=True)

--- a/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
+++ b/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
@@ -842,7 +842,13 @@
     },
     "diffusion": {
       "type": "object",
-      "properties": {}
+      "additionalProperties": false,
+      "properties": {
+        "license": {
+          "$ref": "license-v1.0.0.json"
+        }
+      },
+      "required": ["license"]
     },
     "document": {
       "title": "Document",

--- a/sonar/modules/deposits/mappings/v6/deposits/deposit-v1.0.0.json
+++ b/sonar/modules/deposits/mappings/v6/deposits/deposit-v1.0.0.json
@@ -228,7 +228,12 @@
           "type": "keyword"
         },
         "diffusion": {
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "license": {
+              "type": "keyword"
+            }
+          }
         },
         "document": {
           "type": "object",

--- a/sonar/modules/documents/dojson/rerodoc/model.py
+++ b/sonar/modules/documents/dojson/rerodoc/model.py
@@ -670,11 +670,16 @@ def marc21_to_dissertation_field_508(self, key, value):
 
 
 @marc21tojson.over('usageAndAccessPolicy', '^540..')
-@utils.for_each_value
 @utils.ignore_value
 def marc21_to_usage_and_access_policy(self, key, value):
     """Extract usage and access policy."""
-    return value.get('a')
+    if not value.get('a'):
+        return None
+
+    return {
+        'label': value.get('a'),
+        'license': 'Other OA / license undefined'
+    }
 
 
 @marc21tojson.over('contribution', '^100..')

--- a/sonar/modules/documents/dojson/rerodoc/overdo.py
+++ b/sonar/modules/documents/dojson/rerodoc/overdo.py
@@ -94,6 +94,12 @@ class Overdo(BaseOverdo):
         # Verify data integrity
         self.verify(result)
 
+        # Add default license if not set.
+        if not result.get('usageAndAccessPolicy'):
+            result['usageAndAccessPolicy'] = {
+                'license': 'Other OA / license undefined'
+            }
+
         return result
 
     def get_contributor_role(self, role_700=None):

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -1089,14 +1089,21 @@
       "hideExpression": "!['coar:c_46ec', 'coar:c_7a1f', 'coar:c_db06', 'coar:c_bdcc', 'habilitation_thesis', 'advanced_studies_thesis', 'other'].includes(field.parent.model.documentType)"
     },
     "usageAndAccessPolicy": {
-      "title": "Usage and access policies",
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "title": "Usage and access policy",
-        "type": "string",
-        "minLength": 1
+      "title": "Usage and access policy",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "license": {
+          "$ref": "license-v1.0.0.json"
+        },
+        "label": {
+          "title": "Label",
+          "type": "string",
+          "minLength": 1
+        }
       },
+      "propertiesOrder": ["license", "label"],
+      "required": ["license"],
       "form": {
         "hide": true,
         "templateOptions": {

--- a/sonar/modules/documents/mappings/v6/documents/document-v1.0.0.json
+++ b/sonar/modules/documents/mappings/v6/documents/document-v1.0.0.json
@@ -320,7 +320,15 @@
           }
         },
         "usageAndAccessPolicy": {
-          "type": "text"
+          "type": "object",
+          "properties": {
+            "label": {
+              "type": "text"
+            },
+            "license": {
+              "type": "keyword"
+            }
+          }
         },
         "contribution": {
           "type": "object",

--- a/sonar/modules/documents/marshmallow/json.py
+++ b/sonar/modules/documents/marshmallow/json.py
@@ -90,6 +90,7 @@ class DocumentMetadataSchemaV1(StrictKeysMixin):
     specificCollections = fields.List(SanitizedUnicode())
     dissertation = fields.Dict()
     otherEdition = fields.List(fields.Dict())
+    usageAndAccessPolicy = fields.Dict()
     _bucket = SanitizedUnicode()
     _files = Nested(FileSchemaV1, many=True)
     # When loading, if $schema is not provided, it's retrieved by

--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -26,18 +26,20 @@
 
 <section class="mt-3">
   <div class="row">
-    <div class="col-lg-3">
+    <div class="col-lg-3 text-center">
       {% if files and files | length > 0 %}
       <div class="mb-4">
         {{ thumbnail('documents', record, files | first) }}
       </div>
       {% endif %}
+
       <!-- DOCUMENT TYPE -->
       {% if record.documentType %}
-      <h5 class="text-center my-4">{{ _('document_type_' + record.documentType) }}</h5>
+      <h5 class="my-4">{{ _('document_type_' + record.documentType) }}</h5>
       {% endif %}
+
       {% if files and files | length > 1 %}
-      <p class="text-center">
+      <p>
         <a href="{{ request.url }}#other_files">+ {{ (files | length) - 1 }} {{ _('other files') }}</a>
       </p>
       {% endif %}
@@ -213,6 +215,19 @@
           {{ _('classification_' + classification.classificationPortion) }}
         </dd>
         {% endfor %}
+        {% endif %}
+
+        <!-- LICENSE -->
+        {% if record.usageAndAccessPolicy %}
+        <dt class="col-lg-3">
+          {{ _('License') }}
+        </dt>
+        <dd class="col-lg-9">
+          {{ _(record.usageAndAccessPolicy.license) }}
+          {% if record.usageAndAccessPolicy.label %}
+          <br>{{ record.usageAndAccessPolicy.label }}
+          {% endif %}
+        </dd>
         {% endif %}
 
         <!-- PERMANENT LINK -->

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -486,6 +486,9 @@ def deposit_json():
                 'value': '10.1038/nphys1170'
             }]
         },
+        'diffusion': {
+            'license': 'CC0'
+        },
         'status':
         'in_progress',
         'step':

--- a/tests/ui/documents/dojson/rerodoc/test_rerodoc_model.py
+++ b/tests/ui/documents/dojson/rerodoc/test_rerodoc_model.py
@@ -1827,7 +1827,10 @@ def test_marc21_to_usage_and_access_policy():
     """
     marc21json = create_record(marc21xml)
     data = marc21tojson.do(marc21json)
-    assert data.get('usageAndAccessPolicy') == ['Springer-Verlag Berlin']
+    assert data.get('usageAndAccessPolicy') == {
+        'label': 'Springer-Verlag Berlin',
+        'license': 'Other OA / license undefined'
+    }
 
     # Multiple
     marc21xml = """
@@ -1842,7 +1845,10 @@ def test_marc21_to_usage_and_access_policy():
     """
     marc21json = create_record(marc21xml)
     data = marc21tojson.do(marc21json)
-    assert data.get('usageAndAccessPolicy') == ['Usage 1', 'Usage 2']
+    assert data.get('usageAndAccessPolicy') == {
+        'label': 'Usage 2',
+        'license': 'Other OA / license undefined'
+    }
 
     # Without $a
     marc21xml = """
@@ -1852,7 +1858,9 @@ def test_marc21_to_usage_and_access_policy():
     """
     marc21json = create_record(marc21xml)
     data = marc21tojson.do(marc21json)
-    assert not data.get('usageAndAccessPolicy')
+    assert data.get('usageAndAccessPolicy') == {
+        'license': 'Other OA / license undefined'
+    }
 
     # Without 540
     marc21xml = """
@@ -1860,7 +1868,9 @@ def test_marc21_to_usage_and_access_policy():
     """
     marc21json = create_record(marc21xml)
     data = marc21tojson.do(marc21json)
-    assert not data.get('usageAndAccessPolicy')
+    assert data.get('usageAndAccessPolicy') == {
+        'license': 'Other OA / license undefined'
+    }
 
 
 def test_marc21_to_contribution_field_100():


### PR DESCRIPTION
This PR aims to add a license to deposit and document records. Moreover, the `usageAndAccessPolicy` will be added when a record is imported from RERO DOC.

* Creates a JSON schema for license property.
* Creates the `usageAndAccessPolicy` property in documents when the document is created from a deposit.
* Updates the `usageAndAccessPolicy` property of documents to match the specs.
* Adds a `license` property in deposit's JSON schema.
* Updates the conversion of field `540$a` to match the new structure of the `usageAndAccessPolicy` property.
* Adds a default license for RERO DOC documents if the license is not set.
* Makes the field `usageAndAccessPolicy` available when a document is serialized.
* Displays the license in document's detail view.
* Closes #324.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>