### PR TITLE
deposits: add projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ target/
 # Generated JSON schemas
 sonar/modules/documents/jsonschemas/documents/document-v1.0.0.json
 sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0.json
+sonar/modules/projects/jsonschemas/projects/project-v1.0.0.json
 
 # Generated JSON files
 data/backups/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,6 +14,7 @@
 
 exclude sonar/modules/documents/jsonschemas/documents/document-v1.0.0.json
 exclude sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0.json
+exclude sonar/modules/projects/jsonschemas/projects/project-v1.0.0.json
 
 include *.html
 include *.inv

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -90,6 +90,7 @@ cp ${assets_folder}/node_modules/pdfjs-dist/build/pdf.worker.min.js ${static_fol
 section "Compile JSON schemas" "info"
 invenio utils compile-json ./sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json -o ./sonar/modules/documents/jsonschemas/documents/document-v1.0.0.json
 invenio utils compile-json ./sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json -o ./sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0.json
+invenio utils compile-json ./sonar/modules/projects/jsonschemas/projects/project-v1.0.0_src.json -o ./sonar/modules/projects/jsonschemas/projects/project-v1.0.0.json
 
 # Compile translations catalogs
 section "Compile translations catalogs" "info"

--- a/setup.py
+++ b/setup.py
@@ -101,13 +101,15 @@ setup(
             'organisations = sonar.modules.organisations.jsonschemas',
             'users = sonar.modules.users.jsonschemas',
             'deposits = sonar.modules.deposits.jsonschemas',
+            'projects = sonar.modules.projects.jsonschemas',
             'common = sonar.common.jsonschemas'
         ],
         'invenio_search.mappings': [
             'documents = sonar.modules.documents.mappings',
             'organisations = sonar.modules.organisations.mappings',
             'users = sonar.modules.users.mappings',
-            'deposits = sonar.modules.deposits.mappings'
+            'deposits = sonar.modules.deposits.mappings',
+            'projects = sonar.modules.projects.mappings'
         ],
         'invenio_search.templates': [
             'base-record = sonar.es_templates:list_es_templates'
@@ -120,7 +122,9 @@ setup(
             'user_id = \
                 sonar.modules.users.api:user_pid_minter',
             'deposit_id = \
-                sonar.modules.deposits.api:deposit_pid_minter'
+                sonar.modules.deposits.api:deposit_pid_minter',
+            'project_id = \
+                sonar.modules.projects.api:project_pid_minter'
         ],
         'invenio_pidstore.fetchers': [
             'document_id = \
@@ -130,12 +134,15 @@ setup(
             'user_id = \
                 sonar.modules.users.api:user_pid_fetcher',
             'deposit_id = \
-                sonar.modules.deposits.api:deposit_pid_fetcher'
+                sonar.modules.deposits.api:deposit_pid_fetcher',
+            'project_id = \
+                sonar.modules.projects.api:project_pid_fetcher'
         ],
         "invenio_records.jsonresolver": [
             "organisation = sonar.modules.organisations.jsonresolvers",
             "user = sonar.modules.users.jsonresolvers",
-            "document = sonar.modules.documents.jsonresolvers"
+            "document = sonar.modules.documents.jsonresolvers",
+            "project = sonar.modules.projects.jsonresolvers"
         ],
         'invenio_celery.tasks' : [
             'documents = sonar.modules.documents.tasks'

--- a/sonar/common/jsonschemas/identifiedby-v1.0.0.json
+++ b/sonar/common/jsonschemas/identifiedby-v1.0.0.json
@@ -29,9 +29,9 @@
       "type": "string",
       "minLength": 1,
       "form": {
-        "hideExpression": "model.type !== 'bf:Local'",
+        "hideExpression": "!model || model.type !== 'bf:Local'",
         "expressionProperties": {
-          "templateOptions.required": "model.type === 'bf:Local'"
+          "templateOptions.required": "model && model.type === 'bf:Local'"
         }
       }
     },

--- a/sonar/common/jsonschemas/identifiedby-v1.0.0.json
+++ b/sonar/common/jsonschemas/identifiedby-v1.0.0.json
@@ -1,0 +1,53 @@
+{
+  "title": "Identifier",
+  "description": "Identifier",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "title": "Type",
+      "type": "string",
+      "enum": [
+        "bf:Identifier",
+        "bf:Local"
+      ],
+      "form": {
+        "options": [
+          {
+            "label": "bf:Identifier",
+            "value": "bf:Identifier"
+          },
+          {
+            "label": "bf:Local",
+            "value": "bf:Local"
+          }
+        ]
+      }
+    },
+    "source": {
+      "title": "Source",
+      "type": "string",
+      "minLength": 1,
+      "form": {
+        "hideExpression": "model.type !== 'bf:Local'",
+        "expressionProperties": {
+          "templateOptions.required": "model.type === 'bf:Local'"
+        }
+      }
+    },
+    "value": {
+      "title": "Value",
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "propertiesOrder": [
+    "type",
+    "source",
+    "value"
+  ],
+  "required": [
+    "type",
+    "value"
+  ]
+}

--- a/sonar/config.py
+++ b/sonar/config.py
@@ -40,6 +40,8 @@ from sonar.modules.organisations.api import OrganisationRecord, \
 from sonar.modules.organisations.permissions import OrganisationPermission
 from sonar.modules.permissions import record_permission_factory, \
     wiki_edit_permission
+from sonar.modules.projects.api import ProjectRecord, ProjectSearch
+from sonar.modules.projects.permissions import ProjectPermission
 from sonar.modules.query import and_term_filter, missing_field_filter
 from sonar.modules.users.api import UserRecord, UserSearch
 from sonar.modules.users.permissions import UserPermission
@@ -441,6 +443,45 @@ RECORDS_REST_ENDPOINTS = {
             action='delete', record=record, cls=DepositPermission),
         list_permission_factory_imp=lambda record: record_permission_factory(
             action='list', record=record, cls=DepositPermission)),
+    'proj':
+    dict(
+        pid_type='proj',
+        pid_minter='project_id',
+        pid_fetcher='project_id',
+        default_endpoint_prefix=True,
+        record_class=ProjectRecord,
+        search_class=ProjectSearch,
+        indexer_class='sonar.modules.projects.api:ProjectIndexer',
+        search_index='projects',
+        search_type=None,
+        record_serializers={
+            'application/json': ('sonar.modules.projects.serializers'
+                                 ':json_v1_response'),
+        },
+        search_serializers={
+            'application/json': ('sonar.modules.projects.serializers'
+                                 ':json_v1_search'),
+        },
+        record_loaders={
+            'application/json': ('sonar.modules.projects.loaders'
+                                 ':json_v1'),
+        },
+        list_route='/projects/',
+        item_route='/projects/<pid(proj, record_class="sonar.modules.projects'
+        '.api:ProjectRecord"):pid_value>',
+        default_media_type='application/json',
+        max_result_window=10000,
+        search_factory_imp='sonar.modules.projects.query:search_factory',
+        create_permission_factory_imp=lambda record: record_permission_factory(
+            action='create', cls=ProjectPermission),
+        read_permission_factory_imp=lambda record: record_permission_factory(
+            action='read', record=record, cls=ProjectPermission),
+        update_permission_factory_imp=lambda record: record_permission_factory(
+            action='update', record=record, cls=ProjectPermission),
+        delete_permission_factory_imp=lambda record: record_permission_factory(
+            action='delete', record=record, cls=ProjectPermission),
+        list_permission_factory_imp=lambda record: record_permission_factory(
+            action='list', record=record, cls=ProjectPermission)),
 }
 """REST endpoints."""
 
@@ -520,11 +561,31 @@ RECORDS_REST_FACETS = {
         'filters': {
             'missing_organisation': missing_field_filter('organisation')
         }
+    },
+    'projects': {
+        'aggs': {
+            'user': {
+                'terms': {
+                    'field': 'user.full_name',
+                    'size': DEFAULT_AGGREGATION_SIZE
+                }
+            },
+            'organisation': {
+                'terms': {
+                    'field': 'organisation.pid',
+                    'size': DEFAULT_AGGREGATION_SIZE
+                }
+            }
+        },
+        'filters': {
+            'user': and_term_filter('user.full_name'),
+            'organisation': and_term_filter('organisation.pid')
+        }
     }
 }
 """REST search facets."""
 
-INDEXES = ['documents', 'organisations', 'users', 'deposits']
+INDEXES = ['documents', 'organisations', 'users', 'deposits', 'projects']
 
 RECORDS_REST_SORT_OPTIONS = {}
 for index in INDEXES:

--- a/sonar/modules/deposits/api.py
+++ b/sonar/modules/deposits/api.py
@@ -23,6 +23,7 @@ from functools import partial
 import pytz
 
 from sonar.modules.documents.api import DocumentRecord
+from sonar.modules.projects.api import ProjectRecord
 from sonar.modules.users.api import current_user_record
 
 from ..api import SonarIndexer, SonarRecord, SonarSearch
@@ -284,6 +285,92 @@ class DepositRecord(SonarRecord):
 
         if contributors:
             metadata['contribution'] = contributors
+
+        # Projects
+        if self.get('projects'):
+            projects = []
+
+            for project in self['projects']:
+                # Create a new project
+                if not project.get('$ref'):
+                    data = project.copy()
+
+                    # Store user
+                    data['user'] = {
+                        '$ref':
+                        current_user_record.get_ref_link(
+                            'users', current_user_record['pid'])
+                    }
+
+                    # Store organisation
+                    data['organisation'] = current_user_record['organisation']
+
+                    # Project identifier
+                    if project.get('identifier'):
+                        data['identifiedBy'] = {
+                            'type': 'bf:Identifier',
+                            'value': project['identifier']
+                        }
+                        data.pop('identifier')
+
+                    # Investigators
+                    if project.get('investigators'):
+                        data['investigators'] = []
+                        for investigator in project['investigators']:
+                            investigator_data = {
+                                'agent': {
+                                    'preferred_name': investigator['name']
+                                },
+                                'role': [investigator['role']],
+                            }
+
+                            if investigator.get('affiliation'):
+                                investigator_data[
+                                    'affiliation'] = investigator.get(
+                                        'affiliation')
+
+                            if investigator.get('orcid'):
+                                investigator_data['identifiedBy'] = {
+                                    'type': 'bf:Local',
+                                    'source': 'ORCID',
+                                    'value': investigator.get('orcid')
+                                }
+
+                            data['investigators'].append(investigator_data)
+
+                    # Funding organisations
+                    if project.get('funding_organisations'):
+                        data['funding_organisations'] = []
+                        for funding_organisation in project[
+                                'funding_organisations']:
+                            funding_organisation_data = {
+                                'agent': {
+                                    'preferred_name':
+                                    funding_organisation['name']
+                                }
+                            }
+
+                            if funding_organisation.get('identifier'):
+                                funding_organisation_data['identifiedBy'] = {
+                                    'type': 'bf:Identifier',
+                                    'value': funding_organisation['identifier']
+                                }
+
+                            data['funding_organisations'].append(
+                                funding_organisation_data)
+
+                    project_record = ProjectRecord.create(data, dbcommit=True)
+                    project_record.reindex()
+                    project = {
+                        '$ref':
+                        project_record.get_ref_link('projects',
+                                                    project_record['pid'])
+                    }
+
+                projects.append(project)
+
+            if projects:
+                metadata['projects'] = projects
 
         # License
         metadata['usageAndAccessPolicy'] = {

--- a/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
+++ b/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
@@ -380,7 +380,6 @@
                       "value": "bf:AudioIssueNumber",
                       "group": "------------"
                     },
-
                     {
                       "label": "bf:Ean",
                       "value": "bf:Ean",
@@ -839,10 +838,197 @@
             "minLength": 1,
             "pattern": "^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$",
             "form": {
-              "placeholder": "Example: 1111-2222-3333-4444"
+              "templateOptions": {
+                "placeholder": "Example: 1111-2222-3333-4444"
+              }
             }
           }
         }
+      }
+    },
+    "projects": {
+      "title": "Projects",
+      "type": "array",
+      "default": [{}],
+      "items": {
+        "title": "Project",
+        "type": "object",
+        "oneOf": [
+          {
+            "title": "Existing project",
+            "properties": {
+              "$ref": {
+                "title": "Project",
+                "type": "string",
+                "pattern": "^https://sonar.ch/api/projects/.*?$",
+                "minLength": 1,
+                "form": {
+                  "remoteTypeahead": {
+                    "type": "projects",
+                    "field": "autocomplete_name",
+                    "label": "name"
+                  }
+                }
+              }
+            },
+            "required": [
+              "$ref"
+            ]
+          },
+          {
+            "title": "Add a new project",
+            "properties": {
+              "name": {
+                "title": "Name",
+                "type": "string",
+                "minLength": 1
+              },
+              "description": {
+                "title": "Description",
+                "type": "string",
+                "minLength": 1,
+                "form": {
+                  "type": "textarea",
+                  "templateOptions": {
+                    "rows": 5
+                  }
+                }
+              },
+              "startDate": {
+                "title": "Start date",
+                "description": "Example: 2019-05-05",
+                "type": "string",
+                "format": "date",
+                "pattern": "^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$"
+              },
+              "endDate": {
+                "title": "End date",
+                "description": "Example: 2019-05-05",
+                "type": "string",
+                "format": "date",
+                "pattern": "^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$"
+              },
+              "identifier": {
+                "title": "Identifier",
+                "type": "string",
+                "minLength": 1
+              },
+              "investigators": {
+                "title": "Investigators",
+                "type": "array",
+                "items": {
+                  "title": "Investigator",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "title": "Name",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "role": {
+                      "title": "Role",
+                      "type": "string",
+                      "enum": [
+                        "investigator",
+                        "coinvestigator"
+                      ],
+                      "form": {
+                        "options": [
+                          {
+                            "label": "investigator",
+                            "value": "investigator"
+                          },
+                          {
+                            "label": "coinvestigator",
+                            "value": "coinvestigator"
+                          }
+                        ]
+                      }
+                    },
+                    "affiliation": {
+                      "title": "Affiliation",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "orcid": {
+                      "title": "ORCID",
+                      "type": "string",
+                      "minLength": 1,
+                      "pattern": "^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$",
+                      "form": {
+                        "templateOptions": {
+                          "placeholder": "Example: 1111-2222-3333-4444"
+                        }
+                      }
+                    }
+                  },
+                  "propertiesOrder": [
+                    "name",
+                    "role",
+                    "affiliation",
+                    "orcid"
+                  ],
+                  "required": [
+                    "name",
+                    "role"
+                  ]
+                },
+                "form": {
+                  "templateOptions": {
+                    "cssClass": "editor-title"
+                  }
+                }
+              },
+              "funding_organisations": {
+                "title": "Funding organisations",
+                "type": "array",
+                "items": {
+                  "title": "Funding organisation",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "title": "Name",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "identifier": {
+                      "title": "Identifier",
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "propertiesOrder": [
+                    "name",
+                    "identifier"
+                  ],
+                  "required": [
+                    "name"
+                  ]
+                },
+                "form": {
+                  "templateOptions": {
+                    "cssClass": "editor-title"
+                  }
+                }
+              }
+            },
+            "propertiesOrder": [
+              "name",
+              "description",
+              "startDate",
+              "endDate",
+              "identifier",
+              "investigators",
+              "funding_organisations"
+            ],
+            "required": [
+              "name",
+              "startDate"
+            ]
+          }
+        ]
       }
     },
     "diffusion": {
@@ -853,7 +1039,9 @@
           "$ref": "license-v1.0.0.json"
         }
       },
-      "required": ["license"]
+      "required": [
+        "license"
+      ]
     },
     "document": {
       "title": "Document",

--- a/sonar/modules/deposits/marshmallow/json.py
+++ b/sonar/modules/deposits/marshmallow/json.py
@@ -46,6 +46,7 @@ class DepositMetadataSchemaV1(StrictKeysMixin):
     status = SanitizedUnicode()
     step = SanitizedUnicode()
     user = fields.Dict()
+    projects = fields.List(fields.Dict())
     _files = fields.List(fields.Dict())
     _bucket = SanitizedUnicode()
     # When loading, if $schema is not provided, it's retrieved by

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -1197,8 +1197,13 @@
           "minLength": 1
         }
       },
-      "propertiesOrder": ["license", "label"],
-      "required": ["license"],
+      "propertiesOrder": [
+        "license",
+        "label"
+      ],
+      "required": [
+        "license"
+      ],
       "form": {
         "hide": true,
         "templateOptions": {
@@ -1285,9 +1290,9 @@
                     "type": "string",
                     "minLength": 1,
                     "form": {
-                      "hideExpression": "model.type !== 'bf:Local'",
+                      "hideExpression": "model && model.type !== 'bf:Local'",
                       "expressionProperties": {
-                        "templateOptions.required": "model.type === 'bf:Local'"
+                        "templateOptions.required": "model && model.type === 'bf:Local'"
                       }
                     }
                   },
@@ -1560,12 +1565,49 @@
           "cssClass": "editor-title"
         }
       }
+    },
+    "projects": {
+      "title": "Projects",
+      "type": "array",
+      "items": {
+        "title": "Project",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "$ref": {
+            "title": "Project",
+            "type": "string",
+            "pattern": "^https://sonar.ch/api/projects/.*?$",
+            "minLength": 1,
+            "form": {
+              "remoteTypeahead": {
+                "type": "projects",
+                "field": "autocomplete_name",
+                "label": "name"
+              }
+            }
+          }
+        },
+        "required": [
+          "$ref"
+        ]
+      },
+      "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        },
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
+      }
     }
   },
   "propertiesOrder": [
     "documentType",
     "title",
     "organisation",
+    "projects",
     "classification",
     "language",
     "abstracts",

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -1264,14 +1264,14 @@
                     "title": "Type",
                     "type": "string",
                     "enum": [
-                      "bf:Doi",
+                      "bf:Identifier",
                       "bf:Local"
                     ],
                     "form": {
                       "options": [
                         {
-                          "label": "bf:Doi",
-                          "value": "bf:Doi"
+                          "label": "bf:Identifier",
+                          "value": "bf:Identifier"
                         },
                         {
                           "label": "bf:Local",
@@ -1283,7 +1283,13 @@
                   "source": {
                     "title": "Source",
                     "type": "string",
-                    "minLength": 1
+                    "minLength": 1,
+                    "form": {
+                      "hideExpression": "model.type !== 'bf:Local'",
+                      "expressionProperties": {
+                        "templateOptions.required": "model.type === 'bf:Local'"
+                      }
+                    }
                   },
                   "value": {
                     "title": "Value",
@@ -1291,6 +1297,7 @@
                     "minLength": 1
                   }
                 },
+                "propertiesOrder": ["type", "source", "value"],
                 "form": {
                   "hideExpression": "field.parent.model.type !== 'bf:Person'"
                 }

--- a/sonar/modules/documents/mappings/v7/documents/document-v1.0.0.json
+++ b/sonar/modules/documents/mappings/v7/documents/document-v1.0.0.json
@@ -452,6 +452,17 @@
           }
         }
       },
+      "projects": {
+        "type": "object",
+        "properties": {
+          "pid": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "text"
+          }
+        }
+      },
       "_created": {
         "type": "date"
       },

--- a/sonar/modules/documents/marshmallow/json.py
+++ b/sonar/modules/documents/marshmallow/json.py
@@ -98,6 +98,7 @@ class DocumentMetadataSchemaV1(StrictKeysMixin):
     dissertation = fields.Dict()
     otherEdition = fields.List(fields.Dict())
     usageAndAccessPolicy = fields.Dict()
+    projects = fields.List(fields.Dict())
     _bucket = SanitizedUnicode()
     _files = Nested(FileSchemaV1, many=True)
     _oai = fields.Dict()

--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -157,6 +157,22 @@
       {% endif %}
 
       <dl class="row mb-0">
+        <!-- PROJECTS -->
+        {% if record.projects %}
+        <dt class="col-lg-3">
+          {{ _('Linked projects') }}
+        </dt>
+        <dd class="col-lg-9">
+          <ul class="list-unstyled mb-0">
+            {% for project in record.projects %}
+            <li class="p-0">
+              <a href="{{ url_for('documents.project_detail', pid_value=project.pid, view=view_code) }}">{{ project.name }}</a>
+            </li>
+            {% endfor %}
+          </ul>
+        </dd>
+        {% endif %}
+
         <!-- OTHER EDITION -->
         {% if record.otherEdition %}
         <dt class="col-lg-3">

--- a/sonar/modules/projects/__init__.py
+++ b/sonar/modules/projects/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Project module."""
+
+from __future__ import absolute_import, print_function

--- a/sonar/modules/projects/api.py
+++ b/sonar/modules/projects/api.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Project Api."""
+
+from functools import partial
+
+from ..api import SonarIndexer, SonarRecord, SonarSearch
+from ..fetchers import id_fetcher
+from ..minters import id_minter
+from ..providers import Provider
+
+# provider
+ProjectProvider = type('ProjectProvider', (Provider, ), dict(pid_type='proj'))
+# minter
+project_pid_minter = partial(id_minter, provider=ProjectProvider)
+# fetcher
+project_pid_fetcher = partial(id_fetcher, provider=ProjectProvider)
+
+
+class ProjectSearch(SonarSearch):
+    """Projects search."""
+
+    class Meta:
+        """Search only on item index."""
+
+        index = 'projects'
+        doc_types = []
+
+
+class ProjectRecord(SonarRecord):
+    """Project record."""
+
+    minter = project_pid_minter
+    fetcher = project_pid_fetcher
+    provider = ProjectProvider
+    schema = 'projects/project-v1.0.0.json'
+
+
+class ProjectIndexer(SonarIndexer):
+    """Project indexer."""
+
+    record_cls = ProjectRecord

--- a/sonar/modules/projects/jsonresolvers.py
+++ b/sonar/modules/projects/jsonresolvers.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Project resolver."""
+
+from __future__ import absolute_import, print_function
+
+import jsonresolver
+from invenio_pidstore.resolver import Resolver
+from invenio_records.api import Record
+
+
+# the host corresponds to the config value for the key JSONSCHEMAS_HOST
+@jsonresolver.route('/api/projects/<pid>', host='sonar.ch')
+def project_resolver(pid):
+    """Resolve referenced project."""
+    resolver = Resolver(pid_type='proj', object_type="rec",
+                        getter=Record.get_record)
+    _, record = resolver.resolve(pid)
+
+    if record.get('$schema'):
+        del record['$schema']
+
+    return record

--- a/sonar/modules/projects/jsonschemas/__init__.py
+++ b/sonar/modules/projects/jsonschemas/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""JSON schemas for projects."""

--- a/sonar/modules/projects/jsonschemas/projects/project-v1.0.0_src.json
+++ b/sonar/modules/projects/jsonschemas/projects/project-v1.0.0_src.json
@@ -112,6 +112,10 @@
         "value"
       ],
       "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        },
         "templateOptions": {
           "cssClass": "editor-title"
         }
@@ -120,7 +124,6 @@
     "investigators": {
       "title": "Investigators",
       "type": "array",
-      "minItems": 1,
       "items": {
         "title": "Investigator",
         "type": "object",
@@ -190,6 +193,10 @@
         ]
       },
       "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        },
         "templateOptions": {
           "cssClass": "editor-title"
         }
@@ -198,7 +205,6 @@
     "funding_organisations": {
       "title": "Funding organisations",
       "type": "array",
-      "minItems": 1,
       "items": {
         "title": "Funding organisation",
         "type": "object",
@@ -235,6 +241,10 @@
         ]
       },
       "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        },
         "templateOptions": {
           "cssClass": "editor-title"
         }
@@ -311,8 +321,6 @@
   "required": [
     "name",
     "startDate",
-    "investigators",
-    "funding_organisations",
     "$schema"
   ]
 }

--- a/sonar/modules/projects/jsonschemas/projects/project-v1.0.0_src.json
+++ b/sonar/modules/projects/jsonschemas/projects/project-v1.0.0_src.json
@@ -1,0 +1,318 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://sonar.ch/schemas/projects/project-v1.0.0.json",
+  "additionalProperties": false,
+  "title": "Project",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "default": "https://sonar.ch/schemas/projects/project-v1.0.0.json"
+    },
+    "pid": {
+      "title": "Identifier",
+      "type": "string",
+      "minLength": 1
+    },
+    "name": {
+      "title": "Name",
+      "type": "string",
+      "minLength": 1,
+      "form": {
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
+      }
+    },
+    "description": {
+      "title": "Description",
+      "type": "string",
+      "minLength": 1,
+      "form": {
+        "type": "textarea",
+        "templateOptions": {
+          "cssClass": "editor-title",
+          "rows": 5
+        }
+      }
+    },
+    "startDate": {
+      "title": "Start date",
+      "description": "Example: 2019-05-05",
+      "type": "string",
+      "format": "date",
+      "pattern": "^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$",
+      "form": {
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
+      }
+    },
+    "endDate": {
+      "title": "End date",
+      "description": "Example: 2019-05-05",
+      "type": "string",
+      "format": "date",
+      "pattern": "^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$",
+      "form": {
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
+      }
+    },
+    "identifiedBy": {
+      "title": "Identifier",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "Type",
+          "type": "string",
+          "enum": [
+            "bf:Identifier",
+            "bf:Local"
+          ],
+          "form": {
+            "options": [
+              {
+                "label": "bf:Identifier",
+                "value": "bf:Identifier"
+              },
+              {
+                "label": "bf:Local",
+                "value": "bf:Local"
+              }
+            ]
+          }
+        },
+        "source": {
+          "title": "Source",
+          "type": "string",
+          "minLength": 1,
+          "form": {
+            "hideExpression": "model.type !== 'bf:Local'",
+            "expressionProperties": {
+              "templateOptions.required": "model.type === 'bf:Local'"
+            }
+          }
+        },
+        "value": {
+          "title": "Value",
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "propertiesOrder": [
+        "type",
+        "source",
+        "value"
+      ],
+      "required": [
+        "type",
+        "value"
+      ],
+      "form": {
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
+      }
+    },
+    "investigators": {
+      "title": "Investigators",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "title": "Investigator",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "agent": {
+            "title": "Agent",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "preferred_name": {
+                "title": "Preferred name",
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "propertiesOrder": [
+              "preferred_name"
+            ],
+            "required": [
+              "preferred_name"
+            ]
+          },
+          "role": {
+            "title": "Roles",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "title": "Role",
+              "type": "string",
+              "enum": [
+                "investigator",
+                "coinvestigator"
+              ],
+              "form": {
+                "options": [
+                  {
+                    "label": "investigator",
+                    "value": "investigator"
+                  },
+                  {
+                    "label": "coinvestigator",
+                    "value": "coinvestigator"
+                  }
+                ]
+              }
+            }
+          },
+          "affiliation": {
+            "title": "Affiliation",
+            "type": "string",
+            "minLength": 1
+          },
+          "identifiedBy": {
+            "$ref": "identifiedby-v1.0.0.json"
+          }
+        },
+        "propertiesOrder": [
+          "agent",
+          "role",
+          "affiliation",
+          "identifiedBy"
+        ],
+        "required": [
+          "agent",
+          "role"
+        ]
+      },
+      "form": {
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
+      }
+    },
+    "funding_organisations": {
+      "title": "Funding organisations",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "title": "Funding organisation",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "agent": {
+            "title": "Agent",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "preferred_name": {
+                "title": "Preferred name",
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "propertiesOrder": [
+              "preferred_name"
+            ],
+            "required": [
+              "preferred_name"
+            ]
+          },
+          "identifiedBy": {
+            "$ref": "identifiedby-v1.0.0.json"
+          }
+        },
+        "propertiesOrder": [
+          "agent",
+          "identifiedBy"
+        ],
+        "required": [
+          "agent"
+        ]
+      },
+      "form": {
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
+      }
+    },
+    "organisation": {
+      "title": "Organisation",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "title": "Organisation",
+          "type": "string",
+          "pattern": "^https://sonar.ch/api/organisations/.*?$",
+          "minLength": 1,
+          "form": {
+            "remoteOptions": {
+              "type": "organisations"
+            }
+          }
+        }
+      },
+      "required": [
+        "$ref"
+      ],
+      "form": {
+        "templateOptions": {
+          "cssClass": "editor-title"
+        },
+        "expressionProperties": {
+          "templateOptions.required": "true"
+        }
+      }
+    },
+    "user": {
+      "title": "User",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "$ref": {
+          "title": "User",
+          "type": "string",
+          "pattern": "^https://sonar.ch/api/users/.*?$",
+          "minLength": 1,
+          "form": {
+            "remoteOptions": {
+              "type": "users"
+            }
+          }
+        }
+      },
+      "required": [
+        "$ref"
+      ],
+      "form": {
+        "templateOptions": {
+          "cssClass": "editor-title"
+        },
+        "expressionProperties": {
+          "templateOptions.required": "true"
+        }
+      }
+    }
+  },
+  "propertiesOrder": [
+    "name",
+    "description",
+    "startDate",
+    "endDate",
+    "organisation",
+    "identifiedBy",
+    "investigators",
+    "funding_organisations"
+  ],
+  "required": [
+    "name",
+    "startDate",
+    "investigators",
+    "funding_organisations",
+    "$schema"
+  ]
+}

--- a/sonar/modules/projects/jsonschemas/projects/project-v1.0.0_src.json
+++ b/sonar/modules/projects/jsonschemas/projects/project-v1.0.0_src.json
@@ -90,9 +90,9 @@
           "type": "string",
           "minLength": 1,
           "form": {
-            "hideExpression": "model.type !== 'bf:Local'",
+            "hideExpression": "!model || model.type !== 'bf:Local'",
             "expressionProperties": {
-              "templateOptions.required": "model.type === 'bf:Local'"
+              "templateOptions.required": "model && model.type === 'bf:Local'"
             }
           }
         },

--- a/sonar/modules/projects/loaders/__init__.py
+++ b/sonar/modules/projects/loaders/__init__.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Loaders for projects."""
+
+from __future__ import absolute_import, print_function
+
+from invenio_records_rest.loaders.marshmallow import json_patch_loader, \
+    marshmallow_loader
+
+from ..marshmallow import ProjectMetadataSchemaV1
+
+#: JSON loader using Marshmallow for data validation.
+json_v1 = marshmallow_loader(ProjectMetadataSchemaV1)
+
+__all__ = (
+    'json_v1',
+)

--- a/sonar/modules/projects/mappings/__init__.py
+++ b/sonar/modules/projects/mappings/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Elasticsearch mapping for projects."""
+
+from __future__ import absolute_import, print_function

--- a/sonar/modules/projects/mappings/v7/__init__.py
+++ b/sonar/modules/projects/mappings/v7/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CERN.
+#
+# My site is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+
+"""Elasticsearch mapping for projects."""
+
+from __future__ import absolute_import, print_function

--- a/sonar/modules/projects/mappings/v7/projects/project-v1.0.0.json
+++ b/sonar/modules/projects/mappings/v7/projects/project-v1.0.0.json
@@ -1,4 +1,28 @@
 {
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 1,
+    "max_result_window": 20000,
+    "analysis": {
+      "filter": {
+        "autocomplete_filter": {
+          "type": "edge_ngram",
+          "min_gram": 1,
+          "max_gram": 20
+        }
+      },
+      "analyzer": {
+        "autocomplete": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "filter": [
+            "lowercase",
+            "autocomplete_filter"
+          ]
+        }
+      }
+    }
+  },
   "mappings": {
     "date_detection": false,
     "numeric_detection": false,
@@ -10,7 +34,13 @@
         "type": "keyword"
       },
       "name": {
-        "type": "text"
+        "type": "text",
+        "copy_to": "autocomplete_name"
+      },
+      "autocomplete_name": {
+        "type": "text",
+        "analyzer": "autocomplete",
+        "search_analyzer": "standard"
       },
       "description": {
         "type": "text"

--- a/sonar/modules/projects/mappings/v7/projects/project-v1.0.0.json
+++ b/sonar/modules/projects/mappings/v7/projects/project-v1.0.0.json
@@ -1,0 +1,104 @@
+{
+  "mappings": {
+    "date_detection": false,
+    "numeric_detection": false,
+    "properties": {
+      "$schema": {
+        "type": "keyword"
+      },
+      "pid": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "text"
+      },
+      "description": {
+        "type": "text"
+      },
+      "startDate": {
+        "type": "date"
+      },
+      "endDate": {
+        "type": "date"
+      },
+      "identifiedBy": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "keyword"
+          },
+          "source": {
+            "type": "text"
+          },
+          "value": {
+            "type": "text"
+          }
+        }
+      },
+      "investigators": {
+        "type": "object"
+      },
+      "funding_organisations": {
+        "type": "object",
+        "properties": {
+          "agent": {
+            "type": "object",
+            "properties": {
+              "preferred_name": {
+                "type": "text"
+              }
+            }
+          },
+          "identifiedBy": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "keyword"
+              },
+              "source": {
+                "type": "text"
+              },
+              "value": {
+                "type": "text"
+              }
+            }
+          }
+        }
+      },
+      "organisation": {
+        "type": "object",
+        "properties": {
+          "pid": {
+            "type": "keyword"
+          },
+          "code": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "text"
+          }
+        }
+      },
+      "user": {
+        "type": "object",
+        "properties": {
+          "pid": {
+            "type": "keyword"
+          },
+          "role": {
+            "type": "keyword"
+          },
+          "full_name": {
+            "type": "keyword"
+          }
+        }
+      },
+      "_created": {
+        "type": "date"
+      },
+      "_updated": {
+        "type": "date"
+      }
+    }
+  }
+}

--- a/sonar/modules/projects/marshmallow/__init__.py
+++ b/sonar/modules/projects/marshmallow/__init__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Marshmallow schemas for projects."""
+
+from __future__ import absolute_import, print_function
+
+from .json import ProjectMetadataSchemaV1, ProjectSchemaV1
+
+__all__ = ('ProjectMetadataSchemaV1', 'ProjectSchemaV1',)

--- a/sonar/modules/projects/marshmallow/json.py
+++ b/sonar/modules/projects/marshmallow/json.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Marshmallow schemas for projects."""
+
+from __future__ import absolute_import, print_function
+
+from functools import partial
+
+from flask_security import current_user
+from invenio_records_rest.schemas import StrictKeysMixin
+from invenio_records_rest.schemas.fields import GenFunction, \
+    PersistentIdentifier, SanitizedUnicode
+from marshmallow import fields, pre_dump, pre_load
+
+from sonar.modules.projects.api import ProjectRecord
+from sonar.modules.projects.permissions import ProjectPermission
+from sonar.modules.serializers import schema_from_context
+from sonar.modules.users.api import current_user_record
+
+schema_from_project = partial(schema_from_context, schema=ProjectRecord.schema)
+
+
+class ProjectMetadataSchemaV1(StrictKeysMixin):
+    """Schema for the project metadata."""
+
+    pid = PersistentIdentifier()
+    name = SanitizedUnicode(required=True)
+    description = SanitizedUnicode()
+    startDate = SanitizedUnicode()
+    endDate = SanitizedUnicode()
+    identifiedBy = fields.Dict()
+    investigators = fields.List(fields.Dict())
+    funding_organisations = fields.List(fields.Dict())
+    organisation = fields.Dict()
+    user = fields.Dict()
+    # When loading, if $schema is not provided, it's retrieved by
+    # Record.schema property.
+    schema = GenFunction(load_only=True,
+                         attribute="$schema",
+                         data_key="$schema",
+                         deserialize=schema_from_project)
+    permissions = fields.Dict(dump_only=True)
+
+    @pre_dump
+    def add_permissions(self, item, **kwargs):
+        """Add permissions to record.
+
+        :param item: Dict representing the record.
+        :returns: Modified dict.
+        """
+        item['permissions'] = {
+            'read': ProjectPermission.read(current_user, item),
+            'update': ProjectPermission.update(current_user, item),
+            'delete': ProjectPermission.delete(current_user, item)
+        }
+
+        return item
+
+    @pre_load
+    def remove_fields(self, data, **kwargs):
+        """Removes computed fields.
+
+        :param data: Dict of record data.
+        :returns: Modified data.
+        """
+        data.pop('permissions', None)
+
+        return data
+
+    @pre_load
+    def guess_organisation(self, data, **kwargs):
+        """Guess organisation from current logged user.
+
+        :param data: Dict of record data.
+        :returns: Modified dict of record data.
+        """
+        # Organisation already attached to document, we do nothing.
+        if data.get('organisation'):
+            return data
+
+        # Store current user organisation in new document.
+        if current_user_record.get('organisation'):
+            data['organisation'] = current_user_record['organisation']
+
+        return data
+
+    @pre_load
+    def guess_user(self, data, **kwargs):
+        """Guess user.
+
+        :param data: Dict of record data.
+        :returns: Modified dict of record data.
+        """
+        # If user is already set, we don't set it.
+        if data.get('user'):
+            return data
+
+        # Store current user in project.
+        data['user'] = {
+            '$ref':
+            current_user_record.get_ref_link('users',
+                                             current_user_record['pid'])
+        }
+
+        return data
+
+
+class ProjectSchemaV1(StrictKeysMixin):
+    """Project schema."""
+
+    metadata = fields.Nested(ProjectMetadataSchemaV1)
+    created = fields.Str(dump_only=True)
+    updated = fields.Str(dump_only=True)
+    links = fields.Dict(dump_only=True)
+    id = PersistentIdentifier()
+    explanation = fields.Raw(dump_only=True)

--- a/sonar/modules/projects/marshmallow/json.py
+++ b/sonar/modules/projects/marshmallow/json.py
@@ -32,7 +32,6 @@ from sonar.modules.projects.api import ProjectRecord
 from sonar.modules.projects.permissions import ProjectPermission
 from sonar.modules.serializers import schema_from_context
 from sonar.modules.users.api import current_user_record
-from sonar.modules.utils import localize_date
 
 schema_from_project = partial(schema_from_context, schema=ProjectRecord.schema)
 
@@ -62,10 +61,6 @@ class ProjectMetadataSchemaV1(StrictKeysMixin):
     @pre_dump
     def format_data(self, item, **kwargs):
         """Format data before dumping object."""
-        item['startDate'] = localize_date(item['startDate'])
-        if item.get('endDate'):
-            item['endDate'] = localize_date(item['endDate'])
-
         # Add documents
         item['documents'] = DocumentRecord.get_documents_by_project(
             item['pid'])

--- a/sonar/modules/projects/permissions.py
+++ b/sonar/modules/projects/permissions.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Permissions for projects."""
+
+from sonar.modules.organisations.api import current_organisation
+from sonar.modules.permissions import RecordPermission
+from sonar.modules.projects.api import ProjectRecord
+from sonar.modules.users.api import current_user_record
+
+
+class ProjectPermission(RecordPermission):
+    """Projects permissions."""
+
+    @classmethod
+    def list(cls, user, record=None):
+        """List permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True is action can be done.
+        """
+        return (False if not current_user_record else
+                current_user_record.is_submitter)
+
+    @classmethod
+    def create(cls, user, record=None):
+        """Create permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True is action can be done.
+        """
+        return cls.list(user, record)
+
+    @classmethod
+    def read(cls, user, record):
+        """Read permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True is action can be done.
+        """
+        # At least for submitters logged users.
+        if not current_user_record or not current_user_record.is_submitter:
+            return False
+
+        # Superuser is allowd
+        if current_user_record.is_superuser:
+            return True
+
+        project = ProjectRecord.get_record_by_pid(record['pid'])
+        project = project.replace_refs()
+
+        # Moderators are allowed only for their organisation's deposits.
+        if current_user_record.is_moderator:
+            return current_organisation['pid'] == project['user'][
+                'organisation']['pid']
+
+        # Submitters have only access to their own deposits.
+        return current_user_record['pid'] == project['user']['pid']
+
+    @classmethod
+    def update(cls, user, record):
+        """Update permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True is action can be done.
+        """
+        return cls.read(user, record)
+
+    @classmethod
+    def delete(cls, user, record):
+        """Delete permission check.
+
+        :param user: Logged user.
+        :param recor: Record to check.
+        :returns: True if action can be done.
+        """
+        return cls.read(user, record)

--- a/sonar/modules/projects/query.py
+++ b/sonar/modules/projects/query.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Query for projects."""
+
+from flask import current_app
+
+from sonar.modules.organisations.api import current_organisation
+from sonar.modules.query import default_search_factory
+from sonar.modules.users.api import current_user_record
+
+
+def search_factory(self, search, query_parser=None):
+    """Project search factory.
+
+    :param search: Search instance.
+    :param query_parser: Url arguments.
+    :returns: Tuple with search instance and URL arguments.
+    """
+    search, urlkwargs = default_search_factory(self, search)
+
+    if current_app.config.get('SONAR_APP_DISABLE_PERMISSION_CHECKS'):
+        return (search, urlkwargs)
+
+    # For superusers, records are not filtered.
+    if current_user_record.is_superuser:
+        return (search, urlkwargs)
+
+    # For admin and moderator, only records that belongs to his organisation.
+    if current_user_record.is_moderator:
+        search = search.filter(
+            'term', organisation__pid=current_organisation['pid'])
+        return (search, urlkwargs)
+
+    # For user, only records that belongs to him.
+    if current_user_record.is_submitter:
+        search = search.filter(
+            'term', user__pid=current_user_record['pid'])
+
+    return (search, urlkwargs)

--- a/sonar/modules/projects/serializers/__init__.py
+++ b/sonar/modules/projects/serializers/__init__.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Projects serializers."""
+
+from __future__ import absolute_import, print_function
+
+from invenio_records_rest.serializers.response import record_responsify, \
+    search_responsify
+
+from sonar.modules.organisations.api import OrganisationRecord
+from sonar.modules.serializers import JSONSerializer as _JSONSerializer
+from sonar.modules.users.api import current_user_record
+
+from ..marshmallow import ProjectSchemaV1
+
+
+class JSONSerializer(_JSONSerializer):
+    """JSON serializer for projects."""
+
+    def post_process_serialize_search(self, results, pid_fetcher):
+        """Post process the search results."""
+        if current_user_record:
+            # Remove organisation facet for non super users
+            if not current_user_record.is_superuser:
+                results['aggregations'].pop('organisation', {})
+
+            # Remove organisation facet for non moderators users
+            if not current_user_record.is_moderator:
+                results['aggregations'].pop('user', {})
+
+        # Add organisation name
+        for org_term in results.get('aggregations',
+                                    {}).get('organisation',
+                                            {}).get('buckets', []):
+            organisation = OrganisationRecord.get_record_by_pid(
+                org_term['key'])
+            if organisation:
+                org_term['name'] = organisation['name']
+
+        return super(JSONSerializer,
+                     self).post_process_serialize_search(results, pid_fetcher)
+
+# Serializers
+# ===========
+#: JSON serializer definition.
+json_v1 = JSONSerializer(ProjectSchemaV1)
+
+# Records-REST serializers
+# ========================
+#: JSON record serializer for individual records.
+json_v1_response = record_responsify(json_v1, 'application/json')
+#: JSON record serializer for search results.
+json_v1_search = search_responsify(json_v1, 'application/json')
+
+__all__ = (
+    'json_v1',
+    'json_v1_response',
+    'json_v1_search',
+)

--- a/sonar/modules/utils.py
+++ b/sonar/modules/utils.py
@@ -20,6 +20,7 @@
 import datetime
 import re
 
+import pytz
 from flask import current_app, g
 from invenio_i18n.ext import current_i18n
 from invenio_mail.api import TemplatedMessage
@@ -158,6 +159,17 @@ def format_date(date):
                                           '%Y-%m-%d').strftime('%d.%m.%Y')
 
     return date
+
+
+def localize_date(date, format='%Y-%m-%d'):
+    """Localize the given date string.
+
+    :param date: String representation of the date.
+    :param format: Format of input date.
+    :returns: The localized date string.
+    """
+    return pytz.utc.localize(datetime.datetime.strptime(date,
+                                                        format)).isoformat()
 
 
 def get_specific_theme():

--- a/sonar/modules/utils.py
+++ b/sonar/modules/utils.py
@@ -161,17 +161,6 @@ def format_date(date):
     return date
 
 
-def localize_date(date, format='%Y-%m-%d'):
-    """Localize the given date string.
-
-    :param date: String representation of the date.
-    :param format: Format of input date.
-    :returns: The localized date string.
-    """
-    return pytz.utc.localize(datetime.datetime.strptime(date,
-                                                        format)).isoformat()
-
-
 def get_specific_theme():
     """Return the webpack entry for the current organisation.
 

--- a/sonar/theme/templates/sonar/projects/detail.html
+++ b/sonar/theme/templates/sonar/projects/detail.html
@@ -1,0 +1,87 @@
+{%- extends config.RECORDS_UI_BASE_TEMPLATE %}
+
+{% macro format_identifier(identifier) %}
+<span class="badge badge-secondary text-light mr-1">{{ _(record.identifiedBy.type) }}</span>
+{{ record.identifiedBy.value }}
+{% if record.identifiedBy.source %}
+<i class="text-muted ml-1">{{ record.identifiedBy.source }}</i>
+{% endif %}
+{% endmacro %}
+
+{% block body %}
+<h1>{{ record.name }}</h1>
+{% if record.description %}
+<div class="my-4">{{ record.description | nl2br | safe }}</div>
+{% endif %}
+
+<dl class="row mt-4">
+  <dt class="col-sm-3">{{ _('Start date') }}</dt>
+  <dd class="col-sm-9">{{ record.startDate | format_date }}</dd>
+
+  {% if record.endDate %}
+  <dt class="col-sm-3">{{ _('End date') }}</dt>
+  <dd class="col-sm-9">{{ record.endDate | format_date }}</dd>
+  {% endif %}
+
+  {% if record.identifiedBy %}
+  <dt class="col-sm-3">{{ _('Identifier') }}</dt>
+  <dd class="col-sm-9">{{ format_identifier(record.identifiedBy) }}</dd>
+  {% endif %}
+
+  <dt class="col-sm-3">{{ _('Investigators') }}</dt>
+  <dd class="col-sm-9">
+    <ul class="list-group list-group-flush">
+      {% for investigator in record.investigators %}
+      <li class="list-group-item px-0 py-1">
+        {{ investigator.agent.preferred_name }}
+        {% for role in investigator.role %}
+        <span class="badge badge-secondary text-light ml-1">{{ _(role) }}</span>
+        {% endfor %}
+        {% if investigator.affiliation or investigator.identifiedBy %}
+        <dl class="row mb-0">
+          {% if investigator.affiliation %}
+          <dt class="col-sm-2">{{ _('Affiliation') }}</dt>
+          <dd class="col-sm-10 mb-0">{{ investigator.affiliation }}</dd>
+          {% endif%}
+          {% if investigator.identifiedBy %}
+          <dt class="col-sm-2">{{ _('Identifier') }}</dt>
+          <dd class="col-sm-10">
+            {{ format_identifier(record.identifiedBy) }}
+          </dd>
+          {% endif%}
+
+        </dl>
+        {% endif %}
+      </li>
+      {% endfor %}
+  </dd>
+
+  <dt class="col-sm-3">{{ _('Funding organisations') }}</dt>
+  <dd class="col-sm-9">
+    <ul class="list-group list-group-flush">
+      {% for funding_organisation in record.funding_organisations %}
+      <li class="list-group-item px-0 py-1">
+        {{ funding_organisation.agent.preferred_name }}
+        {% if funding_organisation.identifiedBy %}
+        <dl class="row mb-0 ng-star-inserted">
+          <dt class="col-sm-2">{{ _('Identifier') }}</dt>
+          <dd class="col-sm-10">{{ format_identifier(funding_organisation.identifiedBy) }}</dd>
+        </dl>
+        {% endif %}
+      </li>
+      {% endfor %}
+    </ul>
+  </dd>
+</dl>
+
+{% if record.documents %}
+<h4>{{ _('Linked documents') }}</h4>
+<ul>
+  {% for document in record.documents %}
+  <li>
+    <a href="{{ document.permalink }}">{{ document.title[0] | title_format(current_i18n.language) }}</a>
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% endblock body %}

--- a/sonar/theme/templates/sonar/projects/detail.html
+++ b/sonar/theme/templates/sonar/projects/detail.html
@@ -1,11 +1,12 @@
 {%- extends config.RECORDS_UI_BASE_TEMPLATE %}
 
 {% macro format_identifier(identifier) %}
-<span class="badge badge-secondary text-light mr-1">{{ _(record.identifiedBy.type) }}</span>
-{{ record.identifiedBy.value }}
-{% if record.identifiedBy.source %}
-<i class="text-muted ml-1">{{ record.identifiedBy.source }}</i>
+{% if identifier.source %}
+<span class="badge badge-secondary text-light mr-1">{{ _(identifier.source) }}</span>
+{% else %}
+<span class="badge badge-secondary text-light mr-1">{{ _(identifier.type) }}</span>
 {% endif %}
+{{ identifier.value }}
 {% endmacro %}
 
 {% block body %}
@@ -28,6 +29,7 @@
   <dd class="col-sm-9">{{ format_identifier(record.identifiedBy) }}</dd>
   {% endif %}
 
+  {% if record.investigators %}
   <dt class="col-sm-3">{{ _('Investigators') }}</dt>
   <dd class="col-sm-9">
     <ul class="list-group list-group-flush">
@@ -55,7 +57,9 @@
       </li>
       {% endfor %}
   </dd>
+  {% endif %}
 
+  {% if record.funding_organisations %}
   <dt class="col-sm-3">{{ _('Funding organisations') }}</dt>
   <dd class="col-sm-9">
     <ul class="list-group list-group-flush">
@@ -63,7 +67,7 @@
       <li class="list-group-item px-0 py-1">
         {{ funding_organisation.agent.preferred_name }}
         {% if funding_organisation.identifiedBy %}
-        <dl class="row mb-0 ng-star-inserted">
+        <dl class="row mb-0">
           <dt class="col-sm-2">{{ _('Identifier') }}</dt>
           <dd class="col-sm-10">{{ format_identifier(funding_organisation.identifiedBy) }}</dd>
         </dl>
@@ -72,6 +76,7 @@
       {% endfor %}
     </ul>
   </dd>
+  {% endif %}
 </dl>
 
 {% if record.documents %}

--- a/sonar/theme/views.py
+++ b/sonar/theme/views.py
@@ -40,6 +40,7 @@ from sonar.modules.deposits.permissions import DepositPermission
 from sonar.modules.documents.permissions import DocumentPermission
 from sonar.modules.organisations.permissions import OrganisationPermission
 from sonar.modules.permissions import can_access_manage_view
+from sonar.modules.projects.permissions import ProjectPermission
 from sonar.modules.users.api import UserRecord, current_user_record
 from sonar.modules.users.permissions import UserPermission
 
@@ -128,6 +129,10 @@ def logged_user():
             'deposits': {
                 'add': DepositPermission.create(user),
                 'list': DepositPermission.list(user)
+            },
+            'projects': {
+                'add': ProjectPermission.create(user),
+                'list': ProjectPermission.list(user)
             }
         }
 
@@ -155,7 +160,7 @@ def schemas(record_type):
 
         # TODO: Maybe find a proper way to do this.
         if record_type in [
-                'users', 'documents'
+                'users', 'documents', 'projects'
         ] and not current_user.is_anonymous and current_user_record:
             if record_type == 'users':
                 # If user is admin, restrict available roles list.

--- a/sonar/theme/views.py
+++ b/sonar/theme/views.py
@@ -26,6 +26,7 @@ from __future__ import absolute_import, print_function
 
 import re
 
+import dateutil.parser
 from flask import Blueprint, abort, current_app, jsonify, redirect, \
     render_template, request, url_for
 from flask_babelex import lazy_gettext as _
@@ -258,3 +259,14 @@ def prepare_schema(schema):
     hierarchize_form_options(schema)
 
     return schema
+
+
+@blueprint.app_template_filter()
+def format_date(date, format='%d/%m/%Y'):
+    """Format the given ISO format date string.
+
+    :param date: Date string in ISO format.
+    :param format: Output format.
+    :returns: Formatted date string.
+    """
+    return dateutil.parser.isoparse(date).strftime('%d/%m/%Y')

--- a/tests/api/projects/test_projects_permissions.py
+++ b/tests/api/projects/test_projects_permissions.py
@@ -1,0 +1,324 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test project permissions."""
+
+import json
+
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+
+from sonar.modules.deposits.api import DepositRecord
+
+
+def test_list(app, client, make_project, superuser, admin, moderator,
+              submitter, user):
+    """Test list projects permissions."""
+    make_project('submitter', 'org')
+    make_project('admin', 'org')
+    make_project('submitter', 'org2')
+
+    # Not logged
+    res = client.get(url_for('invenio_records_rest.proj_list'))
+    assert res.status_code == 401
+
+    # Not logged but permission checks disabled
+    app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
+    res = client.get(url_for('invenio_records_rest.proj_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total']['value'] == 3
+    app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=False)
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.get(url_for('invenio_records_rest.proj_list'))
+    assert res.status_code == 403
+
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
+    res = client.get(url_for('invenio_records_rest.proj_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total']['value'] == 1
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.get(url_for('invenio_records_rest.proj_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total']['value'] == 2
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.get(url_for('invenio_records_rest.proj_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total']['value'] == 2
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.get(url_for('invenio_records_rest.proj_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total']['value'] == 3
+
+
+def test_create(client, project_json, superuser, admin, moderator, submitter,
+                user):
+    """Test create project permissions."""
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+    }
+
+    # Not logged
+    res = client.post(url_for('invenio_records_rest.proj_list'),
+                      data=json.dumps(project_json),
+                      headers=headers)
+    assert res.status_code == 401
+
+    # User
+    login_user_via_session(client, email=user['email'])
+    res = client.post(url_for('invenio_records_rest.proj_list'),
+                      data=json.dumps(project_json),
+                      headers=headers)
+    assert res.status_code == 403
+
+    # submitter
+    login_user_via_session(client, email=submitter['email'])
+    res = client.post(url_for('invenio_records_rest.proj_list'),
+                      data=json.dumps(project_json),
+                      headers=headers)
+    assert res.status_code == 201
+
+    # Moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.post(url_for('invenio_records_rest.proj_list'),
+                      data=json.dumps(project_json),
+                      headers=headers)
+    assert res.status_code == 201
+
+    # Admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.post(url_for('invenio_records_rest.proj_list'),
+                      data=json.dumps(project_json),
+                      headers=headers)
+    assert res.status_code == 201
+
+    # Super user
+    login_user_via_session(client, email=superuser['email'])
+    res = client.post(url_for('invenio_records_rest.proj_list'),
+                      data=json.dumps(project_json),
+                      headers=headers)
+    assert res.status_code == 201
+
+
+def test_read(client, make_project, make_user, superuser, admin, moderator,
+              submitter, user):
+    """Test read project permissions."""
+    project1 = make_project('submitter', 'org')
+    project2 = make_project('submitter', 'org2')
+
+    # Not logged
+    res = client.get(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 401
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.get(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 403
+
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
+    res = client.get(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 200
+
+    res = client.get(
+        url_for('invenio_records_rest.proj_item', pid_value=project2['pid']))
+    assert res.status_code == 403
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.get(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 200
+
+    res = client.get(
+        url_for('invenio_records_rest.proj_item', pid_value=project2['pid']))
+    assert res.status_code == 403
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.get(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 200
+
+    res = client.get(
+        url_for('invenio_records_rest.proj_item', pid_value=project2['pid']))
+    assert res.status_code == 403
+
+    # Logged as admin of other organisation
+    other_admin = make_user('admin', 'org2')
+    login_user_via_session(client, email=other_admin['email'])
+    res = client.get(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 403
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.get(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 200
+
+
+def test_update(client, make_project, superuser, admin, moderator, submitter,
+                user):
+    """Test update project permissions."""
+    project1 = make_project('submitter', 'org')
+    project2 = make_project('submitter', 'org2')
+
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+    }
+
+    # Not logged
+    res = client.put(url_for('invenio_records_rest.proj_item',
+                             pid_value=project1['pid']),
+                     data=json.dumps(project1.dumps()),
+                     headers=headers)
+    assert res.status_code == 401
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.put(url_for('invenio_records_rest.proj_item',
+                             pid_value=project1['pid']),
+                     data=json.dumps(project1.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
+    res = client.put(url_for('invenio_records_rest.proj_item',
+                             pid_value=project1['pid']),
+                     data=json.dumps(project1.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+    res = client.put(url_for('invenio_records_rest.proj_item',
+                             pid_value=project2['pid']),
+                     data=json.dumps(project2.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.put(url_for('invenio_records_rest.proj_item',
+                             pid_value=project1['pid']),
+                     data=json.dumps(project1.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+    res = client.put(url_for('invenio_records_rest.proj_item',
+                             pid_value=project2['pid']),
+                     data=json.dumps(project2.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.put(url_for('invenio_records_rest.proj_item',
+                             pid_value=project1['pid']),
+                     data=json.dumps(project1.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+    res = client.put(url_for('invenio_records_rest.proj_item',
+                             pid_value=project2['pid']),
+                     data=json.dumps(project2.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.put(url_for('invenio_records_rest.proj_item',
+                             pid_value=project1['pid']),
+                     data=json.dumps(project1.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+    login_user_via_session(client, email=superuser['email'])
+    res = client.put(url_for('invenio_records_rest.proj_item',
+                             pid_value=project2['pid']),
+                     data=json.dumps(project2.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+
+def test_delete(client, db, make_project, superuser, admin, moderator,
+                submitter, user):
+    """Test delete deposits permissions."""
+    project1 = make_project('submitter', 'org')
+    project2 = make_project('submitter', 'org2')
+
+    # Not logged
+    res = client.delete(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 401
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 403
+
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.proj_item', pid_value=project2['pid']))
+    assert res.status_code == 403
+
+    project1 = make_project('submitter', 'org')
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.proj_item', pid_value=project2['pid']))
+    assert res.status_code == 403
+
+    res = client.delete(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 204
+
+    project1 = make_project('submitter', 'org')
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.proj_item', pid_value=project2['pid']))
+    assert res.status_code == 403
+
+    res = client.delete(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 204
+
+    project1 = make_project('submitter', 'org')
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.proj_item', pid_value=project1['pid']))
+    assert res.status_code == 204

--- a/tests/api/projects/test_projects_rest.py
+++ b/tests/api/projects/test_projects_rest.py
@@ -1,0 +1,249 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test REST endpoint for deposits."""
+
+import json
+
+from flask import url_for
+
+from sonar.modules.deposits.rest import FilesResource
+from sonar.modules.users.api import UserRecord
+
+
+def test_get(app, deposit):
+    """Test get a deposit by its ID."""
+    response = FilesResource.get(deposit['pid'])
+    assert response.status_code == 200
+    assert len(response.json) == 2
+
+
+def test_post(client, deposit):
+    """Test post file in deposit."""
+    # Test non existing deposit
+    url = '/deposits/10000/custom-files?key=1.pdf&type=additional'.format(
+        pid=deposit['pid'])
+    response = client.post(url)
+    assert response.status_code == 400
+
+    # Test non existing "key" paremeter
+    url = '/deposits/{pid}/custom-files?type=additional'.format(
+        pid=deposit['pid'])
+    response = client.post(url)
+    assert response.status_code == 400
+
+    # Test non existing "type" paremeter
+    url = '/deposits/{pid}/custom-files?key=1.pdf'.format(pid=deposit['pid'])
+    response = client.post(url)
+    assert response.status_code == 400
+
+    # Test type not in "main" or "additional"
+    url = '/deposits/{pid}/custom-files?key=1.pdf&type=fake'.format(
+        pid=deposit['pid'])
+    response = client.post(url)
+    assert response.status_code == 400
+
+    # OK
+    url = '/deposits/{pid}/custom-files?key=1.pdf&type=additional'.format(
+        pid=deposit['pid'])
+    response = client.post(url)
+    assert response.status_code == 200
+    assert response.content_type == 'application/json'
+    assert response.json['key'] == '1.pdf'
+
+
+def test_file_put(client, deposit):
+    """Test putting metadata on existing file."""
+    url = '/deposits/{pid}/custom-files/{key}'
+
+    # Non existing deposit
+    response = client.put(url.format(pid=10000, key='main.pdf'))
+    assert response.status_code == 400
+
+    # Non existing file
+    response = client.put(url.format(pid=deposit['pid'], key='fake.pdf'))
+    assert response.status_code == 400
+
+    # OK
+    response = client.put(url.format(pid=deposit['pid'], key='main.pdf'),
+                          data=json.dumps({'label': 'Updated label'}),
+                          headers={'Content-Type': 'application/json'})
+    assert response.status_code == 200
+    assert response.json['label'] == 'Updated label'
+
+    # With embargo date
+    response = client.put(url.format(pid=deposit['pid'], key='main.pdf'),
+                          data=json.dumps({'embargoDate': '2021-01-01'}),
+                          headers={'Content-Type': 'application/json'})
+    assert response.status_code == 200
+    assert response.json['embargoDate'] == '2021-01-01'
+
+    # With wrong embargo date
+    response = client.put(url.format(pid=deposit['pid'], key='main.pdf'),
+                          data=json.dumps({'embargoDate': '2021'}),
+                          headers={'Content-Type': 'application/json'})
+    assert response.status_code == 400
+
+    # Removing embargo date
+    response = client.put(url.format(pid=deposit['pid'], key='main.pdf'),
+                          data=json.dumps({'embargoDate': None}),
+                          headers={'Content-Type': 'application/json'})
+    assert response.status_code == 200
+    assert not response.json.get('embargoDate')
+
+
+def test_publish(client, db, user, moderator, deposit):
+    """Test publishing a deposit."""
+    url = url_for('deposits.publish', pid=deposit['pid'])
+
+    # Everything OK
+    response = client.post(url, data={})
+    assert response.status_code == 200
+
+    # Deposit is not in progress
+    deposit['status'] = 'validated'
+    deposit.commit()
+    db.session.commit()
+    response = client.post(url, data={})
+    assert response.status_code == 400
+
+    # Test the publication by a moderator
+    deposit['status'] = 'in_progress'
+    deposit.commit()
+    user['role'] = 'moderator'
+    user.commit()
+    db.session.commit()
+
+    response = client.post(url, data={})
+    assert response.status_code == 200
+
+
+def test_review(client, db, user, moderator, deposit):
+    """Test reviewing a deposit."""
+    url = url_for('deposits.review', pid=deposit['pid'])
+
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+    }
+
+    # Deposit is not in status to validate
+    response = client.post(url)
+    assert response.status_code == 400
+
+    # No payload posted
+    deposit['status'] = 'to_validate'
+    deposit.commit()
+    db.session.commit()
+
+    response = client.post(url)
+    assert response.status_code == 400
+
+    # Invalid action
+    response = client.post(url,
+                           data=json.dumps({
+                               'action': 'unknown',
+                               'comment': None
+                           }),
+                           headers=headers)
+    assert response.status_code == 400
+
+    # User is not a moderator
+    response = client.post(url,
+                           data=json.dumps({
+                               'action': 'approve',
+                               'comment': None,
+                               'user': {
+                                   '$ref':
+                                   UserRecord.get_ref_link(
+                                       'users', user['pid'])
+                               }
+                           }),
+                           headers=headers)
+    assert response.status_code == 403
+
+    # Valid approval request
+    response = client.post(url,
+                           data=json.dumps({
+                               'action': 'approve',
+                               'comment': None,
+                               'user': {
+                                   '$ref':
+                                   UserRecord.get_ref_link(
+                                       'users', moderator['pid'])
+                               }
+                           }),
+                           headers=headers)
+    assert response.status_code == 200
+
+    # Valid refusal request
+    deposit['status'] = 'to_validate'
+    deposit.commit()
+    db.session.commit()
+    response = client.post(url,
+                           data=json.dumps({
+                               'action': 'reject',
+                               'comment': 'Sorry deposit is not valid',
+                               'user': {
+                                   '$ref':
+                                   UserRecord.get_ref_link(
+                                       'users', moderator['pid'])
+                               }
+                           }),
+                           headers=headers)
+    assert response.status_code == 200
+
+    # Valid ask for changes request
+    deposit['status'] = 'to_validate'
+    deposit.commit()
+    db.session.commit()
+    response = client.post(url,
+                           data=json.dumps({
+                               'action': 'ask_for_changes',
+                               'comment': None,
+                               'user': {
+                                   '$ref':
+                                   UserRecord.get_ref_link(
+                                       'users', moderator['pid'])
+                               }
+                           }),
+                           headers=headers)
+    assert response.status_code == 200
+
+
+def test_extract_metadata(client, deposit):
+    """Test PDF metadata extraction."""
+    url = url_for('deposits.extract_metadata', pid=deposit['pid'])
+
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+    }
+
+    response = client.get(url, headers=headers)
+    assert response.status_code == 200
+    assert response.json[
+        'title'] == 'High-harmonic generation in quantum spin systems'
+
+    deposit.files['main.pdf'].remove()
+    response = client.get(url, headers=headers)
+    assert response.status_code == 500
+
+    response = client.get(url_for('deposits.extract_metadata',
+                                  pid='not-existing'),
+                          headers=headers)
+    assert response.status_code == 400

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ from invenio_files_rest.models import Location
 from sonar.modules.deposits.api import DepositRecord
 from sonar.modules.documents.api import DocumentRecord
 from sonar.modules.organisations.api import OrganisationRecord
+from sonar.modules.projects.api import ProjectRecord
 from sonar.modules.users.api import UserRecord
 
 
@@ -575,6 +576,103 @@ def deposit(app, db, user, pdf_file, bucket_location, deposit_json):
     db.session.commit()
 
     return deposit
+
+
+@pytest.fixture()
+def project_json():
+    """Project JSON."""
+    return {
+        '$schema':
+        'https://sonar.ch/schemas/projects/project-v1.0.0.json',
+        'pid':
+        '11111',
+        'name':
+        'Project 1',
+        'description':
+        'Description of the project',
+        'startDate':
+        '2019-01-01',
+        'endDate':
+        '2020-01-01',
+        'identifiedBy': {
+            'type': 'bf:Local',
+            'source': 'RERO',
+            'value': '1111'
+        },
+        'investigators': [{
+            'agent': {
+                'preferred_name': 'John Doe'
+            },
+            'role': ['investigator'],
+            'affiliation': 'An affiliation',
+            'identifiedBy': {
+                'type': 'bf:Local',
+                'source': 'RERO',
+                'value': '2222'
+            }
+        }],
+        'funding_organisations': [{
+            'agent': {
+                'preferred_name': 'Funding organisation'
+            },
+            'identifiedBy': {
+                'type': 'bf:Local',
+                'source': 'RERO',
+                'value': '3333'
+            }
+        }]
+    }
+
+
+@pytest.fixture()
+def make_project(db, project_json, make_user):
+    """Factory for creating project."""
+
+    def _make_project(role='submitter', organisation=None):
+        user = make_user(role, organisation)
+
+        project_json['user'] = {
+            '$ref': 'https://sonar.ch/api/users/{pid}'.format(pid=user['pid'])
+        }
+
+        project_json['organisation'] = {
+            '$ref':
+            'https://sonar.ch/api/organisations/{pid}'.format(pid=organisation)
+        }
+
+        project_json.pop('pid', None)
+
+        record = ProjectRecord.create(project_json,
+                                      dbcommit=True,
+                                      with_bucket=False)
+        record.commit()
+        record.reindex()
+        db.session.commit()
+
+        return record
+
+    return _make_project
+
+
+@pytest.fixture()
+def project(app, db, user, organisation, project_json):
+    """Deposit fixture."""
+    json = copy.deepcopy(project_json)
+    json['user'] = {
+        '$ref': 'https://sonar.ch/api/users/{pid}'.format(pid=user['pid'])
+    }
+    json['organisation'] = {
+        '$ref':
+        'https://sonar.ch/api/organisations/{pid}'.format(
+            pid=organisation['pid'])
+    }
+
+    project = ProjectRecord.create(json, dbcommit=True, with_bucket=False)
+    project.commit()
+    project.reindex()
+    db.session.commit()
+
+    return project
 
 
 @pytest.fixture()

--- a/tests/ui/deposits/test_deposits_api.py
+++ b/tests/ui/deposits/test_deposits_api.py
@@ -20,8 +20,36 @@
 from invenio_accounts.testutils import login_user_via_view
 
 
-def test_create_document(app, client, deposit, user):
+def test_create_document(app, db, project, client, deposit, user):
     """Test create document based on it."""
+    deposit['projects'] = [{
+        '$ref': 'https://sonar.ch/api/projects/11111'
+    }, {
+        'name':
+        'Project 1',
+        'description':
+        'Description',
+        'identifier':
+        'p-1000',
+        'startDate':
+        '2020-01-01',
+        'endDate':
+        '2021-12-31',
+        'investigators': [{
+            'name': 'John Doe',
+            'role': 'investigator',
+            'affiliation': 'RERO',
+            'orcid': '1000-1000-1000-1000'
+        }],
+        'funding_organisations': [{
+            'name': 'Funding organisation',
+            'identifier': 'f-1000'
+        }]
+    }]
+    deposit.commit()
+    deposit.reindex()
+    db.session.commit()
+
     login_user_via_view(client, email=user['email'], password='123456')
 
     document = deposit.create_document()
@@ -128,6 +156,8 @@ def test_create_document(app, client, deposit, user):
         'type': 'bf:Doi',
         'value': '10.1038/nphys1170'
     }]
+
+    assert len(document['projects']) == 2
 
     assert document.files['main.pdf']['access'] == 'coar:c_f1cf'
     assert document.files['main.pdf']['restricted_outside_organisation']

--- a/tests/ui/documents/test_documents_api.py
+++ b/tests/ui/documents/test_documents_api.py
@@ -88,3 +88,15 @@ def test_get_files_list(document, pdf_file):
     files = document.get_files_list()
     assert len(files) == 3
     assert files[0]['order'] == 1
+
+
+def test_get_documents_by_project(db, project, document):
+    """"Test getting documents by a project."""
+    document['projects'] = [{'$ref': 'https://sonar.ch/api/projects/11111'}]
+    document.commit()
+    document.reindex()
+    db.session.commit()
+
+    documents = DocumentRecord.get_documents_by_project(project['pid'])
+    assert documents[0]['pid'] == '1'
+    assert documents[0]['permalink'] == 'http://localhost/global/documents/1'

--- a/tests/ui/documents/test_documents_views.py
+++ b/tests/ui/documents/test_documents_views.py
@@ -349,3 +349,12 @@ def test_contribution_text():
             'place': 'Place'
         }
     }) == 'Meeting (1234 : 2019 : Place)'
+
+
+def test_project_detail(app, client, project):
+    """Test project detail page."""
+    assert client.get(url_for('documents.project_detail',
+                              pid_value=project['pid'])).status_code == 200
+
+    assert client.get(url_for('documents.project_detail',
+                              pid_value='not-existing')).status_code == 404

--- a/tests/ui/projects/test_projects_jsonresolvers.py
+++ b/tests/ui/projects/test_projects_jsonresolvers.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2019 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test projects jsonresolvers."""
+
+
+def test_projects_resolver(document, project):
+    """Test project resolver."""
+    document['project'] = {'$ref': 'https://sonar.ch/api/projects/11111'}
+    assert document['project']['$ref'] == 'https://sonar.ch/api/projects/11111'
+    assert document.replace_refs().get('project')['name'] == 'Project 1'


### PR DESCRIPTION
* Adds projects to documents when it is created from a deposit.
* Adds `projects` property to deposit JSON schema.
* Adds `projects` property to deposit marshmallow schema.
* Makes `investigators` and `funding_organisations` not mandatory and flags this properties as essentials.
* Removes formatting dates during projects serialization.
* Fixes macro for displaying identifiers.
* Removes unused function `localize_date`.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>