### PR TITLE
deposit: improve editor

### DIFF
--- a/babel.ini
+++ b/babel.ini
@@ -35,4 +35,4 @@ extract_messages = $._, jQuery._
 [ignore: **/**/document-v1.0.0.json]
 [ignore: **/**/deposit-v1.0.0.json]
 [json: **.json]
-keys_to_translate = ['^title$', '^label$', '^description$', '^placeholder$']
+keys_to_translate = ['^title$', '^label$', '^description$', '^placeholder$', '^.*Message$']

--- a/sonar/common/jsonschemas/type-v1.0.0.json
+++ b/sonar/common/jsonschemas/type-v1.0.0.json
@@ -62,217 +62,296 @@
         "value": "coar:c_3248"
       },
       {
-        "label": "document_type_coar:c_c94f",
-        "value": "coar:c_c94f"
-      },
-      {
         "label": "document_type_coar:c_5794",
-        "value": "coar:c_5794",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_18cp",
-        "value": "coar:c_18cp",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_6670",
-        "value": "coar:c_6670",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_18co",
-        "value": "coar:c_18co",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_f744",
-        "value": "coar:c_f744",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_ddb1",
-        "value": "coar:c_ddb1"
-      },
-      {
-        "label": "document_type_coar:c_3e5a",
-        "value": "coar:c_3e5a"
-      },
-      {
-        "label": "document_type_coar:c_beb9",
-        "value": "coar:c_beb9",
-        "level": 1
+        "value": "coar:c_5794"
       },
       {
         "label": "document_type_coar:c_6501",
-        "value": "coar:c_6501",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_998f",
-        "value": "coar:c_998f",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_dcae04bc",
-        "value": "coar:c_dcae04bc",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_8544",
-        "value": "coar:c_8544"
-      },
-      {
-        "label": "document_type_non_textual_object",
-        "value": "non_textual_object"
-      },
-      {
-        "label": "document_type_coar:c_8a7e",
-        "value": "coar:c_8a7e",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_ecc8",
-        "value": "coar:c_ecc8",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_12cc",
-        "value": "coar:c_12cc",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_18cc",
-        "value": "coar:c_18cc",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_18cw",
-        "value": "coar:c_18cw",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_5ce6",
-        "value": "coar:c_5ce6",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_15cd",
-        "value": "coar:c_15cd"
-      },
-      {
-        "label": "document_type_coar:c_2659",
-        "value": "coar:c_2659"
-      },
-      {
-        "label": "document_type_coar:c_0640",
-        "value": "coar:c_0640",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_2cd9",
-        "value": "coar:c_2cd9",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_2fe3",
-        "value": "coar:c_2fe3",
-        "level": 1
+        "value": "coar:c_6501"
       },
       {
         "label": "document_type_coar:c_816b",
         "value": "coar:c_816b"
       },
       {
+        "label": "document_type_coar:c_7a1f",
+        "value": "coar:c_7a1f"
+      },
+      {
+        "label": "document_type_coar:c_db06",
+        "value": "coar:c_db06"
+      },
+      {
+        "label": "document_type_coar:c_bdcc",
+        "value": "coar:c_bdcc"
+      },
+      {
+        "label": "document_type_coar:c_2f33",
+        "value": "coar:c_2f33",
+        "group": "------------"
+      },
+      {
+        "label": "document_type_coar:c_3248",
+        "value": "coar:c_3248",
+        "group": "------------"
+      },
+      {
+        "label": "document_type_coar:c_c94f",
+        "value": "coar:c_c94f",
+        "group": "------------"
+      },
+      {
+        "label": "document_type_coar:c_5794",
+        "value": "coar:c_5794",
+        "group": "------------",
+        "level": 1
+      },
+      {
+        "label": "document_type_coar:c_18cp",
+        "value": "coar:c_18cp",
+        "group": "------------",
+        "level": 1
+      },
+      {
+        "label": "document_type_coar:c_6670",
+        "value": "coar:c_6670",
+        "group": "------------",
+        "level": 1
+      },
+      {
+        "label": "document_type_coar:c_18co",
+        "value": "coar:c_18co",
+        "group": "------------",
+        "level": 1
+      },
+      {
+        "label": "document_type_coar:c_f744",
+        "value": "coar:c_f744",
+        "group": "------------",
+        "level": 1
+      },
+      {
+        "label": "document_type_coar:c_ddb1",
+        "value": "coar:c_ddb1",
+        "group": "------------"
+      },
+      {
+        "label": "document_type_coar:c_3e5a",
+        "value": "coar:c_3e5a",
+        "group": "------------"
+      },
+      {
+        "label": "document_type_coar:c_beb9",
+        "value": "coar:c_beb9",
+        "group": "------------",
+        "level": 1
+      },
+      {
+        "label": "document_type_coar:c_6501",
+        "value": "coar:c_6501",
+        "group": "------------",
+        "level": 1
+      },
+      {
+        "label": "document_type_coar:c_998f",
+        "value": "coar:c_998f",
+        "group": "------------",
+        "level": 1
+      },
+      {
+        "label": "document_type_coar:c_dcae04bc",
+        "value": "coar:c_dcae04bc",
+        "group": "------------",
+        "level": 1
+      },
+      {
+        "label": "document_type_coar:c_8544",
+        "value": "coar:c_8544",
+        "group": "------------"
+      },
+      {
+        "label": "document_type_non_textual_object",
+        "value": "non_textual_object",
+        "group": "------------"
+      },
+      {
+        "label": "document_type_coar:c_8a7e",
+        "value": "coar:c_8a7e",
+        "group": "------------",
+        "level": 1
+      },
+      {
+        "label": "document_type_coar:c_ecc8",
+        "value": "coar:c_ecc8",
+        "group": "------------",
+        "level": 1
+      },
+      {
+        "label": "document_type_coar:c_12cc",
+        "value": "coar:c_12cc",
+        "group": "------------",
+        "level": 1
+      },
+      {
+        "label": "document_type_coar:c_18cc",
+        "value": "coar:c_18cc",
+        "group": "------------",
+        "level": 1
+      },
+      {
+        "label": "document_type_coar:c_18cw",
+        "value": "coar:c_18cw",
+        "group": "------------",
+        "level": 1
+      },
+      {
+        "label": "document_type_coar:c_5ce6",
+        "value": "coar:c_5ce6",
+        "group": "------------",
+        "level": 1
+      },
+      {
+        "label": "document_type_coar:c_15cd",
+        "group": "------------",
+        "value": "coar:c_15cd"
+      },
+      {
+        "label": "document_type_coar:c_2659",
+        "group": "------------",
+        "value": "coar:c_2659"
+      },
+      {
+        "label": "document_type_coar:c_0640",
+        "value": "coar:c_0640",
+        "group": "------------",
+        "level": 1
+      },
+      {
+        "label": "document_type_coar:c_2cd9",
+        "value": "coar:c_2cd9",
+        "group": "------------",
+        "level": 1
+      },
+      {
+        "label": "document_type_coar:c_2fe3",
+        "value": "coar:c_2fe3",
+        "group": "------------",
+        "level": 1
+      },
+      {
+        "label": "document_type_coar:c_816b",
+        "value": "coar:c_816b",
+        "group": "------------"
+      },
+      {
         "label": "document_type_coar:c_93fc",
-        "value": "coar:c_93fc"
+        "value": "coar:c_93fc",
+        "group": "------------"
       },
       {
         "label": "document_type_coar:c_18ww",
         "value": "coar:c_18ww",
+        "group": "------------",
         "level": 1
       },
       {
         "label": "document_type_coar:c_18wz",
         "value": "coar:c_18wz",
+        "group": "------------",
         "level": 1
       },
       {
         "label": "document_type_coar:c_18wq",
         "value": "coar:c_18wq",
+        "group": "------------",
         "level": 1
       },
       {
         "label": "document_type_coar:c_186u",
         "value": "coar:c_186u",
+        "group": "------------",
         "level": 1
       },
       {
         "label": "document_type_coar:c_18op",
         "value": "coar:c_18op",
+        "group": "------------",
         "level": 1
       },
       {
         "label": "document_type_coar:c_ba1f",
         "value": "coar:c_ba1f",
+        "group": "------------",
         "level": 1
       },
       {
         "label": "document_type_coar:c_18hj",
         "value": "coar:c_18hj",
+        "group": "------------",
         "level": 1
       },
       {
         "label": "document_type_coar:c_18ws",
         "value": "coar:c_18ws",
+        "group": "------------",
         "level": 1
       },
       {
         "label": "document_type_coar:c_18gh",
         "value": "coar:c_18gh",
+        "group": "------------",
         "level": 1
       },
       {
         "label": "document_type_coar:c_46ec",
-        "value": "coar:c_46ec"
+        "value": "coar:c_46ec",
+        "group": "------------"
       },
       {
         "label": "document_type_coar:c_7a1f",
         "value": "coar:c_7a1f",
+        "group": "------------",
         "level": 1
       },
       {
         "label": "document_type_coar:c_db06",
         "value": "coar:c_db06",
+        "group": "------------",
         "level": 1
       },
       {
         "label": "document_type_coar:c_bdcc",
         "value": "coar:c_bdcc",
+        "group": "------------",
         "level": 1
       },
       {
         "label": "document_type_habilitation_thesis",
         "value": "habilitation_thesis",
+        "group": "------------",
         "level": 1
       },
       {
         "label": "document_type_advanced_studies_thesis",
         "value": "advanced_studies_thesis",
+        "group": "------------",
         "level": 1
       },
       {
         "label": "document_type_other",
         "value": "other",
+        "group": "------------",
         "level": 1
       },
       {
         "label": "document_type_coar:c_8042",
-        "value": "coar:c_8042"
+        "value": "coar:c_8042",
+        "group": "------------"
       },
       {
         "label": "document_type_coar:c_1843",
-        "value": "coar:c_1843"
+        "value": "coar:c_1843",
+        "group": "------------"
       }
     ],
     "templateOptions": {

--- a/sonar/modules/config.py
+++ b/sonar/modules/config.py
@@ -50,7 +50,7 @@ SONAR_APP_DEFAULT_ORGANISATION = 'global'
 """Default organisation key."""
 
 SONAR_APP_BABEL_TRANSLATE_JSON_KEYS = [
-    'title', 'label', 'description', 'placeholder'
+    'title', 'label', 'description', 'placeholder', 'patternMessage'
 ]
 """Keys to translate in JSON schemas."""
 

--- a/sonar/modules/deposits/api.py
+++ b/sonar/modules/deposits/api.py
@@ -145,13 +145,42 @@ class DepositRecord(SonarRecord):
         metadata['language'] = [{'value': language, 'type': 'bf:Language'}]
 
         # Document date
-        if self['metadata'].get('documentDate'):
-            metadata['provisionActivity'] = [{
+        metadata['provisionActivity'] = [{
+            'type':
+            'bf:Publication',
+            'startDate':
+            self['metadata']['documentDate']
+        }]
+        metadata['provisionActivity'][0]['statement'] = []
+
+        # Publication place
+        if self['metadata'].get('publicationPlace'):
+            metadata['provisionActivity'][0]['statement'].append({
+                'label': [{
+                    'value': self['metadata']['publicationPlace']
+                }],
                 'type':
-                'bf:Publication',
-                'startDate':
-                self['metadata']['documentDate']
-            }]
+                'bf:Place'
+            })
+
+        # Publisher
+        if self['metadata'].get('publisher'):
+            metadata['provisionActivity'][0]['statement'].append({
+                'label': [{
+                    'value': self['metadata']['publisher']
+                }],
+                'type':
+                'bf:Agent'
+            })
+
+        # Add a statement for date
+        metadata['provisionActivity'][0]['statement'].append({
+            'label': [{
+                'value': self['metadata']['documentDate']
+            }],
+            'type':
+            'Date'
+        })
 
         # Published in
         if self['metadata'].get('publication'):

--- a/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
+++ b/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
@@ -254,14 +254,17 @@
       "required": [
         "language",
         "title",
-        "documentType"
+        "documentType",
+        "documentDate"
       ],
       "propertiesOrder": [
         "documentType",
         "title",
         "subtitle",
-        "otherLanguageTitle",
         "language",
+        "otherLanguageTitle",
+        "publicationPlace",
+        "publisher",
         "documentDate",
         "identifiedBy",
         "publication",
@@ -282,7 +285,9 @@
           "minLength": 1,
           "form": {
             "type": "textarea",
-            "rows": 2
+            "templateOptions": {
+              "rows": 3
+            }
           }
         },
         "subtitle": {
@@ -313,14 +318,37 @@
         "language": {
           "$ref": "language-v1.0.0.json"
         },
-        "documentDate": {
-          "title": "Document date",
-          "description": "This field corresponds to the exact publication date of the article, if known.",
+        "publicationPlace": {
+          "title": "Publication place",
           "type": "string",
           "minLength": 1,
-          "pattern": "^[0-9]{4}(-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01]))?$",
           "form": {
-            "placeholder": "Example: 2019 or 2019-05-05"
+            "hideExpression": "!model.documentType || !['coar:c_2f33', 'coar:c_f744', 'coar:c_8a7e', 'coar:c_ecc8', 'coar:c_12cc', 'coar:c_18cc', 'coar:c_18cw', 'coar:c_5ce6', 'coar:c_15cd', 'coar:c_2659', 'coar:c_0640', 'coar:c_2cd9', 'coar:c_2fe3', 'coar:c_93fc', 'coar:c_18ww', 'coar:c_18wz', 'coar:c_18wq', 'coar:c_186u', 'coar:c_18op', 'coar:c_ba1f', 'coar:c_18hj', 'coar:c_18ws', 'coar:c_18gh', 'coar:c_46ec', 'coar:c_7a1f', 'coar:c_db06', 'coar:c_bdcc', 'coar:c_8042', 'coar:c_1843'].includes(model.documentType)"
+          }
+        },
+        "publisher": {
+          "title": "Publisher",
+          "type": "string",
+          "minLength": 1,
+          "form": {
+            "hideExpression": "!model.documentType || !['coar:c_2f33', 'coar:c_f744', 'coar:c_8a7e', 'coar:c_ecc8', 'coar:c_12cc', 'coar:c_18cc', 'coar:c_18cw', 'coar:c_5ce6', 'coar:c_15cd', 'coar:c_2659', 'coar:c_0640', 'coar:c_2cd9', 'coar:c_2fe3', 'coar:c_93fc', 'coar:c_18ww', 'coar:c_18wz', 'coar:c_18wq', 'coar:c_186u', 'coar:c_18op', 'coar:c_ba1f', 'coar:c_18hj', 'coar:c_18ws', 'coar:c_18gh', 'coar:c_46ec', 'coar:c_7a1f', 'coar:c_db06', 'coar:c_bdcc', 'coar:c_8042', 'coar:c_1843'].includes(model.documentType)"
+          }
+        },
+        "documentDate": {
+          "title": "Document date",
+          "description": "Enter the date in the format YYYY.",
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[0-9]{4}$",
+          "form": {
+            "templateOptions": {
+              "placeholder": "Example: 2020"
+            },
+            "validation": {
+              "messages": {
+                "patternMessage": "Format is not valid: YYYY."
+              }
+            }
           }
         },
         "identifiedBy": {
@@ -568,7 +596,9 @@
               "minLength": 1,
               "pattern": "^[0-9]+(-[0-9]+)?$",
               "form": {
-                "placeholder": "Examples: 135, 5-27, …"
+                "templateOptions": {
+                  "placeholder": "Examples: 135, 5-27, …"
+                }
               }
             },
             "editors": {
@@ -611,7 +641,9 @@
                 "type": "string",
                 "minLength": 1,
                 "form": {
-                  "placeholder": "Example: Published version"
+                  "templateOptions": {
+                    "placeholder": "Example: Published version"
+                  }
                 }
               },
               "url": {
@@ -670,7 +702,9 @@
                 "minLength": 1,
                 "form": {
                   "type": "textarea",
-                  "rows": 3
+                  "templateOptions": {
+                    "rows": 3
+                  }
                 }
               }
             }
@@ -743,7 +777,9 @@
               "type": "string",
               "pattern": "^[0-9]{4}(-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01]))?$",
               "form": {
-                "placeholder": "Example: 2019 or 2019-05-05"
+                "templateOptions": {
+                  "placeholder": "Example: 2019 or 2019-05-05"
+                }
               }
             }
           },

--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -51,7 +51,7 @@
       {% endif %}
     </div>
     <div class="col">
-      <h1 class="text-primary">{{ title }}</h1>
+      <h1 class="text-primary">{{ title | nl2br | safe }}</h1>
 
       <!-- CONTRIBUTORS-->
       {% set contributors = record | contributors %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -440,8 +440,10 @@ def deposit_json():
             },
             'language':
             'eng',
+            'publicationPlace': 'Place',
+            'publisher': 'Publisher name',
             'documentDate':
-            '2020-01-01',
+            '2020',
             'publication': {
                 'publishedIn': 'Journal',
                 'year': '2019',
@@ -680,7 +682,6 @@ def project(app, db, user, organisation, project_json):
 def bucket_location(app, db):
     """Create a default location for managing files."""
     tmppath = tempfile.mkdtemp()
-    print(tmppath)
     location = Location(name='default', uri=tmppath, default=True)
     db.session.add(location)
     db.session.commit()

--- a/tests/ui/deposits/test_deposits_api.py
+++ b/tests/ui/deposits/test_deposits_api.py
@@ -76,8 +76,26 @@ def test_create_document(app, db, project, client, deposit, user):
     }]
     assert document['language'] == [{'value': 'eng', 'type': 'bf:Language'}]
     assert document['provisionActivity'] == [{
-        'type': 'bf:Publication',
-        'startDate': '2020-01-01'
+        'type':
+        'bf:Publication',
+        'startDate':
+        '2020',
+        'statement': [{
+            'label': [{
+                'value': 'Place'
+            }],
+            'type': 'bf:Place'
+        }, {
+            'label': [{
+                'value': 'Publisher name'
+            }],
+            'type': 'bf:Agent'
+        }, {
+            'label': [{
+                'value': '2020'
+            }],
+            'type': 'Date'
+        }]
     }]
     assert document['partOf'] == [{
         'numberingYear': '2019',


### PR DESCRIPTION
* Adds `publicationPlace` and `publisher` properties.
* Makes date mandatory and changes description, pattern, placeholder and validation message.
* Moves `language` property before `otherLanguageTitle`.
* Displays a three rows textarea for title and abstracts.
* Fixes the display of all placeholders.
* Extracts translations messages from `*Message` in JSON schemas.
* Adds some preferred choices in document type enumeration.
* Adds provision activity statements for place and agent when a document is create from a deposit.
* Displays title with carriage returns in documents detail views.
* Closes #310.
* Closes #387.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>