### PR TITLE
documents: Customize PDF preview styles

### DIFF
--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -60,6 +60,9 @@ invenio webpack buildall
 mkdir -p ${static_folder}/sonar-ui
 cp -R ${assets_folder}/node_modules/@rero/sonar-ui/dist/sonar/* ${static_folder}/sonar-ui
 
+# Copy worker from pdfjs to avoid a 404 error when previewing PDF files.
+cp ${assets_folder}/node_modules/pdfjs-dist/build/pdf.worker.min.js ${static_folder}/js/pdfjs/
+
 # Compile JSON schemas
 section "Compile JSON schemas" "info"
 invenio utils compile-json ./sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json -o ./sonar/modules/documents/jsonschemas/documents/document-v1.0.0.json

--- a/sonar/config.py
+++ b/sonar/config.py
@@ -211,8 +211,8 @@ APP_DEFAULT_SECURE_HEADERS = {
             'https://fonts.googleapis.com'
         ],
         'font-src': [
-            "'self'", "'unsafe-inline'", 'https://cdnjs.cloudflare.com',
-            'https://fonts.gstatic.com'
+            "'self'", "data:", "blob:", "'unsafe-inline'",
+            'https://cdnjs.cloudflare.com', 'https://fonts.gstatic.com'
         ],
         'img-src': ["'self'", "data:", "blob:"]
         # To allow PDF previewer to create left navigation.
@@ -642,3 +642,7 @@ WIKI_BASE_TEMPLATE = 'sonar/page_wiki.html'
 WIKI_EDIT_VIEW_PERMISSION = wiki_edit_permission
 WIKI_EDIT_UI_PERMISSION = wiki_edit_permission
 WIKI_MARKDOWN_EXTENSIONS = set(('extra', ))
+
+# PREVIEW
+# =======
+PREVIEWER_BASE_TEMPLATE = 'sonar/preview/base.html'

--- a/sonar/theme/assets/scss/preview.scss
+++ b/sonar/theme/assets/scss/preview.scss
@@ -1,0 +1,24 @@
+/*
+  Swiss Open Access Repository
+  Copyright (C) 2019 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#sidebarContent {
+    background-color: rgba(0, 0, 0, 0.7);
+
+    .outlineItem > a {
+        color: white !important;
+    }
+}

--- a/sonar/theme/templates/sonar/preview/base.html
+++ b/sonar/theme/templates/sonar/preview/base.html
@@ -1,0 +1,59 @@
+{# -*- coding: utf-8 -*-
+  Swiss Open Access Repository
+  Copyright (C) 2019 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#}
+
+<!DOCTYPE html>
+<html {%- block html_tags %}{%- endblock %}>
+  <head>
+    <title>{{_('Preview')}}</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    {%- block head %}
+      {% if config.PREVIEWER_ASSETS_USE_WEBPACK %}
+        {% for css_bundle in css_bundles %}
+          {{ webpack[css_bundle] }}
+        {% endfor %}
+        {{ webpack['preview.css'] }}
+      {% else %}
+        {%- for bdl in css_bundles %}
+          {%- assets bdl %}
+            <link href="{{ ASSET_URL }}" rel="stylesheet">
+          {%- endassets %}
+        {%- endfor %}
+      {% endif %}
+    {%- endblock %}
+  </head>
+
+  <body>
+    {%- block page_body %}{%- endblock %}
+
+    {%- block javascript %}
+      {% if config.PREVIEWER_ASSETS_USE_WEBPACK %}
+        {{ webpack['manifest.js'] }}
+        {{ webpack['vendor.js'] }}
+        {% for js_bundle in js_bundles %}
+          {{ webpack[js_bundle] }}
+        {% endfor %}
+      {% else %}
+        {%- for bdl in js_bundles %}
+          {%- assets bdl %}
+            <script src="{{ ASSET_URL }}"></script>
+          {%- endassets %}
+        {%- endfor %}
+      {% endif %}
+    {%- endblock %}
+  </body>
+</html>

--- a/sonar/theme/webpack.py
+++ b/sonar/theme/webpack.py
@@ -29,7 +29,8 @@ theme = WebpackBundle(
     entry={
         'app': './js/app.js',
         'global-theme': './scss/global/theme.scss',
-        'usi-theme': './scss/usi/theme.scss'
+        'usi-theme': './scss/usi/theme.scss',
+        'preview': './scss/preview.scss',
     },
     dependencies={
         'popper.js': '^1.15',


### PR DESCRIPTION
This PR customizes the sidebar of the PDF previewer, to make the bookmarks more visible. It integrates some modifications to improve the PDF preview experience (i.e. with Firefox).

* Copies the worker from `pdf.js` in static folder, to avoid an error when loading the preview.
* Allows `data` and `blob` sources for fonts in content security policies.
* Adds and uses a custom base template for preview, to allow to override styles from `pdf.js`.
* Adds a custom styles sheet for previews.
* Closes #336.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>