### PR TITLE
documents: fix contributions in editor.

### DIFF
--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -1196,13 +1196,8 @@
                     "minLength": 1
                   }
                 },
-                "required": [
-                  "type",
-                  "source",
-                  "value"
-                ],
                 "form": {
-                  "hideExpression": "field.model.type !== 'bf:Person'"
+                  "hideExpression": "field.parent.model.type !== 'bf:Person'"
                 }
               },
               "date_of_birth": {


### PR DESCRIPTION
* Fixes hide expression for `identifiedBy` field in contributions by checking the right model.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>