### PR TITLE
deposits: contributors are not required

### DIFF
--- a/sonar/modules/deposits/api.py
+++ b/sonar/modules/deposits/api.py
@@ -251,7 +251,7 @@ class DepositRecord(SonarRecord):
 
         # Contributors
         contributors = []
-        for contributor in self['contributors']:
+        for contributor in self.get('contributors', []):
             data = {
                 'agent': {
                     'type': 'bf:Person',

--- a/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
+++ b/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
@@ -764,7 +764,6 @@
     "contributors": {
       "title": "Contributors",
       "type": "array",
-      "minItems": 1,
       "default": [
         {}
       ],


### PR DESCRIPTION
* Removes `minLength` property for contributors, as they are not required.
* Checks if `contributors` property exists when document is created from the deposit.
* Closes #352.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>