### PR TITLE
documents: meeting display

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,8 @@ setup(
         'invenio_base.api_apps': [
             'documents = sonar.modules.documents:Documents',
             'organisations = sonar.modules.organisations:Organisations',
-            'sonar = sonar.modules:Sonar'
+            'sonar = sonar.modules:Sonar',
+            'invenio_i18n = invenio_i18n:InvenioI18N'
         ],
         'invenio_jsonschemas.schemas': [
             'documents = sonar.modules.documents.jsonschemas',

--- a/sonar/modules/documents/marshmallow/json.py
+++ b/sonar/modules/documents/marshmallow/json.py
@@ -30,8 +30,9 @@ from marshmallow import fields, pre_dump, pre_load
 
 from sonar.modules.documents.api import DocumentRecord
 from sonar.modules.documents.permissions import DocumentPermission
-from sonar.modules.documents.views import create_publication_statement, \
-    dissertation, is_file_restricted, part_of_format
+from sonar.modules.documents.views import contribution_text, \
+    create_publication_statement, dissertation, is_file_restricted, \
+    part_of_format
 from sonar.modules.serializers import schema_from_context
 from sonar.modules.users.api import current_user_record
 
@@ -167,6 +168,11 @@ class DocumentMetadataSchemaV1(StrictKeysMixin):
         for index, part_of in enumerate(item.get('partOf', [])):
             item['partOf'][index]['text'] = part_of_format(part_of)
 
+        # Contribution
+        for index, contribution in enumerate(item.get('contribution', [])):
+            item['contribution'][index]['text'] = contribution_text(
+                contribution)
+
         if item.get('dissertation'):
             item['dissertation']['text'] = dissertation(item)
 
@@ -201,6 +207,9 @@ class DocumentMetadataSchemaV1(StrictKeysMixin):
 
         for part_of in data.get('partOf', []):
             part_of.pop('text', None)
+
+        for contribution in data.get('contribution', []):
+            contribution.pop('text', None)
 
         data.get('dissertation', {}).pop('text', None)
 

--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -52,10 +52,7 @@
         <ul class="list-unstyled m-0">
           {% for contribution in contributors %}
           <li class="creator {{ 'd-none' if loop.index > 3 }}">
-            {{ contribution.agent.preferred_name }}
-            {% if not 'cre' in contribution.role %}
-            ({{ _('contribution_role_' + contribution.role[0]) | lower }})
-            {% endif %}
+            {{ contribution | contribution_text }}
             {% if contribution.agent.get('identifiedBy', {}).get('value') %}
             <a href="https://orcid.org/{{ contribution.agent.identifiedBy.value }}" target="_blank"
               class="badge badge-secondary text-light">

--- a/sonar/modules/documents/views.py
+++ b/sonar/modules/documents/views.py
@@ -332,6 +332,38 @@ def dissertation(record):
     return ''.join(dissertation_text)
 
 
+@blueprint.app_template_filter()
+def contribution_text(contribution):
+    """Display contribution row text.
+
+    :param contribution: Dict representing the contribution.
+    :returns: Formatted text.
+    """
+    data = [contribution['agent']['preferred_name']]
+
+    # Meeting
+    if contribution['agent']['type'] == 'bf:Meeting':
+        meeting = []
+        if contribution['agent'].get('number'):
+            meeting.append(contribution['agent']['number'])
+
+        if contribution['agent'].get('date'):
+            meeting.append(contribution['agent']['date'])
+
+        if contribution['agent'].get('place'):
+            meeting.append(contribution['agent']['place'])
+
+        data.append('({meeting})'.format(meeting=' : '.join(meeting)))
+
+    # Person
+    if contribution['agent'][
+            'type'] == 'bf:Person' and contribution['role'][0] != 'cre':
+        data.append('({role})'.format(role=_('contribution_role_{role}'.format(
+            role=contribution['role'][0])).lower()))
+
+    return ' '.join(data)
+
+
 def get_language_from_bibliographic_code(language_code):
     """Return language code from bibliographic language.
 

--- a/tests/ui/documents/test_documents_views.py
+++ b/tests/ui/documents/test_documents_views.py
@@ -507,3 +507,54 @@ def test_dissertation():
         }
     ) == 'Thèse de doctorat: Università della Svizzera italiana, 01.01.2010 ' \
          '(jury note: Jury note)'
+
+
+def test_contribution_text():
+    """Test contribution text formatting."""
+    # Just creator
+    assert views.contribution_text({
+        'agent': {
+            'type': 'bf:Person',
+            'preferred_name': 'John Doe'
+        },
+        'role': ['cre']
+    }) == 'John Doe'
+
+    # Contributor
+    assert views.contribution_text({
+        'agent': {
+            'type': 'bf:Person',
+            'preferred_name': 'John Doe'
+        },
+        'role': ['ctb']
+    }) == 'John Doe (contribution_role_ctb)'
+
+    # Meeting with only number
+    assert views.contribution_text({
+        'agent': {
+            'type': 'bf:Meeting',
+            'preferred_name': 'Meeting',
+            'number': '1234'
+        }
+    }) == 'Meeting (1234)'
+
+    # Meeting with number and date
+    assert views.contribution_text({
+        'agent': {
+            'type': 'bf:Meeting',
+            'preferred_name': 'Meeting',
+            'number': '1234',
+            'date': '2019',
+        }
+    }) == 'Meeting (1234 : 2019)'
+
+    # Meeting with number, date and place
+    assert views.contribution_text({
+        'agent': {
+            'type': 'bf:Meeting',
+            'preferred_name': 'Meeting',
+            'number': '1234',
+            'date': '2019',
+            'place': 'Place'
+        }
+    }) == 'Meeting (1234 : 2019 : Place)'


### PR DESCRIPTION
This commit displays the complete meeting information, with number, place and date.

* Creates a view filter to format contribution display.
* Adds the formatted text before serialization.
* Removes the formatted text before JSON loading.
* Displays the formatted text in record detail view.
* Registers the i18n extension in API application, to make the translations available.
* Closes #338.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>