### PR TITLE
projects: add resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ target/
 # Generated JSON schemas
 sonar/modules/documents/jsonschemas/documents/document-v1.0.0.json
 sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0.json
+sonar/modules/projects/jsonschemas/projects/project-v1.0.0.json
 
 # Generated JSON files
 data/backups/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,6 +14,7 @@
 
 exclude sonar/modules/documents/jsonschemas/documents/document-v1.0.0.json
 exclude sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0.json
+exclude sonar/modules/projects/jsonschemas/projects/project-v1.0.0.json
 
 include *.html
 include *.inv

--- a/data/complete_document_sample.json
+++ b/data/complete_document_sample.json
@@ -48,9 +48,6 @@
       "role": [
         "cre"
       ],
-      "controlledAffiliation": [
-        "HEP Vaud"
-      ],
       "affiliation": "Haute école Pédagogique de Lausanne"
     },
     {

--- a/poetry.lock
+++ b/poetry.lock
@@ -244,12 +244,13 @@ description = "Distributed Task Queue."
 name = "celery"
 optional = false
 python-versions = ">=3.6,"
-version = "5.0.2"
+version = "5.0.4"
 
 [package.dependencies]
 billiard = ">=3.6.3.0,<4.0"
-click = ">=7.0"
+click = ">=7.0,<8.0"
 click-didyoumean = ">=0.0.3"
+click-plugins = ">=1.1.1"
 click-repl = ">=0.1.6"
 kombu = ">=5.0.0,<6.0"
 pytz = ">0.0-dev"
@@ -277,6 +278,7 @@ mongodb = ["pymongo (>=3.3.0)"]
 msgpack = ["msgpack"]
 pymemcache = ["python-memcached"]
 pyro = ["pyro4"]
+pytest = ["pytest-celery"]
 redis = ["redis (>=3.2.0)"]
 s3 = ["boto3 (>=1.9.125)"]
 slmq = ["softlayer-messaging (>=1.0.3)"]
@@ -294,7 +296,7 @@ description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
 optional = false
 python-versions = "*"
-version = "2020.11.8"
+version = "2020.12.5"
 
 [[package]]
 category = "main"
@@ -363,6 +365,20 @@ click = "*"
 
 [[package]]
 category = "main"
+description = "An extension module for click to enable registering CLI commands via setuptools entry-points."
+name = "click-plugins"
+optional = false
+python-versions = "*"
+version = "1.1.1"
+
+[package.dependencies]
+click = ">=4.0"
+
+[package.extras]
+dev = ["pytest (>=3.6)", "pytest-cov", "wheel", "coveralls"]
+
+[[package]]
+category = "main"
 description = "REPL plugin for Click"
 name = "click-repl"
 optional = false
@@ -399,11 +415,11 @@ category = "main"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 name = "cryptography"
 optional = false
-python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
-version = "3.2.1"
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
+version = "3.3.1"
 
 [package.dependencies]
-cffi = ">=1.8,<1.11.3 || >1.11.3"
+cffi = ">=1.12"
 six = ">=1.4.1"
 
 [package.extras]
@@ -509,7 +525,7 @@ description = "Python client for Elasticsearch"
 name = "elasticsearch"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4"
-version = "7.10.0"
+version = "7.10.1"
 
 [package.dependencies]
 certifi = "*"
@@ -1030,6 +1046,17 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 version = "0.18.2"
 
 [[package]]
+category = "main"
+description = "Fuzzy string matching in python"
+name = "fuzzywuzzy"
+optional = false
+python-versions = "*"
+version = "0.18.0"
+
+[package.extras]
+speedup = ["python-levenshtein (>=0.12)"]
+
+[[package]]
 category = "dev"
 description = "Git Object Database"
 name = "gitdb"
@@ -1092,10 +1119,14 @@ marker = "python_version < \"3.8\" or python_version >= \"3.7\" and python_versi
 name = "importlib-metadata"
 optional = false
 python-versions = ">=3.6"
-version = "3.1.1"
+version = "3.3.0"
 
 [package.dependencies]
 zipp = ">=0.5"
+
+[package.dependencies.typing-extensions]
+python = "<3.8"
+version = ">=3.6.4"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
@@ -1452,20 +1483,19 @@ description = "Celery module for Invenio."
 name = "invenio-celery"
 optional = false
 python-versions = "*"
-version = "1.2.1"
+version = "1.2.2"
 
 [package.dependencies]
 Flask-CeleryExt = ">=0.3.4"
 celery = ">=4.4.0,<5.1"
 invenio-base = ">=1.2.3"
 msgpack = ">=0.6.2"
-pytest-celery = ">=0.0.0a1"
 redis = ">=2.10.0"
 
 [package.extras]
-all = ["Sphinx (>=3)", "mock (>=1.3.0)", "pytest-invenio (>=1.3.4)", "pytest-cov (>=2.10.1)", "pytest-isort (>=1.2.0)", "pytest-pycodestyle (>=2.2.0)", "pytest-pydocstyle (>=2.2.0)", "pytest (>=6,<7)"]
+all = ["Sphinx (>=3)", "pytest-invenio (>=1.4.0)"]
 docs = ["Sphinx (>=3)"]
-tests = ["mock (>=1.3.0)", "pytest-invenio (>=1.3.4)", "pytest-cov (>=2.10.1)", "pytest-isort (>=1.2.0)", "pytest-pycodestyle (>=2.2.0)", "pytest-pydocstyle (>=2.2.0)", "pytest (>=6,<7)"]
+tests = ["pytest-invenio (>=1.4.0)"]
 
 [[package]]
 category = "main"
@@ -1636,16 +1666,16 @@ description = "Invenio module for building and serving JSONSchemas."
 name = "invenio-jsonschemas"
 optional = false
 python-versions = "*"
-version = "1.1.0"
+version = "1.1.1"
 
 [package.dependencies]
 invenio-base = ">=1.2.2"
 jsonref = ">=0.1"
 
 [package.extras]
-all = ["Sphinx (>=1.6.2)", "check-manifest (>=0.25)", "coverage (>=4.0)", "isort (>=4.2.2)", "jsonresolver (>=0.2.1)", "pydocstyle (>=2.0.0)", "pytest-cov (>=1.8.0)", "pytest-pep8 (>=1.0.6)", "pytest (>=4.0.0,<5.0.0)", "mock (>=1.3.0)"]
+all = ["Sphinx (>=1.6.2)", "jsonresolver (>=0.2.1)", "mock (>=1.3.0)", "pytest-invenio (>=1.4.0)"]
 docs = ["Sphinx (>=1.6.2)"]
-tests = ["check-manifest (>=0.25)", "coverage (>=4.0)", "isort (>=4.2.2)", "jsonresolver (>=0.2.1)", "pydocstyle (>=2.0.0)", "pytest-cov (>=1.8.0)", "pytest-pep8 (>=1.0.6)", "pytest (>=4.0.0,<5.0.0)", "mock (>=1.3.0)"]
+tests = ["jsonresolver (>=0.2.1)", "mock (>=1.3.0)", "pytest-invenio (>=1.4.0)"]
 
 [[package]]
 category = "main"
@@ -1984,11 +2014,11 @@ description = "REST API module for Invenio."
 name = "invenio-rest"
 optional = false
 python-versions = "*"
-version = "1.2.2"
+version = "1.2.3"
 
 [package.dependencies]
 Flask-CORS = ">=2.1.0"
-invenio-base = ">=1.2.2"
+invenio-base = ">=1.2.3"
 webargs = ">=5.5.0,<6.0.0"
 
 [package.dependencies.marshmallow]
@@ -1996,9 +2026,9 @@ python = ">=3.0.0"
 version = ">=2.15.2"
 
 [package.extras]
-all = ["Sphinx (>=1.4.2)", "check-manifest (>=0.25)", "coverage (>=4.0)", "xmltodict (>=0.11.0)", "isort (>=4.2.15)", "mock (>=1.3.0)", "pydocstyle (>=1.0.0)", "pytest-cov (>=1.8.0)", "pytest-pep8 (>=1.0.6)", "pytest (>=4.0.0,<5.0.0)", "marshmallow (>=2.15.2,<3.0.0)", "marshmallow (>=2.15.2)"]
-docs = ["Sphinx (>=1.4.2)"]
-tests = ["check-manifest (>=0.25)", "coverage (>=4.0)", "xmltodict (>=0.11.0)", "isort (>=4.2.15)", "mock (>=1.3.0)", "pydocstyle (>=1.0.0)", "pytest-cov (>=1.8.0)", "pytest-pep8 (>=1.0.6)", "pytest (>=4.0.0,<5.0.0)", "Sphinx (>=1.4.2)"]
+all = ["Sphinx (>=3.3.0)", "xmltodict (>=0.11.0)", "pytest-invenio (>=1.4.0)", "marshmallow (>=2.15.2,<3.0.0)", "marshmallow (>=2.15.2)"]
+docs = ["Sphinx (>=3.3.0)"]
+tests = ["xmltodict (>=0.11.0)", "pytest-invenio (>=1.4.0)", "Sphinx (>=3.3.0)"]
 
 [[package]]
 category = "main"
@@ -2489,12 +2519,12 @@ description = "Rolling backport of unittest.mock for all Pythons"
 name = "mock"
 optional = false
 python-versions = ">=3.6"
-version = "4.0.2"
+version = "4.0.3"
 
 [package.extras]
 build = ["twine", "wheel", "blurb"]
 docs = ["sphinx"]
-test = ["pytest", "pytest-cov"]
+test = ["pytest (<5.4)", "pytest-cov"]
 
 [[package]]
 category = "dev"
@@ -2510,7 +2540,7 @@ description = "MessagePack (de)serializer."
 name = "msgpack"
 optional = false
 python-versions = "*"
-version = "1.0.0"
+version = "1.0.1"
 
 [[package]]
 category = "main"
@@ -2624,7 +2654,7 @@ description = "Core utilities for Python packages"
 name = "packaging"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.7"
+version = "20.8"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
@@ -2778,7 +2808,7 @@ description = "library with cross-python path, ini-parsing, io, code, log facili
 name = "py"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.9.0"
+version = "1.10.0"
 
 [[package]]
 category = "main"
@@ -2813,7 +2843,7 @@ description = "Pygments is a syntax highlighting package written in Python."
 name = "pygments"
 optional = false
 python-versions = ">=3.5"
-version = "2.7.2"
+version = "2.7.3"
 
 [[package]]
 category = "main"
@@ -2894,17 +2924,6 @@ version = "1.0"
 [package.dependencies]
 execnet = ">=1.1.dev1"
 pytest = ">=2.2"
-
-[[package]]
-category = "main"
-description = "pytest-celery a shim pytest plugin to enable celery.contrib.pytest"
-name = "pytest-celery"
-optional = false
-python-versions = "*"
-version = "0.0.0a1"
-
-[package.dependencies]
-celery = ">=4.4.0"
 
 [[package]]
 category = "dev"
@@ -3037,6 +3056,17 @@ name = "python-editor"
 optional = false
 python-versions = "*"
 version = "1.0.4"
+
+[[package]]
+category = "main"
+description = "Python extension for computing string edit distances and similarities."
+name = "python-levenshtein"
+optional = false
+python-versions = "*"
+version = "0.12.0"
+
+[package.dependencies]
+setuptools = "*"
 
 [[package]]
 category = "main"
@@ -3219,7 +3249,7 @@ description = "Python client for Sentry (https://sentry.io)"
 name = "sentry-sdk"
 optional = false
 python-versions = "*"
-version = "0.19.4"
+version = "0.19.5"
 
 [package.dependencies]
 certifi = "*"
@@ -3308,7 +3338,7 @@ marker = "python_version >= \"3.0\""
 name = "soupsieve"
 optional = false
 python-versions = ">=3.5"
-version = "2.0.1"
+version = "2.1"
 
 [[package]]
 category = "main"
@@ -3584,6 +3614,15 @@ urllib3 = ">=1.24.2,<2.0.0"
 
 [[package]]
 category = "main"
+description = "Backported and Experimental Type Hints for Python 3.5+"
+marker = "python_version < \"3.8\" or python_version >= \"3.7\" and python_version < \"3.8\""
+name = "typing-extensions"
+optional = false
+python-versions = "*"
+version = "3.7.4.3"
+
+[[package]]
+category = "main"
 description = "Python port of Browserscope's user agent parser"
 name = "ua-parser"
 optional = false
@@ -3834,7 +3873,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "5c554287d0c94a3945592a475c974c65cffd71b01399727cb1e1f4d3f5cfb3ec"
+content-hash = "f3cbbdf11606b5b58be31b1ccc327c3c6fbd6732c9d657746069ec70f9e6ca0c"
 lock-version = "1.0"
 python-versions = "^3.6"
 
@@ -3950,12 +3989,12 @@ cchardet = [
     {file = "cchardet-2.1.7.tar.gz", hash = "sha256:c428b6336545053c2589f6caf24ea32276c6664cb86db817e03a94c60afa0eaf"},
 ]
 celery = [
-    {file = "celery-5.0.2-py3-none-any.whl", hash = "sha256:930c3acd55349d028c4e7104a7d377729cbcca19d9fce470c17172d9e7f9a8b6"},
-    {file = "celery-5.0.2.tar.gz", hash = "sha256:012c814967fe89e3f5d2cf49df2dba3de5f29253a7f4f2270e8fce6b901b4ebf"},
+    {file = "celery-5.0.4-py3-none-any.whl", hash = "sha256:533f3635065b7ed362ffc04228635b4c82d53a9ab812118ccdedb5eae281fb97"},
+    {file = "celery-5.0.4.tar.gz", hash = "sha256:45bb7909061862305cefec94289fabc1b89ac004680f4dc7d9dea642a2507e53"},
 ]
 certifi = [
-    {file = "certifi-2020.11.8-py2.py3-none-any.whl", hash = "sha256:1f422849db327d534e3d0c5f02a263458c3955ec0aae4ff09b95f195c59f4edd"},
-    {file = "certifi-2020.11.8.tar.gz", hash = "sha256:f05def092c44fbf25834a51509ef6e631dc19765ab8a57b4e7ab85531f0a9cf4"},
+    {file = "certifi-2020.12.5-py2.py3-none-any.whl", hash = "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"},
+    {file = "certifi-2020.12.5.tar.gz", hash = "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c"},
 ]
 cffi = [
     {file = "cffi-1.14.4-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:ebb253464a5d0482b191274f1c8bf00e33f7e0b9c66405fbffc61ed2c839c775"},
@@ -4011,6 +4050,10 @@ click-default-group = [
 click-didyoumean = [
     {file = "click-didyoumean-0.0.3.tar.gz", hash = "sha256:112229485c9704ff51362fe34b2d4f0b12fc71cc20f6d2b3afabed4b8bfa6aeb"},
 ]
+click-plugins = [
+    {file = "click-plugins-1.1.1.tar.gz", hash = "sha256:46ab999744a9d831159c3411bb0c79346d94a444df9a3a3742e9ed63645f264b"},
+    {file = "click_plugins-1.1.1-py2.py3-none-any.whl", hash = "sha256:5d262006d3222f5057fd81e1623d4443e41dcda5dc815c06b442aa3c02889fc8"},
+]
 click-repl = [
     {file = "click-repl-0.1.6.tar.gz", hash = "sha256:b9f29d52abc4d6059f8e276132a111ab8d94980afe6a5432b9d996544afa95d5"},
     {file = "click_repl-0.1.6-py3-none-any.whl", hash = "sha256:9c4c3d022789cae912aad8a3f5e1d7c2cdd016ee1225b5212ad3e8691563cda5"},
@@ -4055,28 +4098,20 @@ coverage = [
     {file = "coverage-5.3.tar.gz", hash = "sha256:280baa8ec489c4f542f8940f9c4c2181f0306a8ee1a54eceba071a449fb870a0"},
 ]
 cryptography = [
-    {file = "cryptography-3.2.1-cp27-cp27m-macosx_10_10_x86_64.whl", hash = "sha256:6dc59630ecce8c1f558277ceb212c751d6730bd12c80ea96b4ac65637c4f55e7"},
-    {file = "cryptography-3.2.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:75e8e6684cf0034f6bf2a97095cb95f81537b12b36a8fedf06e73050bb171c2d"},
-    {file = "cryptography-3.2.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:4e7268a0ca14536fecfdf2b00297d4e407da904718658c1ff1961c713f90fd33"},
-    {file = "cryptography-3.2.1-cp27-cp27m-win32.whl", hash = "sha256:7117319b44ed1842c617d0a452383a5a052ec6aa726dfbaffa8b94c910444297"},
-    {file = "cryptography-3.2.1-cp27-cp27m-win_amd64.whl", hash = "sha256:a733671100cd26d816eed39507e585c156e4498293a907029969234e5e634bc4"},
-    {file = "cryptography-3.2.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:a75f306a16d9f9afebfbedc41c8c2351d8e61e818ba6b4c40815e2b5740bb6b8"},
-    {file = "cryptography-3.2.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:5849d59358547bf789ee7e0d7a9036b2d29e9a4ddf1ce5e06bb45634f995c53e"},
-    {file = "cryptography-3.2.1-cp35-abi3-macosx_10_10_x86_64.whl", hash = "sha256:bd717aa029217b8ef94a7d21632a3bb5a4e7218a4513d2521c2a2fd63011e98b"},
-    {file = "cryptography-3.2.1-cp35-abi3-manylinux1_x86_64.whl", hash = "sha256:efe15aca4f64f3a7ea0c09c87826490e50ed166ce67368a68f315ea0807a20df"},
-    {file = "cryptography-3.2.1-cp35-abi3-manylinux2010_x86_64.whl", hash = "sha256:32434673d8505b42c0de4de86da8c1620651abd24afe91ae0335597683ed1b77"},
-    {file = "cryptography-3.2.1-cp35-abi3-manylinux2014_aarch64.whl", hash = "sha256:7b8d9d8d3a9bd240f453342981f765346c87ade811519f98664519696f8e6ab7"},
-    {file = "cryptography-3.2.1-cp35-cp35m-win32.whl", hash = "sha256:d3545829ab42a66b84a9aaabf216a4dce7f16dbc76eb69be5c302ed6b8f4a29b"},
-    {file = "cryptography-3.2.1-cp35-cp35m-win_amd64.whl", hash = "sha256:a4e27ed0b2504195f855b52052eadcc9795c59909c9d84314c5408687f933fc7"},
-    {file = "cryptography-3.2.1-cp36-abi3-win32.whl", hash = "sha256:13b88a0bd044b4eae1ef40e265d006e34dbcde0c2f1e15eb9896501b2d8f6c6f"},
-    {file = "cryptography-3.2.1-cp36-abi3-win_amd64.whl", hash = "sha256:07ca431b788249af92764e3be9a488aa1d39a0bc3be313d826bbec690417e538"},
-    {file = "cryptography-3.2.1-cp36-cp36m-win32.whl", hash = "sha256:a035a10686532b0587d58a606004aa20ad895c60c4d029afa245802347fab57b"},
-    {file = "cryptography-3.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:d26a2557d8f9122f9bf445fc7034242f4375bd4e95ecda007667540270965b13"},
-    {file = "cryptography-3.2.1-cp37-cp37m-win32.whl", hash = "sha256:545a8550782dda68f8cdc75a6e3bf252017aa8f75f19f5a9ca940772fc0cb56e"},
-    {file = "cryptography-3.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:55d0b896631412b6f0c7de56e12eb3e261ac347fbaa5d5e705291a9016e5f8cb"},
-    {file = "cryptography-3.2.1-cp38-cp38-win32.whl", hash = "sha256:3cd75a683b15576cfc822c7c5742b3276e50b21a06672dc3a800a2d5da4ecd1b"},
-    {file = "cryptography-3.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:d25cecbac20713a7c3bc544372d42d8eafa89799f492a43b79e1dfd650484851"},
-    {file = "cryptography-3.2.1.tar.gz", hash = "sha256:d3d5e10be0cf2a12214ddee45c6bd203dab435e3d83b4560c03066eda600bfe3"},
+    {file = "cryptography-3.3.1-cp27-cp27m-macosx_10_10_x86_64.whl", hash = "sha256:c366df0401d1ec4e548bebe8f91d55ebcc0ec3137900d214dd7aac8427ef3030"},
+    {file = "cryptography-3.3.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:9f6b0492d111b43de5f70052e24c1f0951cb9e6022188ebcb1cc3a3d301469b0"},
+    {file = "cryptography-3.3.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:a69bd3c68b98298f490e84519b954335154917eaab52cf582fa2c5c7efc6e812"},
+    {file = "cryptography-3.3.1-cp27-cp27m-win32.whl", hash = "sha256:84ef7a0c10c24a7773163f917f1cb6b4444597efd505a8aed0a22e8c4780f27e"},
+    {file = "cryptography-3.3.1-cp27-cp27m-win_amd64.whl", hash = "sha256:594a1db4511bc4d960571536abe21b4e5c3003e8750ab8365fafce71c5d86901"},
+    {file = "cryptography-3.3.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:0003a52a123602e1acee177dc90dd201f9bb1e73f24a070db7d36c588e8f5c7d"},
+    {file = "cryptography-3.3.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:83d9d2dfec70364a74f4e7c70ad04d3ca2e6a08b703606993407bf46b97868c5"},
+    {file = "cryptography-3.3.1-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:dc42f645f8f3a489c3dd416730a514e7a91a59510ddaadc09d04224c098d3302"},
+    {file = "cryptography-3.3.1-cp36-abi3-manylinux1_x86_64.whl", hash = "sha256:788a3c9942df5e4371c199d10383f44a105d67d401fb4304178020142f020244"},
+    {file = "cryptography-3.3.1-cp36-abi3-manylinux2010_x86_64.whl", hash = "sha256:69e836c9e5ff4373ce6d3ab311c1a2eed274793083858d3cd4c7d12ce20d5f9c"},
+    {file = "cryptography-3.3.1-cp36-abi3-manylinux2014_aarch64.whl", hash = "sha256:9e21301f7a1e7c03dbea73e8602905a4ebba641547a462b26dd03451e5769e7c"},
+    {file = "cryptography-3.3.1-cp36-abi3-win32.whl", hash = "sha256:b4890d5fb9b7a23e3bf8abf5a8a7da8e228f1e97dc96b30b95685df840b6914a"},
+    {file = "cryptography-3.3.1-cp36-abi3-win_amd64.whl", hash = "sha256:0e85aaae861d0485eb5a79d33226dd6248d2a9f133b81532c8f5aae37de10ff7"},
+    {file = "cryptography-3.3.1.tar.gz", hash = "sha256:7e177e4bea2de937a584b13645cab32f25e3d96fc0bc4a4cf99c27dc77682be6"},
 ]
 dcxml = [
     {file = "dcxml-0.1.2-py2.py3-none-any.whl", hash = "sha256:36a394f09ebfbb52c2931f259873a7b4ef5468f54b0bc3df66dd0d2fd2633092"},
@@ -4107,8 +4142,8 @@ dparse = [
     {file = "dparse-0.5.1.tar.gz", hash = "sha256:a1b5f169102e1c894f9a7d5ccf6f9402a836a5d24be80a986c7ce9eaed78f367"},
 ]
 elasticsearch = [
-    {file = "elasticsearch-7.10.0-py2.py3-none-any.whl", hash = "sha256:9a21bfa7dc6a0b0dc142088bd653d8ce5ab284b4f7a3ded716185adf5276a7fe"},
-    {file = "elasticsearch-7.10.0.tar.gz", hash = "sha256:9053ca99bc9db84f5d80e124a79a32dfa0f7079b2112b546a03241c0dbeda36d"},
+    {file = "elasticsearch-7.10.1-py2.py3-none-any.whl", hash = "sha256:4ebd34fd223b31c99d9f3b6b6236d3ac18b3046191a37231e8235b06ae7db955"},
+    {file = "elasticsearch-7.10.1.tar.gz", hash = "sha256:a725dd923d349ca0652cf95d6ce23d952e2153740cf4ab6daf4a2d804feeed48"},
 ]
 elasticsearch-dsl = [
     {file = "elasticsearch-dsl-7.3.0.tar.gz", hash = "sha256:0ed75f6ff037e36b2397a8e92cae0ddde79b83adc70a154b8946064cb62f7301"},
@@ -4240,6 +4275,10 @@ ftfy = [
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
 ]
+fuzzywuzzy = [
+    {file = "fuzzywuzzy-0.18.0-py2.py3-none-any.whl", hash = "sha256:928244b28db720d1e0ee7587acf660ea49d7e4c632569cad4f1cd7e68a5f0993"},
+    {file = "fuzzywuzzy-0.18.0.tar.gz", hash = "sha256:45016e92264780e58972dca1b3d939ac864b78437422beecebb3095f8efd00e8"},
+]
 gitdb = [
     {file = "gitdb-4.0.5-py3-none-any.whl", hash = "sha256:91f36bfb1ab7949b3b40e23736db18231bf7593edada2ba5c3a174a7b23657ac"},
     {file = "gitdb-4.0.5.tar.gz", hash = "sha256:c9e1f2d0db7ddb9a704c2a0217be31214e91a4fe1dea1efad19ae42ba0c285c9"},
@@ -4261,8 +4300,8 @@ imagesize = [
     {file = "imagesize-1.2.0.tar.gz", hash = "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-3.1.1-py3-none-any.whl", hash = "sha256:6112e21359ef8f344e7178aa5b72dc6e62b38b0d008e6d3cb212c5b84df72013"},
-    {file = "importlib_metadata-3.1.1.tar.gz", hash = "sha256:b0c2d3b226157ae4517d9625decf63591461c66b3a808c2666d538946519d170"},
+    {file = "importlib_metadata-3.3.0-py3-none-any.whl", hash = "sha256:bf792d480abbd5eda85794e4afb09dd538393f7d6e6ffef6e9f03d2014cf9450"},
+    {file = "importlib_metadata-3.3.0.tar.gz", hash = "sha256:5c5a2720817414a6c41f0a49993908068243ae02c1635a228126519b509c8aed"},
 ]
 importlib-resources = [
     {file = "importlib_resources-3.3.0-py2.py3-none-any.whl", hash = "sha256:a3d34a8464ce1d5d7c92b0ea4e921e696d86f2aa212e684451cb1482c8d84ed5"},
@@ -4307,8 +4346,8 @@ invenio-cache = [
     {file = "invenio_cache-1.1.0-py2.py3-none-any.whl", hash = "sha256:a4562639f2f63cbc9de1302e159ecd9363f17d53d912a8d0773ffe76e2f153fc"},
 ]
 invenio-celery = [
-    {file = "invenio-celery-1.2.1.tar.gz", hash = "sha256:c524cb3a6b93c571cbfe35095cbafcf7f33417334cfec8057d662f2f58a6cb5b"},
-    {file = "invenio_celery-1.2.1-py2.py3-none-any.whl", hash = "sha256:1aecf48091358fa201c158e861bc7a95153ef437e5c48b9aef9d1f673e490590"},
+    {file = "invenio-celery-1.2.2.tar.gz", hash = "sha256:ac74076f0656a299ad741d6ec2752f7b06bf3b45d742179952267058c868d93d"},
+    {file = "invenio_celery-1.2.2-py2.py3-none-any.whl", hash = "sha256:f03d9d0bb0d5c3b2e1d53ded0dc8839e83d738d00913854de33cefbfa95c4d8d"},
 ]
 invenio-config = [
     {file = "invenio-config-1.0.3.tar.gz", hash = "sha256:9d10492b49a46703f0ac028ce8ab78b5ff1c72b180ecb4ffcee5bf49682d1e6c"},
@@ -4338,8 +4377,8 @@ invenio-indexer = [
     {file = "invenio-indexer-1.1.2.tar.gz", hash = "sha256:9f96a55c99761d8d9abea105fe66edd6e0ddac872444d7c9f596e5b153448e41"},
 ]
 invenio-jsonschemas = [
-    {file = "invenio-jsonschemas-1.1.0.tar.gz", hash = "sha256:79024155971ffdefa6ffa40f465f7823b47d65b69510798a2834de41fed432a7"},
-    {file = "invenio_jsonschemas-1.1.0-py2.py3-none-any.whl", hash = "sha256:e115a072e4d164ea55aac05f3ce2b535aee8aaf0838be339c4e3ed924ec1e02a"},
+    {file = "invenio-jsonschemas-1.1.1.tar.gz", hash = "sha256:6279917292ff9b1ec1686d770502571aee86d4fa109ff7daa54939ef4f494c2e"},
+    {file = "invenio_jsonschemas-1.1.1-py2.py3-none-any.whl", hash = "sha256:e0447ebb96cb7abefbc70d45cde00b49c81691b6d8336318f55b58785087b086"},
 ]
 invenio-logging = [
     {file = "invenio-logging-1.3.0.tar.gz", hash = "sha256:fc2ccf7a3da8533cec4a87353a9c48d05dcc1fc9467c4314f6779bf088cb3cbc"},
@@ -4387,8 +4426,8 @@ invenio-records-ui = [
     {file = "invenio_records_ui-1.1.0-py2.py3-none-any.whl", hash = "sha256:20480d8c4b5ec8f6378f859ee74b57429c3de3d4688534b75b4925ad32f5afaa"},
 ]
 invenio-rest = [
-    {file = "invenio-rest-1.2.2.tar.gz", hash = "sha256:9b1593ffad4e3fbbb5ee8c1414a4e2d048e3996c9e669119f753939dbc04cad7"},
-    {file = "invenio_rest-1.2.2-py2.py3-none-any.whl", hash = "sha256:048d65e6e858937f6d70038d5ffc03f69bb6b70aa6cb286b7dfe16f00de7777e"},
+    {file = "invenio-rest-1.2.3.tar.gz", hash = "sha256:1ca669cffac3ce9c795f6a0d4669460e2b2369b01abaaf71792872714e42a3f5"},
+    {file = "invenio_rest-1.2.3-py2.py3-none-any.whl", hash = "sha256:bce36d4b09894942b7756855c8159854d6f1ce550fefa5d78bedc6998933678f"},
 ]
 invenio-search = [
     {file = "invenio-search-1.3.1.tar.gz", hash = "sha256:37f222b6d6649df5fac5731225784d57f588c933843d14a8807e4e4ab3c5adc5"},
@@ -4576,32 +4615,52 @@ mistune = [
     {file = "mistune-0.8.4.tar.gz", hash = "sha256:59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e"},
 ]
 mock = [
-    {file = "mock-4.0.2-py3-none-any.whl", hash = "sha256:3f9b2c0196c60d21838f307f5825a7b86b678cedc58ab9e50a8988187b4d81e0"},
-    {file = "mock-4.0.2.tar.gz", hash = "sha256:dd33eb70232b6118298d516bbcecd26704689c386594f0f3c4f13867b2c56f72"},
+    {file = "mock-4.0.3-py3-none-any.whl", hash = "sha256:122fcb64ee37cfad5b3f48d7a7d51875d7031aaf3d8be7c42e2bee25044eee62"},
+    {file = "mock-4.0.3.tar.gz", hash = "sha256:7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2f82554bac7bc"},
 ]
 more-itertools = [
     {file = "more-itertools-8.6.0.tar.gz", hash = "sha256:b3a9005928e5bed54076e6e549c792b306fddfe72b2d1d22dd63d42d5d3899cf"},
     {file = "more_itertools-8.6.0-py3-none-any.whl", hash = "sha256:8e1a2a43b2f2727425f2b5839587ae37093f19153dc26c0927d1048ff6557330"},
 ]
 msgpack = [
-    {file = "msgpack-1.0.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:cec8bf10981ed70998d98431cd814db0ecf3384e6b113366e7f36af71a0fca08"},
-    {file = "msgpack-1.0.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:aa5c057eab4f40ec47ea6f5a9825846be2ff6bf34102c560bad5cad5a677c5be"},
-    {file = "msgpack-1.0.0-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:4233b7f86c1208190c78a525cd3828ca1623359ef48f78a6fea4b91bb995775a"},
-    {file = "msgpack-1.0.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:b3758dfd3423e358bbb18a7cccd1c74228dffa7a697e5be6cb9535de625c0dbf"},
-    {file = "msgpack-1.0.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:25b3bc3190f3d9d965b818123b7752c5dfb953f0d774b454fd206c18fe384fb8"},
-    {file = "msgpack-1.0.0-cp36-cp36m-win32.whl", hash = "sha256:e7bbdd8e2b277b77782f3ce34734b0dfde6cbe94ddb74de8d733d603c7f9e2b1"},
-    {file = "msgpack-1.0.0-cp36-cp36m-win_amd64.whl", hash = "sha256:5dba6d074fac9b24f29aaf1d2d032306c27f04187651511257e7831733293ec2"},
-    {file = "msgpack-1.0.0-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:908944e3f038bca67fcfedb7845c4a257c7749bf9818632586b53bcf06ba4b97"},
-    {file = "msgpack-1.0.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:db685187a415f51d6b937257474ca72199f393dad89534ebbdd7d7a3b000080e"},
-    {file = "msgpack-1.0.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ea41c9219c597f1d2bf6b374d951d310d58684b5de9dc4bd2976db9e1e22c140"},
-    {file = "msgpack-1.0.0-cp37-cp37m-win32.whl", hash = "sha256:e35b051077fc2f3ce12e7c6a34cf309680c63a842db3a0616ea6ed25ad20d272"},
-    {file = "msgpack-1.0.0-cp37-cp37m-win_amd64.whl", hash = "sha256:5bea44181fc8e18eed1d0cd76e355073f00ce232ff9653a0ae88cb7d9e643322"},
-    {file = "msgpack-1.0.0-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c901e8058dd6653307906c5f157f26ed09eb94a850dddd989621098d347926ab"},
-    {file = "msgpack-1.0.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:271b489499a43af001a2e42f42d876bb98ccaa7e20512ff37ca78c8e12e68f84"},
-    {file = "msgpack-1.0.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7a22c965588baeb07242cb561b63f309db27a07382825fc98aecaf0827c1538e"},
-    {file = "msgpack-1.0.0-cp38-cp38-win32.whl", hash = "sha256:002a0d813e1f7b60da599bdf969e632074f9eec1b96cbed8fb0973a63160a408"},
-    {file = "msgpack-1.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:39c54fdebf5fa4dda733369012c59e7d085ebdfe35b6cf648f09d16708f1be5d"},
-    {file = "msgpack-1.0.0.tar.gz", hash = "sha256:9534d5cc480d4aff720233411a1f765be90885750b07df772380b34c10ecb5c0"},
+    {file = "msgpack-1.0.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:4bea1938e484c9caca9585105f447d6807c496c153b7244fa726b3cc4a68ec9e"},
+    {file = "msgpack-1.0.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:2966b155356fd231fa441131d7301e1596ee38974ad56dc57fd752fdbe2bb63f"},
+    {file = "msgpack-1.0.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:c82fc6cdba5737eb6ed0c926a30a5d56e7b050297375a16d6c5ad89b576fd979"},
+    {file = "msgpack-1.0.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:e157edf4213dacafb0f862e0b7a3a18448250cec91aa1334f432f49028acc650"},
+    {file = "msgpack-1.0.1-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:35ff1ac162a77fb78be360d9f771d36cbf1202e94fc6d70e284ad5db6ab72608"},
+    {file = "msgpack-1.0.1-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:bf8eedc7bfbf63cbc9abe58287c32d78780a347835e82c23033c68f11f80bb05"},
+    {file = "msgpack-1.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:03c5554315317d76c25a15569dd52ac6047b105df71e861f24faf9675672b72d"},
+    {file = "msgpack-1.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1d7ab166401f7789bf11262439336c0a01b878f0d602e48f35c35d2e3a555820"},
+    {file = "msgpack-1.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:7b50afd767cc053ad92fad39947c3670db27305fd1c49acded44d9d9ac8b56fd"},
+    {file = "msgpack-1.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:99ea9e65876546743b2b8bb5bc7adefbb03b9da78a899827467da197a48f790b"},
+    {file = "msgpack-1.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:0968b368a9a9081435bfcb7a57a1e8b75c7bf038ef911b369acd2e038c7f873a"},
+    {file = "msgpack-1.0.1-cp36-cp36m-win32.whl", hash = "sha256:decf2091b75987ca2564e3b742f9614eb7d57e39ff04eaa68af7a3fc5648f7ed"},
+    {file = "msgpack-1.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:c4e5f96a1d0d916ce7a16decb7499e8923ddef007cf7d68412fb68767766648a"},
+    {file = "msgpack-1.0.1-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:d113c6b1239c62669ef3063693842605a3edbfebc39a333cf91ba60d314afe6d"},
+    {file = "msgpack-1.0.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:69f6aa503378548ea1e760c11aeb6fc91952bf3634fd806a38a0e47edb507fcd"},
+    {file = "msgpack-1.0.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ce4ebe2c79411cd5671b20862831880e7850a2de699cff6626f48853fde61ae6"},
+    {file = "msgpack-1.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d76672602db16e3f44bc1a85c7ee5f15d79e02fcf5bc9d133c2954753be6eddc"},
+    {file = "msgpack-1.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:b5b27923b6c98a2616b7e906a29e4e10e1b4424aea87a0e0d5636327dc6ea315"},
+    {file = "msgpack-1.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:20196229acc193939223118c7420838749d5b0cece49cd397739a3a6ffcfe2d1"},
+    {file = "msgpack-1.0.1-cp37-cp37m-win32.whl", hash = "sha256:c60e8b2bf754b8dcc1075c5bee0b177ed9193e7cbd2377faaf507120a948e697"},
+    {file = "msgpack-1.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:29a6fb3729215b6fcab786ef4f460a5406a5c056f7021191f70ff7712a3f6ba4"},
+    {file = "msgpack-1.0.1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:e13b9007af66a3f62574bc0a13843df0e4402f5ee4b00a02aa1803f01d26b9fb"},
+    {file = "msgpack-1.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:d3cea07ad16919a44e8d1ea67efa5244855cdce807d672f41694acc24d08834e"},
+    {file = "msgpack-1.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:1e8d27bac821f8aa909904a704a67e5e8bc2e42b153415fc3621b7afbc06702b"},
+    {file = "msgpack-1.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:35cbefa7d7bddfb4b0770a1b9ff721cd8dfe9a680947a68457974d5e3e6acc2f"},
+    {file = "msgpack-1.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:2933443313289725f16bd7b99a8c3aa6a2cca1549e661d7407f056a0af80bf7b"},
+    {file = "msgpack-1.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:f20d7d4f1f0728560408ba6933154abccf0c20f24642a2404b43d5c23e4119ab"},
+    {file = "msgpack-1.0.1-cp38-cp38-win32.whl", hash = "sha256:b107f9b36665bf7d7c6176a938a361a7aba16aa179d833919448f77287866484"},
+    {file = "msgpack-1.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:e234ff83628ca3ab345bf97fb36ccbf6d2f1700f5e08868643bf4489edc960f8"},
+    {file = "msgpack-1.0.1-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:abcc62303ac4d789878d4aac4cdba1bbe2adb478d67be99cd4a6d56ac3a4028f"},
+    {file = "msgpack-1.0.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:4e58b9f4a99bc3a90859bb006ec4422448a5ce39e5cd6e7498c56de5dcec9c34"},
+    {file = "msgpack-1.0.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:1fc9f21da9fd77088ebfd3c9941b044ca3f4a048e85f7ff5727f26bcdbffed61"},
+    {file = "msgpack-1.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:40dd1ac7420f071e96b3e4a4a7b8e69546a6f8065ff5995dbacf53f86207eb98"},
+    {file = "msgpack-1.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:66d47e952856bfcde46d8351380d0b5b928a73112b66bc06d5367dfcc077c06a"},
+    {file = "msgpack-1.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:01835e300967e5ad6fdbfc36eafe74df67ff47e16e0d6dee8766630550315903"},
+    {file = "msgpack-1.0.1-cp39-cp39-win32.whl", hash = "sha256:f08d9dd3ce0c5e972dc4653f0fb66d2703941e65356388c13032b578dd718261"},
+    {file = "msgpack-1.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:c144ff4954a6ea40aa603600c8be175349588fc68696092889fa34ab6e055060"},
+    {file = "msgpack-1.0.1.tar.gz", hash = "sha256:7033215267a0e9f60f4a5e4fb2228a932c404f237817caff8dc3115d9e7cd975"},
 ]
 nbconvert = [
     {file = "nbconvert-5.6.1-py2.py3-none-any.whl", hash = "sha256:f0d6ec03875f96df45aa13e21fd9b8450c42d7e1830418cccc008c0df725fcee"},
@@ -4626,8 +4685,8 @@ orcid = [
     {file = "orcid-1.0.3.tar.gz", hash = "sha256:5fe28b6d92aed5abe7145c959e4fa2afb90260be215ff3f36ad31c94ee41d0db"},
 ]
 packaging = [
-    {file = "packaging-20.7-py2.py3-none-any.whl", hash = "sha256:eb41423378682dadb7166144a4926e443093863024de508ca5c9737d6bc08376"},
-    {file = "packaging-20.7.tar.gz", hash = "sha256:05af3bb85d320377db281cf254ab050e1a7ebcbf5410685a9a407e18a1f81236"},
+    {file = "packaging-20.8-py2.py3-none-any.whl", hash = "sha256:24e0da08660a87484d1602c30bb4902d74816b6985b93de36926f5bc95741858"},
+    {file = "packaging-20.8.tar.gz", hash = "sha256:78598185a7008a470d64526a8059de9aaa449238f280fc9eb6b13ba6c4109093"},
 ]
 pandocfilters = [
     {file = "pandocfilters-1.4.3.tar.gz", hash = "sha256:bc63fbb50534b4b1f8ebe1860889289e8af94a23bff7445259592df25a3906eb"},
@@ -4736,8 +4795,8 @@ ptyprocess = [
     {file = "ptyprocess-0.6.0.tar.gz", hash = "sha256:923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0"},
 ]
 py = [
-    {file = "py-1.9.0-py2.py3-none-any.whl", hash = "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2"},
-    {file = "py-1.9.0.tar.gz", hash = "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"},
+    {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
+    {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
 ]
 pycountry = [
     {file = "pycountry-20.7.3.tar.gz", hash = "sha256:81084a53d3454344c0292deebc20fcd0a1488c136d4900312cbd465cf552cb42"},
@@ -4751,8 +4810,8 @@ pydocstyle = [
     {file = "pydocstyle-5.1.1.tar.gz", hash = "sha256:19b86fa8617ed916776a11cd8bc0197e5b9856d5433b777f51a3defe13075325"},
 ]
 pygments = [
-    {file = "Pygments-2.7.2-py3-none-any.whl", hash = "sha256:88a0bbcd659fcb9573703957c6b9cff9fab7295e6e76db54c9d00ae42df32773"},
-    {file = "Pygments-2.7.2.tar.gz", hash = "sha256:381985fcc551eb9d37c52088a32914e00517e57f4a21609f48141ba08e193fa0"},
+    {file = "Pygments-2.7.3-py3-none-any.whl", hash = "sha256:f275b6c0909e5dafd2d6269a656aa90fa58ebf4a74f8fcf9053195d226b24a08"},
+    {file = "Pygments-2.7.3.tar.gz", hash = "sha256:ccf3acacf3782cbed4a989426012f1c535c9a90d3a7fc3f16d231b9372d2b716"},
 ]
 pyjwt = [
     {file = "PyJWT-1.7.1-py2.py3-none-any.whl", hash = "sha256:5c6eca3c2940464d106b99ba83b00c6add741c9becaec087fb7ccdefea71350e"},
@@ -4775,10 +4834,6 @@ pytest = [
 ]
 pytest-cache = [
     {file = "pytest-cache-1.0.tar.gz", hash = "sha256:be7468edd4d3d83f1e844959fd6e3fd28e77a481440a7118d430130ea31b07a9"},
-]
-pytest-celery = [
-    {file = "pytest-celery-0.0.0a1.tar.gz", hash = "sha256:3e0e0817c2d3f2870dafebd915bf13100fc12920b5d42dfe5fdc35844fe42e62"},
-    {file = "pytest_celery-0.0.0a1-py2.py3-none-any.whl", hash = "sha256:2fa8d0ae0d573fb2ee51902bfa220e891044eafadbfb132b28b7087295c3004f"},
 ]
 pytest-cov = [
     {file = "pytest-cov-2.10.1.tar.gz", hash = "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"},
@@ -4821,6 +4876,9 @@ python-editor = [
     {file = "python_editor-1.0.4-py2.7.egg", hash = "sha256:ea87e17f6ec459e780e4221f295411462e0d0810858e055fc514684350a2f522"},
     {file = "python_editor-1.0.4-py3-none-any.whl", hash = "sha256:1bf6e860a8ad52a14c3ee1252d5dc25b2030618ed80c022598f00176adc8367d"},
     {file = "python_editor-1.0.4-py3.5.egg", hash = "sha256:c3da2053dbab6b29c94e43c486ff67206eafbe7eb52dbec7390b5e2fb05aac77"},
+]
+python-levenshtein = [
+    {file = "python-Levenshtein-0.12.0.tar.gz", hash = "sha256:033a11de5e3d19ea25c9302d11224e1a1898fe5abd23c61c7c360c25195e3eb1"},
 ]
 python-slugify = [
     {file = "python-slugify-4.0.1.tar.gz", hash = "sha256:69a517766e00c1268e5bbfc0d010a0a8508de0b18d30ad5a1ff357f8ae724270"},
@@ -4918,8 +4976,8 @@ selenium = [
     {file = "selenium-3.141.0.tar.gz", hash = "sha256:deaf32b60ad91a4611b98d8002757f29e6f2c2d5fcaf202e1c9ad06d6772300d"},
 ]
 sentry-sdk = [
-    {file = "sentry-sdk-0.19.4.tar.gz", hash = "sha256:1052f0ed084e532f66cb3e4ba617960d820152aee8b93fc6c05bd53861768c1c"},
-    {file = "sentry_sdk-0.19.4-py2.py3-none-any.whl", hash = "sha256:4c42910a55a6b1fe694d5e4790d5188d105d77b5a6346c1c64cbea8c06c0e8b7"},
+    {file = "sentry-sdk-0.19.5.tar.gz", hash = "sha256:737a094e49a529dd0fdcaafa9e97cf7c3d5eb964bd229821d640bc77f3502b3f"},
+    {file = "sentry_sdk-0.19.5-py2.py3-none-any.whl", hash = "sha256:0a711ec952441c2ec89b8f5d226c33bc697914f46e876b44a4edd3e7864cf4d0"},
 ]
 sickle = [
     {file = "Sickle-0.7.0-py3-none-any.whl", hash = "sha256:6ace7b1d1fc76571fe0dbfefc2c49e5e6c026e2d0dcaae521f4da21e98d4bc85"},
@@ -4990,8 +5048,8 @@ snowballstemmer = [
     {file = "snowballstemmer-2.0.0.tar.gz", hash = "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"},
 ]
 soupsieve = [
-    {file = "soupsieve-2.0.1-py3-none-any.whl", hash = "sha256:1634eea42ab371d3d346309b93df7870a88610f0725d47528be902a0d95ecc55"},
-    {file = "soupsieve-2.0.1.tar.gz", hash = "sha256:a59dc181727e95d25f781f0eb4fd1825ff45590ec8ff49eadfd7f1a537cc0232"},
+    {file = "soupsieve-2.1-py3-none-any.whl", hash = "sha256:4bb21a6ee4707bf43b61230e80740e71bfe56e55d1f1f50924b087bb2975c851"},
+    {file = "soupsieve-2.1.tar.gz", hash = "sha256:6dc52924dc0bc710a5d16794e6b3480b2c7c08b07729505feab2b2c16661ff6e"},
 ]
 speaklater = [
     {file = "speaklater-1.3.tar.gz", hash = "sha256:59fea336d0eed38c1f0bf3181ee1222d0ef45f3a9dd34ebe65e6bfffdd6a65a9"},
@@ -5101,6 +5159,11 @@ transifex-client = [
     {file = "transifex-client-0.12.5.tar.gz", hash = "sha256:23c88c55d1469b62a771646d4f202b6fe5f4abbcdbe61bda3a3b08c44aaa7a78"},
     {file = "transifex_client-0.12.5-py2-none-any.whl", hash = "sha256:139867ffaf340aa2b74b0c44fa2d6525bf641357d04b7961a5b10ebe468678d8"},
     {file = "transifex-client-0.14.2.tar.gz", hash = "sha256:b458c56d6d07d2d8269b43d5049026304ed9a34d31bdf655d9e1864807e7555b"},
+]
+typing-extensions = [
+    {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
+    {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
+    {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
 ]
 ua-parser = [
     {file = "ua-parser-0.10.0.tar.gz", hash = "sha256:47b1782ed130d890018d983fac37c2a80799d9e0b9c532e734c67cf70f185033"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ netaddr = "*"
 dcxml = "*"
 lxml = ">=4.6.2"
 webdavclient3 = "^3.14.5"
+fuzzywuzzy = "^0.18.0"
+python-Levenshtein = "^0.12.0"
 
 [tool.poetry.dev-dependencies]
 Flask-Debugtoolbar = ">=0.10.1"

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -90,6 +90,7 @@ cp ${assets_folder}/node_modules/pdfjs-dist/build/pdf.worker.min.js ${static_fol
 section "Compile JSON schemas" "info"
 invenio utils compile-json ./sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json -o ./sonar/modules/documents/jsonschemas/documents/document-v1.0.0.json
 invenio utils compile-json ./sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json -o ./sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0.json
+invenio utils compile-json ./sonar/modules/projects/jsonschemas/projects/project-v1.0.0_src.json -o ./sonar/modules/projects/jsonschemas/projects/project-v1.0.0.json
 
 # Compile translations catalogs
 section "Compile translations catalogs" "info"

--- a/setup.py
+++ b/setup.py
@@ -101,13 +101,15 @@ setup(
             'organisations = sonar.modules.organisations.jsonschemas',
             'users = sonar.modules.users.jsonschemas',
             'deposits = sonar.modules.deposits.jsonschemas',
+            'projects = sonar.modules.projects.jsonschemas',
             'common = sonar.common.jsonschemas'
         ],
         'invenio_search.mappings': [
             'documents = sonar.modules.documents.mappings',
             'organisations = sonar.modules.organisations.mappings',
             'users = sonar.modules.users.mappings',
-            'deposits = sonar.modules.deposits.mappings'
+            'deposits = sonar.modules.deposits.mappings',
+            'projects = sonar.modules.projects.mappings'
         ],
         'invenio_search.templates': [
             'base-record = sonar.es_templates:list_es_templates'
@@ -120,7 +122,9 @@ setup(
             'user_id = \
                 sonar.modules.users.api:user_pid_minter',
             'deposit_id = \
-                sonar.modules.deposits.api:deposit_pid_minter'
+                sonar.modules.deposits.api:deposit_pid_minter',
+            'project_id = \
+                sonar.modules.projects.api:project_pid_minter'
         ],
         'invenio_pidstore.fetchers': [
             'document_id = \
@@ -130,12 +134,15 @@ setup(
             'user_id = \
                 sonar.modules.users.api:user_pid_fetcher',
             'deposit_id = \
-                sonar.modules.deposits.api:deposit_pid_fetcher'
+                sonar.modules.deposits.api:deposit_pid_fetcher',
+            'project_id = \
+                sonar.modules.projects.api:project_pid_fetcher'
         ],
         "invenio_records.jsonresolver": [
             "organisation = sonar.modules.organisations.jsonresolvers",
             "user = sonar.modules.users.jsonresolvers",
-            "document = sonar.modules.documents.jsonresolvers"
+            "document = sonar.modules.documents.jsonresolvers",
+            "project = sonar.modules.projects.jsonresolvers"
         ],
         'invenio_celery.tasks' : [
             'documents = sonar.modules.documents.tasks'

--- a/sonar/affiliations/__init__.py
+++ b/sonar/affiliations/__init__.py
@@ -11,11 +11,14 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-[pytest]
-pep8ignore = docs/conf.py ALL
-addopts = --pep8 --doctest-glob="*.rst" --doctest-modules --cov=sonar --cov-report=term-missing --ignore=setup.py -p celery.contrib.pytest
-testpaths = docs tests sonar
-; Not displaying all the PendingDeprecationWarnings from invenio
-filterwarnings =
-    ignore::PendingDeprecationWarning
+"""Affiliations."""
+
+from __future__ import absolute_import, print_function
+
+from .affiliation_resolver import AffiliationResolver
+
+__all__ = ('AffiliationResolver', )

--- a/sonar/affiliations/affiliation_resolver.py
+++ b/sonar/affiliations/affiliation_resolver.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Affiliations resolver."""
+
+import csv
+
+from fuzzywuzzy import fuzz
+from werkzeug.utils import cached_property
+
+CSV_FILE = './data/affiliations.csv'
+
+
+class AffiliationResolver():
+    """Affiliation resolver."""
+
+    @cached_property
+    def affiliations(self):
+        """List of affiliations retrieved from a dedicated file.
+
+        :returns: List of affliations
+        """
+        affiliations = []
+
+        with open(CSV_FILE, 'r') as file:
+            reader = csv.reader(file, delimiter='\t')
+            for row in reader:
+                affiliation = []
+                for index, value in enumerate(row):
+                    if index > 0 and value:
+                        affiliation.append(value)
+
+                if affiliation:
+                    affiliations.append(affiliation)
+
+        return affiliations
+
+    def resolve(self, searched_affiliation):
+        """Resolve affiliations from given parameter.
+
+        :param searched_affiliation: Affiliation to match.
+        :returns: String of matching affiliation.
+        """
+        if not searched_affiliation:
+            return None
+
+        for affiliations in self.affiliations:
+            for affiliation in affiliations:
+                if fuzz.partial_ratio(searched_affiliation, affiliation) > 90:
+                    return affiliations[0]
+
+        return None

--- a/sonar/common/jsonschemas/identifiedby-v1.0.0.json
+++ b/sonar/common/jsonschemas/identifiedby-v1.0.0.json
@@ -1,0 +1,53 @@
+{
+  "title": "Identifier",
+  "description": "Identifier",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "title": "Type",
+      "type": "string",
+      "enum": [
+        "bf:Identifier",
+        "bf:Local"
+      ],
+      "form": {
+        "options": [
+          {
+            "label": "bf:Identifier",
+            "value": "bf:Identifier"
+          },
+          {
+            "label": "bf:Local",
+            "value": "bf:Local"
+          }
+        ]
+      }
+    },
+    "source": {
+      "title": "Source",
+      "type": "string",
+      "minLength": 1,
+      "form": {
+        "hideExpression": "!model || model.type !== 'bf:Local'",
+        "expressionProperties": {
+          "templateOptions.required": "model && model.type === 'bf:Local'"
+        }
+      }
+    },
+    "value": {
+      "title": "Value",
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "propertiesOrder": [
+    "type",
+    "source",
+    "value"
+  ],
+  "required": [
+    "type",
+    "value"
+  ]
+}

--- a/sonar/config.py
+++ b/sonar/config.py
@@ -40,6 +40,8 @@ from sonar.modules.organisations.api import OrganisationRecord, \
 from sonar.modules.organisations.permissions import OrganisationPermission
 from sonar.modules.permissions import record_permission_factory, \
     wiki_edit_permission
+from sonar.modules.projects.api import ProjectRecord, ProjectSearch
+from sonar.modules.projects.permissions import ProjectPermission
 from sonar.modules.query import and_term_filter, missing_field_filter
 from sonar.modules.users.api import UserRecord, UserSearch
 from sonar.modules.users.permissions import UserPermission
@@ -441,6 +443,45 @@ RECORDS_REST_ENDPOINTS = {
             action='delete', record=record, cls=DepositPermission),
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=DepositPermission)),
+    'proj':
+    dict(
+        pid_type='proj',
+        pid_minter='project_id',
+        pid_fetcher='project_id',
+        default_endpoint_prefix=True,
+        record_class=ProjectRecord,
+        search_class=ProjectSearch,
+        indexer_class='sonar.modules.projects.api:ProjectIndexer',
+        search_index='projects',
+        search_type=None,
+        record_serializers={
+            'application/json': ('sonar.modules.projects.serializers'
+                                 ':json_v1_response'),
+        },
+        search_serializers={
+            'application/json': ('sonar.modules.projects.serializers'
+                                 ':json_v1_search'),
+        },
+        record_loaders={
+            'application/json': ('sonar.modules.projects.loaders'
+                                 ':json_v1'),
+        },
+        list_route='/projects/',
+        item_route='/projects/<pid(proj, record_class="sonar.modules.projects'
+        '.api:ProjectRecord"):pid_value>',
+        default_media_type='application/json',
+        max_result_window=10000,
+        search_factory_imp='sonar.modules.projects.query:search_factory',
+        create_permission_factory_imp=lambda record: record_permission_factory(
+            action='create', cls=ProjectPermission),
+        read_permission_factory_imp=lambda record: record_permission_factory(
+            action='read', record=record, cls=ProjectPermission),
+        update_permission_factory_imp=lambda record: record_permission_factory(
+            action='update', record=record, cls=ProjectPermission),
+        delete_permission_factory_imp=lambda record: record_permission_factory(
+            action='delete', record=record, cls=ProjectPermission),
+        list_permission_factory_imp=lambda record: record_permission_factory(
+            action='list', record=record, cls=ProjectPermission)),
 }
 """REST endpoints."""
 
@@ -520,11 +561,31 @@ RECORDS_REST_FACETS = {
         'filters': {
             'missing_organisation': missing_field_filter('organisation')
         }
+    },
+    'projects': {
+        'aggs': {
+            'user': {
+                'terms': {
+                    'field': 'user.full_name',
+                    'size': DEFAULT_AGGREGATION_SIZE
+                }
+            },
+            'organisation': {
+                'terms': {
+                    'field': 'organisation.pid',
+                    'size': DEFAULT_AGGREGATION_SIZE
+                }
+            }
+        },
+        'filters': {
+            'user': and_term_filter('user.full_name'),
+            'organisation': and_term_filter('organisation.pid')
+        }
     }
 }
 """REST search facets."""
 
-INDEXES = ['documents', 'organisations', 'users', 'deposits']
+INDEXES = ['documents', 'organisations', 'users', 'deposits', 'projects']
 
 RECORDS_REST_SORT_OPTIONS = {}
 for index in INDEXES:

--- a/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
+++ b/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
@@ -380,7 +380,6 @@
                       "value": "bf:AudioIssueNumber",
                       "group": "------------"
                     },
-
                     {
                       "label": "bf:Ean",
                       "value": "bf:Ean",
@@ -839,10 +838,198 @@
             "minLength": 1,
             "pattern": "^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$",
             "form": {
-              "placeholder": "Example: 1111-2222-3333-4444"
+              "templateOptions": {
+                "placeholder": "Example: 1111-2222-3333-4444"
+              }
             }
           }
         }
+      }
+    },
+    "projects": {
+      "title": "Research projects",
+      "type": "array",
+      "default": [{}],
+      "minItems": 0,
+      "items": {
+        "title": "Research project",
+        "type": "object",
+        "additionnalProperties": false,
+        "oneOf": [
+          {
+            "title": "Existing project",
+            "properties": {
+              "$ref": {
+                "title": "Project",
+                "type": "string",
+                "pattern": "^https://sonar.ch/api/projects/.*?$",
+                "form": {
+                  "remoteTypeahead": {
+                    "type": "projects",
+                    "field": "autocomplete_name",
+                    "label": "name"
+                  }
+                }
+              }
+            },
+            "required": [
+              "$ref"
+            ]
+          },
+          {
+            "title": "Add a new project",
+            "properties": {
+              "name": {
+                "title": "Name",
+                "type": "string",
+                "minLength": 1
+              },
+              "description": {
+                "title": "Description",
+                "type": "string",
+                "minLength": 1,
+                "form": {
+                  "type": "textarea",
+                  "templateOptions": {
+                    "rows": 5
+                  }
+                }
+              },
+              "startDate": {
+                "title": "Start date",
+                "description": "Example: 2019-05-05",
+                "type": "string",
+                "format": "date",
+                "pattern": "^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$"
+              },
+              "endDate": {
+                "title": "End date",
+                "description": "Example: 2019-05-05",
+                "type": "string",
+                "format": "date",
+                "pattern": "^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$"
+              },
+              "identifier": {
+                "title": "Identifier",
+                "type": "string",
+                "minLength": 1
+              },
+              "investigators": {
+                "title": "Investigators",
+                "type": "array",
+                "items": {
+                  "title": "Investigator",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "title": "Name",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "role": {
+                      "title": "Role",
+                      "type": "string",
+                      "enum": [
+                        "investigator",
+                        "coinvestigator"
+                      ],
+                      "form": {
+                        "options": [
+                          {
+                            "label": "investigator",
+                            "value": "investigator"
+                          },
+                          {
+                            "label": "coinvestigator",
+                            "value": "coinvestigator"
+                          }
+                        ]
+                      }
+                    },
+                    "affiliation": {
+                      "title": "Affiliation",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "orcid": {
+                      "title": "ORCID",
+                      "type": "string",
+                      "minLength": 1,
+                      "pattern": "^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$",
+                      "form": {
+                        "templateOptions": {
+                          "placeholder": "Example: 1111-2222-3333-4444"
+                        }
+                      }
+                    }
+                  },
+                  "propertiesOrder": [
+                    "name",
+                    "role",
+                    "affiliation",
+                    "orcid"
+                  ],
+                  "required": [
+                    "name",
+                    "role"
+                  ]
+                },
+                "form": {
+                  "templateOptions": {
+                    "cssClass": "editor-title"
+                  }
+                }
+              },
+              "funding_organisations": {
+                "title": "Funding organisations",
+                "type": "array",
+                "items": {
+                  "title": "Funding organisation",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "title": "Name",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "identifier": {
+                      "title": "Identifier",
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "propertiesOrder": [
+                    "name",
+                    "identifier"
+                  ],
+                  "required": [
+                    "name"
+                  ]
+                },
+                "form": {
+                  "templateOptions": {
+                    "cssClass": "editor-title"
+                  }
+                }
+              }
+            },
+            "propertiesOrder": [
+              "name",
+              "description",
+              "startDate",
+              "endDate",
+              "identifier",
+              "investigators",
+              "funding_organisations"
+            ],
+            "required": [
+              "name",
+              "startDate"
+            ]
+          }
+        ]
       }
     },
     "diffusion": {
@@ -853,7 +1040,9 @@
           "$ref": "license-v1.0.0.json"
         }
       },
-      "required": ["license"]
+      "required": [
+        "license"
+      ]
     },
     "document": {
       "title": "Document",

--- a/sonar/modules/deposits/marshmallow/json.py
+++ b/sonar/modules/deposits/marshmallow/json.py
@@ -46,6 +46,7 @@ class DepositMetadataSchemaV1(StrictKeysMixin):
     status = SanitizedUnicode()
     step = SanitizedUnicode()
     user = fields.Dict()
+    projects = fields.List(fields.Dict())
     _files = fields.List(fields.Dict())
     _bucket = SanitizedUnicode()
     # When loading, if $schema is not provided, it's retrieved by

--- a/sonar/modules/documents/dojson/rerodoc/model.py
+++ b/sonar/modules/documents/dojson/rerodoc/model.py
@@ -702,9 +702,6 @@ def marc21_to_contribution_field_100(self, key, value):
     # Affiliation
     if value.get('u'):
         data['affiliation'] = value.get('u')
-        affiliations = DocumentRecord.get_affiliations(value.get('u'))
-        if affiliations:
-            data['controlledAffiliation'] = affiliations
 
     # Date of birth - date of death
     date_of_birth, date_of_death = overdo.extract_date(value.get('d'))
@@ -748,9 +745,6 @@ def marc21_to_contribution_field_700(self, key, value):
     # Affiliation
     if value.get('u'):
         data['affiliation'] = value.get('u')
-        affiliations = DocumentRecord.get_affiliations(value.get('u'))
-        if affiliations:
-            data['controlledAffiliation'] = affiliations
 
     # Date of birth - date of death
     date_of_birth, date_of_death = overdo.extract_date(value.get('d'))

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -1197,8 +1197,13 @@
           "minLength": 1
         }
       },
-      "propertiesOrder": ["license", "label"],
-      "required": ["license"],
+      "propertiesOrder": [
+        "license",
+        "label"
+      ],
+      "required": [
+        "license"
+      ],
       "form": {
         "hide": true,
         "templateOptions": {
@@ -1264,14 +1269,14 @@
                     "title": "Type",
                     "type": "string",
                     "enum": [
-                      "bf:Doi",
+                      "bf:Identifier",
                       "bf:Local"
                     ],
                     "form": {
                       "options": [
                         {
-                          "label": "bf:Doi",
-                          "value": "bf:Doi"
+                          "label": "bf:Identifier",
+                          "value": "bf:Identifier"
                         },
                         {
                           "label": "bf:Local",
@@ -1283,7 +1288,13 @@
                   "source": {
                     "title": "Source",
                     "type": "string",
-                    "minLength": 1
+                    "minLength": 1,
+                    "form": {
+                      "hideExpression": "model && model.type !== 'bf:Local'",
+                      "expressionProperties": {
+                        "templateOptions.required": "model && model.type === 'bf:Local'"
+                      }
+                    }
                   },
                   "value": {
                     "title": "Value",
@@ -1291,6 +1302,7 @@
                     "minLength": 1
                   }
                 },
+                "propertiesOrder": ["type", "source", "value"],
                 "form": {
                   "hideExpression": "field.parent.model.type !== 'bf:Person'"
                 }
@@ -1553,12 +1565,48 @@
           "cssClass": "editor-title"
         }
       }
+    },
+    "projects": {
+      "title": "Research projects",
+      "type": "array",
+      "minItems": 0,
+      "items": {
+        "title": "Research project",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "$ref": {
+            "type": "string",
+            "pattern": "^https://sonar.ch/api/projects/.*?$",
+            "form": {
+              "remoteTypeahead": {
+                "type": "projects",
+                "field": "autocomplete_name",
+                "label": "name"
+              }
+            }
+          }
+        },
+        "required": [
+          "$ref"
+        ]
+      },
+      "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        },
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
+      }
     }
   },
   "propertiesOrder": [
     "documentType",
     "title",
     "organisation",
+    "projects",
     "classification",
     "language",
     "abstracts",

--- a/sonar/modules/documents/mappings/v7/documents/document-v1.0.0.json
+++ b/sonar/modules/documents/mappings/v7/documents/document-v1.0.0.json
@@ -452,6 +452,43 @@
           }
         }
       },
+      "projects": {
+        "type": "object",
+        "properties": {
+          "pid": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "text"
+          },
+          "investigators": {
+            "type": "object",
+            "properties": {
+              "agent": {
+                "type": "object",
+                "properties": {
+                  "preferred_name": {
+                    "type": "text"
+                  }
+                }
+              }
+            }
+          },
+          "funding_organisations": {
+            "type": "object",
+            "properties": {
+              "agent": {
+                "type": "object",
+                "properties": {
+                  "preferred_name": {
+                    "type": "text"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "_created": {
         "type": "date"
       },

--- a/sonar/modules/documents/marshmallow/json.py
+++ b/sonar/modules/documents/marshmallow/json.py
@@ -98,6 +98,7 @@ class DocumentMetadataSchemaV1(StrictKeysMixin):
     dissertation = fields.Dict()
     otherEdition = fields.List(fields.Dict())
     usageAndAccessPolicy = fields.Dict()
+    projects = fields.List(fields.Dict())
     _bucket = SanitizedUnicode()
     _files = Nested(FileSchemaV1, many=True)
     _oai = fields.Dict()

--- a/sonar/modules/documents/query.py
+++ b/sonar/modules/documents/query.py
@@ -33,7 +33,7 @@ FIELDS = [
     'otherMaterialCharacteristics', 'formats', 'additionalMaterials',
     'series.*', 'notes', 'abstracts.*', 'identifiedBy.*', 'subjects.*',
     'otherEdition.*', 'classification.*', 'contentNote', 'dissertation.*',
-    'usageAndAccessPolicy', 'contribution.*', 'partOf.*'
+    'usageAndAccessPolicy', 'contribution.*', 'partOf.*', 'projects.*'
 ]
 
 

--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -162,6 +162,31 @@
       {% endif %}
 
       <dl class="row mb-0">
+        <!-- PROJECTS -->
+        {% if record.projects %}
+        <dt class="col-lg-3">
+          {{ _('Research projects') }}
+        </dt>
+        <dd class="col-lg-9">
+          <ul class="list-unstyled mb-0">
+            {% for project in record.projects %}
+            <li class="p-0">
+              <a href="{{ url_for('documents.project_detail', pid_value=project.pid, view=view_code) }}">
+                {{ project.name }}
+              </a>
+              {%- if project.funding_organisations -%}
+              ({{ _('supported by') }}&nbsp;
+              {%- for funding_organisation in project.funding_organisations -%}
+              {{funding_organisation.agent.preferred_name}}{% if not loop.last %},&nbsp;{% endif %}
+              {%- endfor -%}
+              )
+              {%- endif -%}
+            </li>
+            {% endfor %}
+          </ul>
+        </dd>
+        {% endif %}
+
         <!-- OTHER EDITION -->
         {% if record.otherEdition %}
         <dt class="col-lg-3">

--- a/sonar/modules/projects/__init__.py
+++ b/sonar/modules/projects/__init__.py
@@ -11,11 +11,11 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-[pytest]
-pep8ignore = docs/conf.py ALL
-addopts = --pep8 --doctest-glob="*.rst" --doctest-modules --cov=sonar --cov-report=term-missing --ignore=setup.py -p celery.contrib.pytest
-testpaths = docs tests sonar
-; Not displaying all the PendingDeprecationWarnings from invenio
-filterwarnings =
-    ignore::PendingDeprecationWarning
+
+"""Project module."""
+
+from __future__ import absolute_import, print_function

--- a/sonar/modules/projects/api.py
+++ b/sonar/modules/projects/api.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Project Api."""
+
+from functools import partial
+
+from sonar.affiliations import AffiliationResolver
+
+from ..api import SonarIndexer, SonarRecord, SonarSearch
+from ..fetchers import id_fetcher
+from ..minters import id_minter
+from ..providers import Provider
+
+# provider
+ProjectProvider = type('ProjectProvider', (Provider, ), dict(pid_type='proj'))
+# minter
+project_pid_minter = partial(id_minter, provider=ProjectProvider)
+# fetcher
+project_pid_fetcher = partial(id_fetcher, provider=ProjectProvider)
+
+
+class ProjectSearch(SonarSearch):
+    """Projects search."""
+
+    class Meta:
+        """Search only on item index."""
+
+        index = 'projects'
+        doc_types = []
+
+
+class ProjectRecord(SonarRecord):
+    """Project record."""
+
+    minter = project_pid_minter
+    fetcher = project_pid_fetcher
+    provider = ProjectProvider
+    schema = 'projects/project-v1.0.0.json'
+
+    @classmethod
+    def create(cls,
+               data,
+               id_=None,
+               dbcommit=False,
+               with_bucket=False,
+               **kwargs):
+        """Create project record.
+
+        :param data: Record data dictionary.
+        :param id_: Specify a UUID to use for the new record, instead of
+                    automatically generated.
+        :param dbcommit: True if record is committed to DB.
+        :param with_bucket: True if a bucket have to be associated.
+        :returns: Project instance.
+        """
+        cls.guess_controlled_affiliations(data)
+
+        return super(ProjectRecord, cls).create(data,
+                                                id_=id_,
+                                                dbcommit=dbcommit,
+                                                with_bucket=with_bucket,
+                                                **kwargs)
+
+    @classmethod
+    def guess_controlled_affiliations(cls, data):
+        """Guess controlled affiliations.
+
+        :param data: Record data.
+        """
+        affiliation_resolver = AffiliationResolver()
+        for investigator in data.get('investigators', []):
+            if investigator.get('affiliation'):
+                controlled_affiliation = affiliation_resolver.resolve(
+                    investigator['affiliation'])
+                if controlled_affiliation:
+                    investigator['controlledAffiliation'] = [
+                        controlled_affiliation
+                    ]
+
+    def update(self, data):
+        """Update record.
+
+        :param data: Record data.
+        :returns: Record instance
+        """
+        self.guess_controlled_affiliations(data)
+        return super(ProjectRecord, self).update(data)
+
+
+class ProjectIndexer(SonarIndexer):
+    """Project indexer."""
+
+    record_cls = ProjectRecord

--- a/sonar/modules/projects/jsonresolvers.py
+++ b/sonar/modules/projects/jsonresolvers.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Project resolver."""
+
+from __future__ import absolute_import, print_function
+
+import jsonresolver
+from invenio_pidstore.resolver import Resolver
+from invenio_records.api import Record
+
+
+# the host corresponds to the config value for the key JSONSCHEMAS_HOST
+@jsonresolver.route('/api/projects/<pid>', host='sonar.ch')
+def project_resolver(pid):
+    """Resolve referenced project."""
+    resolver = Resolver(pid_type='proj', object_type="rec",
+                        getter=Record.get_record)
+    _, record = resolver.resolve(pid)
+
+    if record.get('$schema'):
+        del record['$schema']
+
+    return record

--- a/sonar/modules/projects/jsonschemas/__init__.py
+++ b/sonar/modules/projects/jsonschemas/__init__.py
@@ -11,11 +11,8 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-[pytest]
-pep8ignore = docs/conf.py ALL
-addopts = --pep8 --doctest-glob="*.rst" --doctest-modules --cov=sonar --cov-report=term-missing --ignore=setup.py -p celery.contrib.pytest
-testpaths = docs tests sonar
-; Not displaying all the PendingDeprecationWarnings from invenio
-filterwarnings =
-    ignore::PendingDeprecationWarning
+"""JSON schemas for projects."""

--- a/sonar/modules/projects/jsonschemas/projects/project-v1.0.0_src.json
+++ b/sonar/modules/projects/jsonschemas/projects/project-v1.0.0_src.json
@@ -1,0 +1,340 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://sonar.ch/schemas/projects/project-v1.0.0.json",
+  "additionalProperties": false,
+  "title": "Research project",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "default": "https://sonar.ch/schemas/projects/project-v1.0.0.json"
+    },
+    "pid": {
+      "title": "Identifier",
+      "type": "string",
+      "minLength": 1
+    },
+    "name": {
+      "title": "Name",
+      "type": "string",
+      "minLength": 1,
+      "form": {
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
+      }
+    },
+    "description": {
+      "title": "Description",
+      "type": "string",
+      "minLength": 1,
+      "form": {
+        "type": "textarea",
+        "templateOptions": {
+          "cssClass": "editor-title",
+          "rows": 5
+        }
+      }
+    },
+    "startDate": {
+      "title": "Start date",
+      "description": "Enter the date in the format YYYY-MM-DD.",
+      "type": "string",
+      "format": "date",
+      "pattern": "^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$",
+      "form": {
+        "templateOptions": {
+          "placeholder": "Example: 2020-12-01",
+          "cssClass": "editor-title"
+        }
+      }
+    },
+    "endDate": {
+      "title": "End date",
+      "description": "Enter the date in the format YYYY-MM-DD.",
+      "type": "string",
+      "format": "date",
+      "pattern": "^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$",
+      "form": {
+        "templateOptions": {
+          "placeholder": "Example: 2020-12-01",
+          "cssClass": "editor-title"
+        }
+      }
+    },
+    "identifiedBy": {
+      "title": "Identifier",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "Type",
+          "type": "string",
+          "enum": [
+            "bf:Identifier",
+            "bf:Local"
+          ],
+          "form": {
+            "options": [
+              {
+                "label": "bf:Identifier",
+                "value": "bf:Identifier"
+              },
+              {
+                "label": "bf:Local",
+                "value": "bf:Local"
+              }
+            ]
+          }
+        },
+        "source": {
+          "title": "Source",
+          "type": "string",
+          "minLength": 1,
+          "form": {
+            "hideExpression": "!model || model.type !== 'bf:Local'",
+            "expressionProperties": {
+              "templateOptions.required": "model && model.type === 'bf:Local'"
+            }
+          }
+        },
+        "value": {
+          "title": "Value",
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "propertiesOrder": [
+        "type",
+        "source",
+        "value"
+      ],
+      "required": [
+        "type",
+        "value"
+      ],
+      "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        },
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
+      }
+    },
+    "investigators": {
+      "title": "Investigators",
+      "type": "array",
+      "minItems": 0,
+      "items": {
+        "title": "Investigator",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "agent": {
+            "title": "Agent",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "preferred_name": {
+                "title": "Preferred name",
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "propertiesOrder": [
+              "preferred_name"
+            ],
+            "required": [
+              "preferred_name"
+            ]
+          },
+          "role": {
+            "title": "Roles",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "title": "Role",
+              "type": "string",
+              "enum": [
+                "investigator",
+                "coinvestigator"
+              ],
+              "default": "investigator",
+              "form": {
+                "options": [
+                  {
+                    "label": "investigator",
+                    "value": "investigator"
+                  },
+                  {
+                    "label": "coinvestigator",
+                    "value": "coinvestigator"
+                  }
+                ]
+              }
+            }
+          },
+          "affiliation": {
+            "title": "Affiliation",
+            "type": "string",
+            "minLength": 1
+          },
+          "controlledAffiliation": {
+            "title": "Controlled affiliations",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "title": "Controlled affiliation",
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "identifiedBy": {
+            "$ref": "identifiedby-v1.0.0.json"
+          }
+        },
+        "propertiesOrder": [
+          "agent",
+          "role",
+          "affiliation",
+          "controlledAffiliation",
+          "identifiedBy"
+        ],
+        "required": [
+          "agent",
+          "role"
+        ]
+      },
+      "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        },
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
+      }
+    },
+    "funding_organisations": {
+      "title": "Funding organisations",
+      "type": "array",
+      "minItems": 0,
+      "items": {
+        "title": "Funding organisation",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "agent": {
+            "title": "Agent",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "preferred_name": {
+                "title": "Preferred name",
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "propertiesOrder": [
+              "preferred_name"
+            ],
+            "required": [
+              "preferred_name"
+            ]
+          },
+          "identifiedBy": {
+            "$ref": "identifiedby-v1.0.0.json"
+          }
+        },
+        "propertiesOrder": [
+          "agent",
+          "identifiedBy"
+        ],
+        "required": [
+          "agent"
+        ]
+      },
+      "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        },
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
+      }
+    },
+    "organisation": {
+      "title": "Organisation",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "title": "Organisation",
+          "type": "string",
+          "pattern": "^https://sonar.ch/api/organisations/.*?$",
+          "form": {
+            "remoteOptions": {
+              "type": "organisations"
+            }
+          }
+        }
+      },
+      "required": [
+        "$ref"
+      ],
+      "form": {
+        "templateOptions": {
+          "cssClass": "editor-title"
+        },
+        "expressionProperties": {
+          "templateOptions.required": "true"
+        }
+      }
+    },
+    "user": {
+      "title": "User",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "$ref": {
+          "title": "User",
+          "type": "string",
+          "pattern": "^https://sonar.ch/api/users/.*?$",
+          "form": {
+            "remoteOptions": {
+              "type": "users"
+            }
+          }
+        }
+      },
+      "required": [
+        "$ref"
+      ],
+      "form": {
+        "templateOptions": {
+          "cssClass": "editor-title"
+        },
+        "expressionProperties": {
+          "templateOptions.required": "true"
+        }
+      }
+    }
+  },
+  "propertiesOrder": [
+    "name",
+    "description",
+    "startDate",
+    "endDate",
+    "organisation",
+    "identifiedBy",
+    "investigators",
+    "funding_organisations"
+  ],
+  "required": [
+    "name",
+    "startDate",
+    "$schema"
+  ]
+}

--- a/sonar/modules/projects/loaders/__init__.py
+++ b/sonar/modules/projects/loaders/__init__.py
@@ -11,11 +11,22 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-[pytest]
-pep8ignore = docs/conf.py ALL
-addopts = --pep8 --doctest-glob="*.rst" --doctest-modules --cov=sonar --cov-report=term-missing --ignore=setup.py -p celery.contrib.pytest
-testpaths = docs tests sonar
-; Not displaying all the PendingDeprecationWarnings from invenio
-filterwarnings =
-    ignore::PendingDeprecationWarning
+"""Loaders for projects."""
+
+from __future__ import absolute_import, print_function
+
+from invenio_records_rest.loaders.marshmallow import json_patch_loader, \
+    marshmallow_loader
+
+from ..marshmallow import ProjectMetadataSchemaV1
+
+#: JSON loader using Marshmallow for data validation.
+json_v1 = marshmallow_loader(ProjectMetadataSchemaV1)
+
+__all__ = (
+    'json_v1',
+)

--- a/sonar/modules/projects/mappings/__init__.py
+++ b/sonar/modules/projects/mappings/__init__.py
@@ -11,11 +11,10 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-[pytest]
-pep8ignore = docs/conf.py ALL
-addopts = --pep8 --doctest-glob="*.rst" --doctest-modules --cov=sonar --cov-report=term-missing --ignore=setup.py -p celery.contrib.pytest
-testpaths = docs tests sonar
-; Not displaying all the PendingDeprecationWarnings from invenio
-filterwarnings =
-    ignore::PendingDeprecationWarning
+"""Elasticsearch mapping for projects."""
+
+from __future__ import absolute_import, print_function

--- a/sonar/modules/projects/mappings/v7/__init__.py
+++ b/sonar/modules/projects/mappings/v7/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CERN.
+#
+# My site is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+
+"""Elasticsearch mapping for projects."""
+
+from __future__ import absolute_import, print_function

--- a/sonar/modules/projects/mappings/v7/projects/project-v1.0.0.json
+++ b/sonar/modules/projects/mappings/v7/projects/project-v1.0.0.json
@@ -1,0 +1,167 @@
+{
+  "settings": {
+    "number_of_shards": 8,
+    "number_of_replicas": 2,
+    "max_result_window": 20000,
+    "analysis": {
+      "filter": {
+        "autocomplete_filter": {
+          "type": "edge_ngram",
+          "min_gram": 1,
+          "max_gram": 20
+        }
+      },
+      "analyzer": {
+        "autocomplete": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "filter": [
+            "lowercase",
+            "autocomplete_filter"
+          ]
+        }
+      }
+    }
+  },
+  "mappings": {
+    "date_detection": false,
+    "numeric_detection": false,
+    "properties": {
+      "$schema": {
+        "type": "keyword"
+      },
+      "pid": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "text",
+        "copy_to": "autocomplete_name"
+      },
+      "autocomplete_name": {
+        "type": "text",
+        "analyzer": "autocomplete",
+        "search_analyzer": "standard"
+      },
+      "description": {
+        "type": "text"
+      },
+      "startDate": {
+        "type": "date"
+      },
+      "endDate": {
+        "type": "date"
+      },
+      "identifiedBy": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "keyword"
+          },
+          "source": {
+            "type": "text"
+          },
+          "value": {
+            "type": "text"
+          }
+        }
+      },
+      "investigators": {
+        "type": "object",
+        "properties": {
+          "agent": {
+            "type": "object",
+            "properties": {
+              "preferred_name": {
+                "type": "text"
+              }
+            }
+          },
+          "role": {
+            "type": "keyword"
+          },
+          "affiliation": {
+            "type": "text"
+          },
+          "controlledAffilication": {
+            "type": "keyword"
+          },
+          "identifiedBy": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "keyword"
+              },
+              "source": {
+                "type": "text"
+              },
+              "value": {
+                "type": "text"
+              }
+            }
+          }
+        }
+      },
+      "funding_organisations": {
+        "type": "object",
+        "properties": {
+          "agent": {
+            "type": "object",
+            "properties": {
+              "preferred_name": {
+                "type": "text"
+              }
+            }
+          },
+          "identifiedBy": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "keyword"
+              },
+              "source": {
+                "type": "text"
+              },
+              "value": {
+                "type": "text"
+              }
+            }
+          }
+        }
+      },
+      "organisation": {
+        "type": "object",
+        "properties": {
+          "pid": {
+            "type": "keyword"
+          },
+          "code": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "text"
+          }
+        }
+      },
+      "user": {
+        "type": "object",
+        "properties": {
+          "pid": {
+            "type": "keyword"
+          },
+          "role": {
+            "type": "keyword"
+          },
+          "full_name": {
+            "type": "keyword"
+          }
+        }
+      },
+      "_created": {
+        "type": "date"
+      },
+      "_updated": {
+        "type": "date"
+      }
+    }
+  }
+}

--- a/sonar/modules/projects/marshmallow/__init__.py
+++ b/sonar/modules/projects/marshmallow/__init__.py
@@ -11,11 +11,14 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-[pytest]
-pep8ignore = docs/conf.py ALL
-addopts = --pep8 --doctest-glob="*.rst" --doctest-modules --cov=sonar --cov-report=term-missing --ignore=setup.py -p celery.contrib.pytest
-testpaths = docs tests sonar
-; Not displaying all the PendingDeprecationWarnings from invenio
-filterwarnings =
-    ignore::PendingDeprecationWarning
+"""Marshmallow schemas for projects."""
+
+from __future__ import absolute_import, print_function
+
+from .json import ProjectMetadataSchemaV1, ProjectSchemaV1
+
+__all__ = ('ProjectMetadataSchemaV1', 'ProjectSchemaV1',)

--- a/sonar/modules/projects/marshmallow/json.py
+++ b/sonar/modules/projects/marshmallow/json.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Marshmallow schemas for projects."""
+
+from __future__ import absolute_import, print_function
+
+from functools import partial
+
+from flask_security import current_user
+from invenio_records_rest.schemas import StrictKeysMixin
+from invenio_records_rest.schemas.fields import GenFunction, \
+    PersistentIdentifier, SanitizedUnicode
+from marshmallow import fields, pre_dump, pre_load
+
+from sonar.modules.documents.api import DocumentRecord
+from sonar.modules.projects.api import ProjectRecord
+from sonar.modules.projects.permissions import ProjectPermission
+from sonar.modules.serializers import schema_from_context
+from sonar.modules.users.api import current_user_record
+
+schema_from_project = partial(schema_from_context, schema=ProjectRecord.schema)
+
+
+class ProjectMetadataSchemaV1(StrictKeysMixin):
+    """Schema for the project metadata."""
+
+    pid = PersistentIdentifier()
+    name = SanitizedUnicode(required=True)
+    description = SanitizedUnicode()
+    startDate = SanitizedUnicode()
+    endDate = SanitizedUnicode()
+    identifiedBy = fields.Dict()
+    investigators = fields.List(fields.Dict())
+    funding_organisations = fields.List(fields.Dict())
+    organisation = fields.Dict()
+    user = fields.Dict()
+    documents = fields.List(fields.Dict(), dump_only=True)
+    # When loading, if $schema is not provided, it's retrieved by
+    # Record.schema property.
+    schema = GenFunction(load_only=True,
+                         attribute="$schema",
+                         data_key="$schema",
+                         deserialize=schema_from_project)
+    permissions = fields.Dict(dump_only=True)
+
+    def dump(self, obj, *args, **kwargs):
+        """Dump object.
+
+        Override the parent method to add the documents linked to projects.
+        It was not possible to use the `pre_dump` decorator, because
+        `add_permission` need this property and we cannot be sure that this
+        hook will be executed first.
+        """
+        obj['documents'] = DocumentRecord.get_documents_by_project(obj['pid'])
+        return super(ProjectMetadataSchemaV1, self).dump(obj, *args, **kwargs)
+
+    @pre_dump
+    def add_permissions(self, item, **kwargs):
+        """Add permissions to record.
+
+        :param item: Dict representing the record.
+        :returns: Modified dict.
+        """
+        item['permissions'] = {
+            'read': ProjectPermission.read(current_user, item),
+            'update': ProjectPermission.update(current_user, item),
+            'delete': ProjectPermission.delete(current_user, item)
+        }
+
+        return item
+
+    @pre_load
+    def remove_fields(self, data, **kwargs):
+        """Removes computed fields.
+
+        :param data: Dict of record data.
+        :returns: Modified data.
+        """
+        data.pop('permissions', None)
+        data.pop('documents', None)
+
+        return data
+
+    @pre_load
+    def guess_organisation(self, data, **kwargs):
+        """Guess organisation from current logged user.
+
+        :param data: Dict of record data.
+        :returns: Modified dict of record data.
+        """
+        # Organisation already attached to document, we do nothing.
+        if data.get('organisation'):
+            return data
+
+        # Store current user organisation in new document.
+        if current_user_record.get('organisation'):
+            data['organisation'] = current_user_record['organisation']
+
+        return data
+
+    @pre_load
+    def guess_user(self, data, **kwargs):
+        """Guess user.
+
+        :param data: Dict of record data.
+        :returns: Modified dict of record data.
+        """
+        # If user is already set, we don't set it.
+        if data.get('user'):
+            return data
+
+        # Store current user in project.
+        data['user'] = {
+            '$ref':
+            current_user_record.get_ref_link('users',
+                                             current_user_record['pid'])
+        }
+
+        return data
+
+
+class ProjectSchemaV1(StrictKeysMixin):
+    """Project schema."""
+
+    metadata = fields.Nested(ProjectMetadataSchemaV1)
+    created = fields.Str(dump_only=True)
+    updated = fields.Str(dump_only=True)
+    links = fields.Dict(dump_only=True)
+    id = PersistentIdentifier()
+    explanation = fields.Raw(dump_only=True)

--- a/sonar/modules/projects/permissions.py
+++ b/sonar/modules/projects/permissions.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Permissions for projects."""
+
+from flask import request
+
+from sonar.modules.documents.api import DocumentRecord
+from sonar.modules.organisations.api import current_organisation
+from sonar.modules.permissions import RecordPermission
+from sonar.modules.projects.api import ProjectRecord
+from sonar.modules.users.api import current_user_record
+
+
+class ProjectPermission(RecordPermission):
+    """Projects permissions."""
+
+    @classmethod
+    def list(cls, user, record=None):
+        """List permission check.
+
+        :param user: Logged user.
+        :param record: Record to check.
+        :returns: True is action can be done.
+        """
+        return (False if not current_user_record else
+                current_user_record.is_submitter)
+
+    @classmethod
+    def create(cls, user, record=None):
+        """Create permission check.
+
+        :param user: Logged user.
+        :param record: Record to check.
+        :returns: True is action can be done.
+        """
+        return cls.list(user, record)
+
+    @classmethod
+    def read(cls, user, record):
+        """Read permission check.
+
+        :param user: Logged user.
+        :param record: Record to check.
+        :returns: True is action can be done.
+        """
+        # At least for submitters logged users.
+        if not current_user_record or not current_user_record.is_submitter:
+            return False
+
+        return True
+
+    @classmethod
+    def update(cls, user, record):
+        """Update permission check.
+
+        :param user: Logged user.
+        :param record: Record to check.
+        :returns: True is action can be done.
+        """
+        # At least for submitters logged users.
+        if not current_user_record or not current_user_record.is_submitter:
+            return False
+
+        # Superuser is allowd
+        if current_user_record.is_superuser:
+            return True
+
+        project = ProjectRecord.get_record_by_pid(record['pid'])
+        project = project.replace_refs()
+
+        # For admin or moderators users, they can update only their
+        # organisation's projects.
+        if current_user_record.is_moderator:
+            return current_organisation['pid'] == project['organisation'][
+                'pid']
+
+        # For submitters, they can only modify their own projects
+        return current_user_record['pid'] == project['user']['pid']
+
+    @classmethod
+    def delete(cls, user, record):
+        """Delete permission check.
+
+        :param user: Logged user.
+        :param record: Record to check.
+        :returns: True if action can be done.
+        """
+        documents = DocumentRecord.get_documents_by_project(record['pid'])
+        if documents:
+            return False
+
+        return cls.update(user, record)

--- a/sonar/modules/projects/query.py
+++ b/sonar/modules/projects/query.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Query for projects."""
+
+from flask import current_app, request
+
+from sonar.modules.organisations.api import current_organisation
+from sonar.modules.query import default_search_factory
+from sonar.modules.users.api import current_user_record
+
+
+def search_factory(self, search, query_parser=None):
+    """Project search factory.
+
+    :param search: Search instance.
+    :param query_parser: Url arguments.
+    :returns: Tuple with search instance and URL arguments.
+    """
+    search, urlkwargs = default_search_factory(self, search)
+
+    if current_app.config.get('SONAR_APP_DISABLE_PERMISSION_CHECKS'):
+        return (search, urlkwargs)
+
+    # For superusers, records are not filtered.
+    if current_user_record.is_superuser:
+        return (search, urlkwargs)
+
+    # For admin and moderator, only records that belongs to his organisation.
+    # The same rule is applied when searching project in typeahead input.
+    # TODO: Find a better way for handling typeahead calls..
+    if current_user_record.is_moderator or (
+            request.args.get('q') and
+            request.args['q'].startswith('autocomplete_name')):
+        search = search.filter('term',
+                               organisation__pid=current_organisation['pid'])
+        return (search, urlkwargs)
+
+    # For user, only records that belongs to him.
+    if current_user_record.is_submitter:
+        search = search.filter('term', user__pid=current_user_record['pid'])
+
+    return (search, urlkwargs)

--- a/sonar/modules/projects/serializers/__init__.py
+++ b/sonar/modules/projects/serializers/__init__.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Projects serializers."""
+
+from __future__ import absolute_import, print_function
+
+from invenio_records_rest.serializers.response import record_responsify, \
+    search_responsify
+
+from sonar.modules.documents.api import DocumentRecord
+from sonar.modules.organisations.api import OrganisationRecord
+from sonar.modules.serializers import JSONSerializer as _JSONSerializer
+from sonar.modules.users.api import current_user_record
+
+from ..marshmallow import ProjectSchemaV1
+
+
+class JSONSerializer(_JSONSerializer):
+    """JSON serializer for projects."""
+
+    def post_process_serialize_search(self, results, pid_fetcher):
+        """Post process the search results."""
+        if current_user_record:
+            # Remove organisation facet for non super users
+            if not current_user_record.is_superuser:
+                results['aggregations'].pop('organisation', {})
+
+            # Remove user facet for non moderators users
+            if not current_user_record.is_moderator:
+                results['aggregations'].pop('user', {})
+
+        # Add organisation name
+        for org_term in results.get('aggregations',
+                                    {}).get('organisation',
+                                            {}).get('buckets', []):
+            organisation = OrganisationRecord.get_record_by_pid(
+                org_term['key'])
+            if organisation:
+                org_term['name'] = organisation['name']
+
+        return super(JSONSerializer,
+                     self).post_process_serialize_search(results, pid_fetcher)
+
+
+# Serializers
+# ===========
+#: JSON serializer definition.
+json_v1 = JSONSerializer(ProjectSchemaV1)
+
+# Records-REST serializers
+# ========================
+#: JSON record serializer for individual records.
+json_v1_response = record_responsify(json_v1, 'application/json')
+#: JSON record serializer for search results.
+json_v1_search = search_responsify(json_v1, 'application/json')
+
+__all__ = (
+    'json_v1',
+    'json_v1_response',
+    'json_v1_search',
+)

--- a/sonar/theme/templates/sonar/projects/detail.html
+++ b/sonar/theme/templates/sonar/projects/detail.html
@@ -1,0 +1,95 @@
+{%- extends config.RECORDS_UI_BASE_TEMPLATE %}
+
+{% macro format_identifier(identifier) %}
+{%- if identifier.source %}
+<span class="badge badge-secondary text-light mr-1">{{ _(identifier.source) }}</span>
+{% else -%}
+<span class="badge badge-secondary text-light mr-1">{{ _(identifier.type) }}</span>
+{%- endif -%}
+{{ identifier.value }}
+{% endmacro %}
+
+{% block body %}
+<div class="mb-3">
+  <a href="javascript: history.back(-1)">
+    <i class="fa fa-arrow-left mr-1"></i> {{ _('Back') }}
+  </a>
+</div>
+<h1>{{ record.name }}</h1>
+{% if record.description %}
+<div class="my-4">{{ record.description | nl2br | safe }}</div>
+{% endif %}
+
+<dl class="row mt-4">
+  <dt class="col-sm-3">{{ _('Period') }}</dt>
+  <dd class="col-sm-9">{{ record.startDate | format_date }} - {{ record.endDate | format_date if record.endDate else '' }}</dd>
+
+  {% if record.identifiedBy %}
+  <dt class="col-sm-3">{{ _('Identifier') }}</dt>
+  <dd class="col-sm-9">{{ format_identifier(record.identifiedBy) }}</dd>
+  {% endif %}
+
+  {% if record.investigators %}
+  <dt class="col-sm-3">{{ _('Investigators') }}</dt>
+  <dd class="col-sm-9">
+    {% for investigator in record.investigators %}
+    <p class="m-0">
+      {{ investigator.agent.preferred_name }}
+      (
+      {%- for role in investigator.role -%}
+      {{ _(role) }}{% if not loop.last %},&nbsp;{%endif%}
+      {%- endfor -%}
+      )
+      {% if investigator.identifiedBy %}
+      {{ format_identifier(investigator.identifiedBy) }}
+      {% endif%}
+      {% if investigator.affiliation %}
+      {% if investigator.controlledAffiliation %}
+      <small class="affiliation-tooltip" data-placement="top"
+        title="{{ investigator.controlledAffiliation | join(' ; ') }}"><i
+          class="text-muted">{{ investigator.affiliation }}</i></small>
+      {% else %}
+      <small><i class="text-muted">{{ investigator.affiliation }}</i></small>
+      {% endif %}
+      {% endif %}
+    </p>
+    {% endfor %}
+  </dd>
+  {% endif %}
+
+  {% if record.funding_organisations %}
+  <dt class="col-sm-3">{{ _('Funding organisations') }}</dt>
+  <dd class="col-sm-9">
+    {% for funding_organisation in record.funding_organisations %}
+    <p class="m-0">
+      {{ funding_organisation.agent.preferred_name }}
+      {% if funding_organisation.identifiedBy %}
+      {{ format_identifier(funding_organisation.identifiedBy) }}
+      {% endif %}
+    </p>
+    {% endfor %}
+  </dd>
+  {% endif %}
+</dl>
+
+{% if record.documents %}
+<h4>{{ _('Linked documents') }}</h4>
+<ul>
+  {% for document in record.documents %}
+  <li>
+    <a href="{{ document.permalink }}">{{ document.title[0] | title_format(current_i18n.language) }}</a>
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% endblock body %}
+
+
+{% block javascript %}
+{{super()}}
+<script>
+  $(document).ready(function () {
+    $('.affiliation-tooltip').tooltip();
+  });
+</script>
+{% endblock javascript %}

--- a/sonar/theme/views.py
+++ b/sonar/theme/views.py
@@ -26,6 +26,7 @@ from __future__ import absolute_import, print_function
 
 import re
 
+import dateutil.parser
 from flask import Blueprint, abort, current_app, jsonify, redirect, \
     render_template, request, url_for
 from flask_babelex import lazy_gettext as _
@@ -40,6 +41,7 @@ from sonar.modules.deposits.permissions import DepositPermission
 from sonar.modules.documents.permissions import DocumentPermission
 from sonar.modules.organisations.permissions import OrganisationPermission
 from sonar.modules.permissions import can_access_manage_view
+from sonar.modules.projects.permissions import ProjectPermission
 from sonar.modules.users.api import UserRecord, current_user_record
 from sonar.modules.users.permissions import UserPermission
 
@@ -128,6 +130,10 @@ def logged_user():
             'deposits': {
                 'add': DepositPermission.create(user),
                 'list': DepositPermission.list(user)
+            },
+            'projects': {
+                'add': ProjectPermission.create(user),
+                'list': ProjectPermission.list(user)
             }
         }
 
@@ -155,7 +161,7 @@ def schemas(record_type):
 
         # TODO: Maybe find a proper way to do this.
         if record_type in [
-                'users', 'documents'
+                'users', 'documents', 'projects'
         ] and not current_user.is_anonymous and current_user_record:
             if record_type == 'users':
                 # If user is admin, restrict available roles list.
@@ -253,3 +259,14 @@ def prepare_schema(schema):
     hierarchize_form_options(schema)
 
     return schema
+
+
+@blueprint.app_template_filter()
+def format_date(date, format='%d/%m/%Y'):
+    """Format the given ISO format date string.
+
+    :param date: Date string in ISO format.
+    :param format: Output format.
+    :returns: Formatted date string.
+    """
+    return dateutil.parser.isoparse(date).strftime('%d/%m/%Y')

--- a/tests/api/projects/test_projects_permissions.py
+++ b/tests/api/projects/test_projects_permissions.py
@@ -1,0 +1,339 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test project permissions."""
+
+import json
+
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+
+from sonar.modules.deposits.api import DepositRecord
+
+
+def test_list(app, client, make_project, superuser, admin, moderator,
+              submitter, user):
+    """Test list projects permissions."""
+    make_project('submitter', 'org')
+    make_project('admin', 'org')
+    make_project('submitter', 'org2')
+
+    # Not logged
+    res = client.get(url_for('invenio_records_rest.proj_list'))
+    assert res.status_code == 401
+
+    # Not logged but permission checks disabled
+    app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
+    res = client.get(url_for('invenio_records_rest.proj_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total']['value'] == 3
+    app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=False)
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.get(url_for('invenio_records_rest.proj_list'))
+    assert res.status_code == 403
+
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
+    res = client.get(url_for('invenio_records_rest.proj_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total']['value'] == 1
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.get(url_for('invenio_records_rest.proj_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total']['value'] == 2
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.get(url_for('invenio_records_rest.proj_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total']['value'] == 2
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.get(url_for('invenio_records_rest.proj_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total']['value'] == 3
+
+
+def test_create(client, project_json, superuser, admin, moderator, submitter,
+                user):
+    """Test create project permissions."""
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+    }
+
+    # Not logged
+    res = client.post(url_for('invenio_records_rest.proj_list'),
+                      data=json.dumps(project_json),
+                      headers=headers)
+    assert res.status_code == 401
+
+    # User
+    login_user_via_session(client, email=user['email'])
+    res = client.post(url_for('invenio_records_rest.proj_list'),
+                      data=json.dumps(project_json),
+                      headers=headers)
+    assert res.status_code == 403
+
+    # submitter
+    login_user_via_session(client, email=submitter['email'])
+    res = client.post(url_for('invenio_records_rest.proj_list'),
+                      data=json.dumps(project_json),
+                      headers=headers)
+    assert res.status_code == 201
+
+    # Moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.post(url_for('invenio_records_rest.proj_list'),
+                      data=json.dumps(project_json),
+                      headers=headers)
+    assert res.status_code == 201
+
+    # Admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.post(url_for('invenio_records_rest.proj_list'),
+                      data=json.dumps(project_json),
+                      headers=headers)
+    assert res.status_code == 201
+
+    # Super user
+    login_user_via_session(client, email=superuser['email'])
+    res = client.post(url_for('invenio_records_rest.proj_list'),
+                      data=json.dumps(project_json),
+                      headers=headers)
+    assert res.status_code == 201
+
+
+def test_read(client, make_project, make_user, superuser, admin, moderator,
+              submitter, user):
+    """Test read project permissions."""
+    project1 = make_project('submitter', 'org')
+    project2 = make_project('submitter', 'org2')
+
+    # Not logged
+    res = client.get(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 401
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.get(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 403
+
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
+    res = client.get(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 200
+
+    res = client.get(
+        url_for('invenio_records_rest.proj_item', pid_value=project2['pid']))
+    assert res.status_code == 200
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.get(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 200
+
+    res = client.get(
+        url_for('invenio_records_rest.proj_item', pid_value=project2['pid']))
+    assert res.status_code == 200
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.get(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 200
+
+    res = client.get(
+        url_for('invenio_records_rest.proj_item', pid_value=project2['pid']))
+    assert res.status_code == 200
+
+    # Logged as admin of other organisation
+    other_admin = make_user('admin', 'org2')
+    login_user_via_session(client, email=other_admin['email'])
+    res = client.get(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 200
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.get(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 200
+
+
+def test_update(client, make_project, superuser, admin, moderator, submitter,
+                user):
+    """Test update project permissions."""
+    project1 = make_project('submitter', 'org')
+    project2 = make_project('submitter', 'org2')
+
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+    }
+
+    # Not logged
+    res = client.put(url_for('invenio_records_rest.proj_item',
+                             pid_value=project1['pid']),
+                     data=json.dumps(project1.dumps()),
+                     headers=headers)
+    assert res.status_code == 401
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.put(url_for('invenio_records_rest.proj_item',
+                             pid_value=project1['pid']),
+                     data=json.dumps(project1.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
+    res = client.put(url_for('invenio_records_rest.proj_item',
+                             pid_value=project1['pid']),
+                     data=json.dumps(project1.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+    res = client.put(url_for('invenio_records_rest.proj_item',
+                             pid_value=project2['pid']),
+                     data=json.dumps(project2.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.put(url_for('invenio_records_rest.proj_item',
+                             pid_value=project1['pid']),
+                     data=json.dumps(project1.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+    res = client.put(url_for('invenio_records_rest.proj_item',
+                             pid_value=project2['pid']),
+                     data=json.dumps(project2.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.put(url_for('invenio_records_rest.proj_item',
+                             pid_value=project1['pid']),
+                     data=json.dumps(project1.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+    res = client.put(url_for('invenio_records_rest.proj_item',
+                             pid_value=project2['pid']),
+                     data=json.dumps(project2.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.put(url_for('invenio_records_rest.proj_item',
+                             pid_value=project1['pid']),
+                     data=json.dumps(project1.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+    login_user_via_session(client, email=superuser['email'])
+    res = client.put(url_for('invenio_records_rest.proj_item',
+                             pid_value=project2['pid']),
+                     data=json.dumps(project2.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+
+def test_delete(client, db, document, make_project, superuser, admin,
+                moderator, submitter, user):
+    """Test delete deposits permissions."""
+    project1 = make_project('submitter', 'org')
+    project2 = make_project('submitter', 'org2')
+
+    # Not logged
+    res = client.delete(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 401
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 403
+
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.proj_item', pid_value=project2['pid']))
+    assert res.status_code == 403
+
+    project1 = make_project('submitter', 'org')
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.proj_item', pid_value=project2['pid']))
+    assert res.status_code == 403
+
+    res = client.delete(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 204
+
+    project1 = make_project('submitter', 'org')
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.proj_item', pid_value=project2['pid']))
+    assert res.status_code == 403
+
+    res = client.delete(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 204
+
+    project1 = make_project('submitter', 'org')
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 204
+
+    project1 = make_project('submitter', 'org')
+
+    # Cannot remove project as it is linked to document.
+    document['projects'] = [{
+        '$ref':
+        'https://sonar.ch/api/projects/{pid}'.format(pid=project1['pid'])
+    }]
+    document.commit()
+    document.reindex()
+    db.session.commit()
+
+    res = client.delete(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 403

--- a/tests/ui/deposits/test_deposits_api.py
+++ b/tests/ui/deposits/test_deposits_api.py
@@ -20,8 +20,36 @@
 from invenio_accounts.testutils import login_user_via_view
 
 
-def test_create_document(app, client, deposit, user):
+def test_create_document(app, db, project, client, deposit, user):
     """Test create document based on it."""
+    deposit['projects'] = [{
+        '$ref': 'https://sonar.ch/api/projects/11111'
+    }, {
+        'name':
+        'Project 1',
+        'description':
+        'Description',
+        'identifier':
+        'p-1000',
+        'startDate':
+        '2020-01-01',
+        'endDate':
+        '2021-12-31',
+        'investigators': [{
+            'name': 'John Doe',
+            'role': 'investigator',
+            'affiliation': 'RERO',
+            'orcid': '1000-1000-1000-1000'
+        }],
+        'funding_organisations': [{
+            'name': 'Funding organisation',
+            'identifier': 'f-1000'
+        }]
+    }]
+    deposit.commit()
+    deposit.reindex()
+    db.session.commit()
+
     login_user_via_view(client, email=user['email'], password='123456')
 
     document = deposit.create_document()
@@ -128,6 +156,8 @@ def test_create_document(app, client, deposit, user):
         'type': 'bf:Doi',
         'value': '10.1038/nphys1170'
     }]
+
+    assert len(document['projects']) == 2
 
     assert document.files['main.pdf']['access'] == 'coar:c_f1cf'
     assert document.files['main.pdf']['restricted_outside_organisation']

--- a/tests/ui/documents/dojson/rerodoc/test_rerodoc_model.py
+++ b/tests/ui/documents/dojson/rerodoc/test_rerodoc_model.py
@@ -1897,8 +1897,7 @@ def test_marc21_to_contribution_field_100():
         },
         'role': ['cre'],
         'affiliation':
-        'University of Bern, Switzerland',
-        'controlledAffiliation': ['Uni of Bern and Hospital']
+        'University of Bern, Switzerland'
     }]
 
     # Not $a
@@ -1949,8 +1948,7 @@ def test_marc21_to_contribution_field_100():
         },
         'role': ['cre'],
         'affiliation':
-        'University of Bern, Switzerland',
-        'controlledAffiliation': ['Uni of Bern and Hospital']
+        'University of Bern, Switzerland'
     }]
 
     # Only birth date, variant 2
@@ -1973,8 +1971,7 @@ def test_marc21_to_contribution_field_100():
         },
         'role': ['cre'],
         'affiliation':
-        'University of Bern, Switzerland',
-        'controlledAffiliation': ['Uni of Bern and Hospital']
+        'University of Bern, Switzerland'
     }]
 
     # Only birth date, variant 3
@@ -1997,8 +1994,7 @@ def test_marc21_to_contribution_field_100():
         },
         'role': ['cre'],
         'affiliation':
-        'University of Bern, Switzerland',
-        'controlledAffiliation': ['Uni of Bern and Hospital']
+        'University of Bern, Switzerland'
     }]
 
 
@@ -2026,8 +2022,7 @@ def test_marc21_to_contribution_field_700():
         },
         'role': ['dgs'],
         'affiliation':
-        'University of Bern, Switzerland',
-        'controlledAffiliation': ['Uni of Bern and Hospital']
+        'University of Bern, Switzerland'
     }]
 
     # Not $a
@@ -2065,8 +2060,7 @@ def test_marc21_to_contribution_field_700():
         },
         'role': ['dgs'],
         'affiliation':
-        'University of Bern, Switzerland',
-        'controlledAffiliation': ['Uni of Bern and Hospital']
+        'University of Bern, Switzerland'
     }]
 
     # Role from field 980, but not existing

--- a/tests/ui/documents/test_documents_api.py
+++ b/tests/ui/documents/test_documents_api.py
@@ -37,30 +37,6 @@ def test_get_record_by_identifier(app, document):
     assert not record
 
 
-def test_get_affiliations():
-    """Test getting controlled affiliations."""
-    affiliation = '''
-    Institute for Research in Biomedicine (IRB), Faculty of Biomedical
-    Sciences, Università della Svizzera italiana, Switzerland - Graduate
-    School for Cellular and Biomedical Sciences, University of Bern, c/o
-    Theodor Kocher Institute, Freiestrasse 1, P.O. Box 938, CH-3000 Bern 9,
-    Switzerland
-    '''
-    affiliations = DocumentRecord.get_affiliations(affiliation)
-    assert affiliations == [
-        'Uni of Bern and Hospital', 'Uni of Italian Switzerland'
-    ]
-
-    affiliations = DocumentRecord.get_affiliations(None)
-    assert not affiliations
-
-
-def test_load_affiliations():
-    """Test load affiliations from file."""
-    DocumentRecord.load_affiliations()
-    assert len(DocumentRecord.affiliations) == 77
-
-
 def test_get_next_file_order(document_with_file, document):
     """Test getting next file position."""
     # One file with order 1
@@ -88,3 +64,15 @@ def test_get_files_list(document, pdf_file):
     files = document.get_files_list()
     assert len(files) == 3
     assert files[0]['order'] == 1
+
+
+def test_get_documents_by_project(db, project, document):
+    """"Test getting documents by a project."""
+    document['projects'] = [{'$ref': 'https://sonar.ch/api/projects/11111'}]
+    document.commit()
+    document.reindex()
+    db.session.commit()
+
+    documents = DocumentRecord.get_documents_by_project(project['pid'])
+    assert documents[0]['pid'] == '1'
+    assert documents[0]['permalink'] == 'http://localhost/global/documents/1'

--- a/tests/ui/documents/test_documents_views.py
+++ b/tests/ui/documents/test_documents_views.py
@@ -349,3 +349,12 @@ def test_contribution_text():
             'place': 'Place'
         }
     }) == 'Meeting (1234 : 2019 : Place)'
+
+
+def test_project_detail(app, client, project):
+    """Test project detail page."""
+    assert client.get(url_for('documents.project_detail',
+                              pid_value=project['pid'])).status_code == 200
+
+    assert client.get(url_for('documents.project_detail',
+                              pid_value='not-existing')).status_code == 404

--- a/tests/ui/projects/test_projects_jsonresolvers.py
+++ b/tests/ui/projects/test_projects_jsonresolvers.py
@@ -11,11 +11,15 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-[pytest]
-pep8ignore = docs/conf.py ALL
-addopts = --pep8 --doctest-glob="*.rst" --doctest-modules --cov=sonar --cov-report=term-missing --ignore=setup.py -p celery.contrib.pytest
-testpaths = docs tests sonar
-; Not displaying all the PendingDeprecationWarnings from invenio
-filterwarnings =
-    ignore::PendingDeprecationWarning
+"""Test projects jsonresolvers."""
+
+
+def test_projects_resolver(document, project):
+    """Test project resolver."""
+    document['project'] = {'$ref': 'https://sonar.ch/api/projects/11111'}
+    assert document['project']['$ref'] == 'https://sonar.ch/api/projects/11111'
+    assert document.replace_refs().get('project')['name'] == 'Project 1'

--- a/tests/unit/affiliations/test_affiliation_resolver.py
+++ b/tests/unit/affiliations/test_affiliation_resolver.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test affiliations resolver."""
+
+from sonar.affiliations import AffiliationResolver
+
+
+def test_affiliations_property():
+    """Test loading affiliations from file."""
+    affiliation_resolver = AffiliationResolver()
+    assert len(affiliation_resolver.affiliations) == 77
+
+
+def test_resolve():
+    """Test resolve affiliations."""
+    affiliation_resolver = AffiliationResolver()
+
+    assert not affiliation_resolver.resolve(None)
+
+    test_string = ('Institute for Computer Music and Sound Technology, Zurich'
+                   ' University of the Arts, Switzerland')
+    assert affiliation_resolver.resolve(test_string) == 'ZHdK (Zurich)'
+
+    test_string = 'IST'
+    assert affiliation_resolver.resolve(test_string) == 'IST'
+
+    test_string = ('Clinic for Cardiovascular Surgery, University Hospital'
+                   'Zurich, Raemistrasse 100, 8091 Zurich, Switzerland')
+    assert affiliation_resolver.resolve(
+        test_string) == 'Uni of Zurich and Hospital'
+
+    test_string = 'Not existing'
+    assert not affiliation_resolver.resolve(test_string)

--- a/tests/unit/documents/loaders/test_rerodoc_loader.py
+++ b/tests/unit/documents/loaders/test_rerodoc_loader.py
@@ -226,8 +226,7 @@ def test_rerodoc_loader(app, organisation):
             'role': ['cre'],
             'affiliation':
             'Institute for Computational Science, University of Zürich, '
-            'Winterthurerstrasse 190, CH-8057 Zürich, Switzerland',
-            'controlledAffiliation': ['Uni of Zurich and Hospital']
+            'Winterthurerstrasse 190, CH-8057 Zürich, Switzerland'
         }, {
             'agent': {
                 'type': 'bf:Person',


### PR DESCRIPTION
Creates a project resource, with CRUD operations and permissions to access this resource and links projects to documents.

* Creates the files for handling `project` resource.
* Configures REST endpoint for `project` resource.
* Adds permissions for projects when logged user is serialized.
* Compiles JSON schema for `project` resource in bootstrap's script.
* Adds a common schema for `identifiedby` field.
* Fixes values for type and fields ordering for contributor identifier in documents.
* Adds a `projects` property to document's JSON schema.
* Adds a `projects` property to document's elasticsearch mapping.
* Serializes `projects` property in marshmallow schema.
* Adds `autocomplete_name` property to project's elasticsearch mapping, to be able to search projects in typehead.
* Adds a method in documents API, to get documents linked to a given project.
* Serializes `documents` in project marshmallow schema and formats data before dumping JSON.
* Calls `replace_refs` method to get projects information in document detail view.
* Displays projects associated to document in document's detail view.
* Adds a view to display project details.
* Adds a filter for formatting a date in jinja templates.
* Fixes an error with `identifiedBy` field, when the model is not available.
* Adds projects to documents when it is created from a deposit.
* Adds `projects` property to deposit JSON schema.
* Adds `projects` property to deposit marshmallow schema.
* Creates a class for handling controlled affiliations.
* Guesses controlled affiliation when a document or a project is created or updated.
* Closes #358.
* Closes #362.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>