### PR TITLE
documents: add a back button in detail views

### DIFF
--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -24,6 +24,11 @@
 {% set files = record.get_files_list() %}
 
 <section class="mt-3">
+  <div class="mb-3">
+    <a href="javascript: history.back(-1)">
+      <i class="fa fa-arrow-left mr-1"></i> {{ _('Back') }}
+    </a>
+  </div>
   <div class="row">
     <div class="col-lg-3 text-center">
       {% if files and files | length > 0 %}

--- a/sonar/theme/templates/sonar/partial/organisation.html
+++ b/sonar/theme/templates/sonar/partial/organisation.html
@@ -28,9 +28,9 @@
             </form>
           </div>
           <div class="col text-right">
-            <a href="{{url_for('documents.index', view=config.SONAR_APP_DEFAULT_ORGANISATION)}}"
-              class="btn btn-outline-primary">
-              {{_('Back to SONAR')}}
+            <a href="{{ url_for('documents.index', view=config.SONAR_APP_DEFAULT_ORGANISATION) }}"
+              class="btn btn-outline-primary btn-sm">
+              {{ _('Back to SONAR') }}
             </a>
           </div>
         </div>


### PR DESCRIPTION
* Adds a button to go back to search results in documents detail views.
* Reduces the size of `Back to SONAR` button in organisation's context.
* Closes #383.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>