### PR TITLE
deposit: fix log date format

### DIFF
--- a/sonar/modules/deposits/api.py
+++ b/sonar/modules/deposits/api.py
@@ -20,6 +20,8 @@
 from datetime import datetime
 from functools import partial
 
+import pytz
+
 from sonar.modules.documents.api import DocumentRecord
 from sonar.modules.users.api import current_user_record
 
@@ -84,7 +86,7 @@ class DepositRecord(SonarRecord):
 
         log = {
             'user': user,
-            'date': datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+            'date': pytz.utc.localize(datetime.utcnow()).isoformat(),
             'action': action
         }
 

--- a/sonar/modules/deposits/mappings/v6/deposits/deposit-v1.0.0.json
+++ b/sonar/modules/deposits/mappings/v6/deposits/deposit-v1.0.0.json
@@ -84,8 +84,7 @@
               "type": "keyword"
             },
             "date": {
-              "type": "date",
-              "format": "yyyy-MM-dd HH:mm:ss"
+              "type": "date"
             },
             "comment": {
               "type": "text"


### PR DESCRIPTION
* Fixes date format to UTC timezone for deposit logs.
* Closes #333.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>