### PR TITLE
documents: set DOI clickable

### DIFF
--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -226,7 +226,11 @@
             {% for identifier in record.identifiedBy %}
             <li>
               <span class="badge badge-secondary text-light mr-1">{{ _(identifier.type) }}</span>
+              {% if identifier.type == 'bf:Doi' %}
+              <a href="https://doi.org/{{ identifier.value }}" target="_blank">{{ identifier.value }}</a>
+              {% else %}
               {{ identifier.value }}
+              {% endif %}
               {% if identifier.source %}
               <i class="text-muted ml-1">{{ identifier.source }}</i>
               {% endif %}


### PR DESCRIPTION
* Adds a link for identifiers of type `DOI`.
* Closes #403.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>