### PR TITLE
db: drop tables instead of drop database

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -81,8 +81,8 @@ section "Clear files" "info"
 invenio utils clear-files
 
 section "Initialize database" "info"
-invenio db destroy --yes-i-know
-invenio db init create
+invenio db drop --yes-i-know
+invenio db create
 
 section "Initialize elasticsearch indexes" "info"
 invenio index destroy --force --yes-i-know


### PR DESCRIPTION
Drops all tables instead of drop database to avoid errors in production cluster, as DB user has no privileges to drop or create a database.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>