### PR TITLE
documents: allow multiple organisations

### DIFF
--- a/sonar/modules/deposits/api.py
+++ b/sonar/modules/deposits/api.py
@@ -104,7 +104,7 @@ class DepositRecord(SonarRecord):
 
         # Organisation
         if current_user_record and current_user_record.get('organisation'):
-            metadata['organisation'] = current_user_record['organisation']
+            metadata['organisation'] = [current_user_record['organisation']]
 
         # Document type
         metadata['documentType'] = self['metadata']['documentType']

--- a/sonar/modules/documents/dojson/rerodoc/model.py
+++ b/sonar/modules/documents/dojson/rerodoc/model.py
@@ -69,10 +69,10 @@ def marc21_to_type_and_organisation(self, key, value):
             overdo.create_organisation(organisation)
             overdo.registererd_organisations.append(organisation)
 
-        self['organisation'] = {
-            '$ref': OrganisationRecord.get_ref_link('organisations',
-                                                    organisation)
-        }
+        self['organisation'] = [{
+            '$ref':
+            OrganisationRecord.get_ref_link('organisations', organisation)
+        }]
 
     # get doc type by mapping
     key = value.get('a', '') + '|' + value.get('f', '')
@@ -677,10 +677,7 @@ def marc21_to_usage_and_access_policy(self, key, value):
     if not value.get('a'):
         return None
 
-    return {
-        'label': value.get('a'),
-        'license': 'Other OA / license undefined'
-    }
+    return {'label': value.get('a'), 'license': 'Other OA / license undefined'}
 
 
 @overdo.over('contribution', '^100..')

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -206,24 +206,28 @@
       "minLength": 1
     },
     "organisation": {
-      "title": "Organisation",
-      "type": "object",
-      "properties": {
-        "$ref": {
-          "title": "Organisation",
-          "type": "string",
-          "pattern": "^https://sonar.ch/api/organisations/.*?$",
-          "minLength": 1,
-          "form": {
-            "remoteOptions": {
-              "type": "organisations"
+      "title": "Organisations",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "title": "Organisation",
+        "type": "object",
+        "properties": {
+          "$ref": {
+            "type": "string",
+            "pattern": "^https://sonar.ch/api/organisations/.*?$",
+            "minLength": 1,
+            "form": {
+              "remoteOptions": {
+                "type": "organisations"
+              }
             }
           }
-        }
+        },
+        "required": [
+          "$ref"
+        ]
       },
-      "required": [
-        "$ref"
-      ],
       "form": {
         "templateOptions": {
           "cssClass": "editor-title"
@@ -1301,7 +1305,11 @@
                     "minLength": 1
                   }
                 },
-                "propertiesOrder": ["type", "source", "value"],
+                "propertiesOrder": [
+                  "type",
+                  "source",
+                  "value"
+                ],
                 "form": {
                   "hideExpression": "field.parent.model.type !== 'bf:Person'"
                 }

--- a/sonar/modules/documents/loaders/schemas/rerodoc.py
+++ b/sonar/modules/documents/loaders/schemas/rerodoc.py
@@ -33,7 +33,7 @@ class RerodocSchema(Marc21Schema):
     partOf = fields.List(fields.Dict())
     abstracts = fields.List(fields.Dict())
     contribution = fields.List(fields.Dict())
-    organisation = fields.Dict()
+    organisation = fields.List(fields.Dict())
     language = fields.List(fields.Dict())
     copyrightDate = fields.List(fields.String())
     editionStatement = fields.Dict()

--- a/sonar/modules/documents/marshmallow/json.py
+++ b/sonar/modules/documents/marshmallow/json.py
@@ -80,7 +80,7 @@ class DocumentMetadataSchemaV1(StrictKeysMixin):
     partOf = fields.List(fields.Dict())
     abstracts = fields.List(fields.Dict())
     contribution = fields.List(fields.Dict())
-    organisation = fields.Dict()
+    organisation = fields.List(fields.Dict())
     language = fields.List(fields.Dict())
     copyrightDate = fields.List(fields.String())
     editionStatement = fields.Dict()
@@ -195,7 +195,7 @@ class DocumentMetadataSchemaV1(StrictKeysMixin):
 
         # Store current user organisation in new document.
         if current_user_record.get('organisation'):
-            data['organisation'] = current_user_record['organisation']
+            data['organisation'] = [current_user_record['organisation']]
 
         return data
 

--- a/sonar/modules/documents/permissions.py
+++ b/sonar/modules/documents/permissions.py
@@ -83,7 +83,11 @@ class DocumentPermission(RecordPermission):
 
         # For admin or moderators users, they can access only to their
         # organisation's documents.
-        return current_organisation['pid'] == document['organisation']['pid']
+        for organisation in document['organisation']:
+            if current_organisation['pid'] == organisation['pid']:
+                return True
+
+        return False
 
     @classmethod
     def update(cls, user, record):

--- a/sonar/modules/documents/receivers.py
+++ b/sonar/modules/documents/receivers.py
@@ -140,9 +140,11 @@ def update_oai_property(sender, record):
 
     record['_oai']['updated'] = pytz.utc.localize(
         datetime.utcnow()).isoformat()
-    record['_oai']['sets'] = [
-        SonarRecord.get_pid_by_ref_link(record['organisation']['$ref'])
-    ] if record.get('organisation') else []
+    record['_oai']['sets'] = []
+
+    for organisation in record.get('organisation', []):
+        record['_oai']['sets'].append(
+            SonarRecord.get_pid_by_ref_link(organisation['$ref']))
 
 
 def export_json(sender=None, records=None, **kwargs):

--- a/tests/api/documents/test_documents_permissions.py
+++ b/tests/api/documents/test_documents_permissions.py
@@ -118,7 +118,7 @@ def test_create(client, document_json, superuser, admin, moderator, submitter,
                       data=json.dumps(document_json),
                       headers=headers)
     assert res.status_code == 201
-    assert res.json['metadata']['organisation'][
+    assert res.json['metadata']['organisation'][0][
         '$ref'] == 'https://sonar.ch/api/organisations/org'
 
     # Admin
@@ -127,7 +127,7 @@ def test_create(client, document_json, superuser, admin, moderator, submitter,
                       data=json.dumps(document_json),
                       headers=headers)
     assert res.status_code == 201
-    assert res.json['metadata']['organisation'][
+    assert res.json['metadata']['organisation'][0][
         '$ref'] == 'https://sonar.ch/api/organisations/org'
 
     # Super user
@@ -136,7 +136,7 @@ def test_create(client, document_json, superuser, admin, moderator, submitter,
                       data=json.dumps(document_json),
                       headers=headers)
     assert res.status_code == 201
-    assert res.json['metadata']['organisation'][
+    assert res.json['metadata']['organisation'][0][
         '$ref'] == 'https://sonar.ch/api/organisations/org'
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -368,9 +368,10 @@ def make_document(db, document_json, make_organisation, pdf_file):
     def _make_document(organisation='org', with_file=False, pid=None):
         if organisation:
             make_organisation(organisation)
-            document_json['organisation'] = {
-                '$ref': 'https://sonar.ch/api/organisations/org'
-            }
+            document_json['organisation'] = [{
+                '$ref':
+                'https://sonar.ch/api/organisations/org'
+            }]
 
         if pid:
             document_json['pid'] = pid
@@ -440,8 +441,10 @@ def deposit_json():
             },
             'language':
             'eng',
-            'publicationPlace': 'Place',
-            'publisher': 'Publisher name',
+            'publicationPlace':
+            'Place',
+            'publisher':
+            'Publisher name',
             'documentDate':
             '2020',
             'publication': {

--- a/tests/ui/deposits/test_deposits_api.py
+++ b/tests/ui/deposits/test_deposits_api.py
@@ -54,9 +54,10 @@ def test_create_document(app, db, project, client, deposit, user):
 
     document = deposit.create_document()
 
-    assert document['organisation'] == {
-        '$ref': 'https://sonar.ch/api/organisations/org'
-    }
+    assert document['organisation'] == [{
+        '$ref':
+        'https://sonar.ch/api/organisations/org'
+    }]
 
     assert document['documentType'] == 'coar:c_816b'
     assert document['title'] == [{

--- a/tests/ui/documents/dojson/rerodoc/test_rerodoc_model.py
+++ b/tests/ui/documents/dojson/rerodoc/test_rerodoc_model.py
@@ -58,9 +58,10 @@ def test_marc21_to_type_and_organisation(app, bucket_location,
     marc21json = create_record(marc21xml)
     data = overdo.do(marc21json)
     assert data.get('documentType') == 'coar:c_2f33'
-    assert data.get('organisation') == {
-        '$ref': 'https://sonar.ch/api/organisations/baage'
-    }
+    assert data.get('organisation') == [{
+        '$ref':
+        'https://sonar.ch/api/organisations/baage'
+    }]
 
     # Type, subtype and organisation
     marc21xml = """
@@ -78,9 +79,10 @@ def test_marc21_to_type_and_organisation(app, bucket_location,
     marc21json = create_record(marc21xml)
     data = overdo.do(marc21json)
     assert data.get('documentType') == 'coar:c_6501'
-    assert data.get('organisation') == {
-        '$ref': 'https://sonar.ch/api/organisations/baage'
-    }
+    assert data.get('organisation') == [{
+        '$ref':
+        'https://sonar.ch/api/organisations/baage'
+    }]
 
     # Organisation only
     marc21xml = """
@@ -96,9 +98,10 @@ def test_marc21_to_type_and_organisation(app, bucket_location,
     marc21json = create_record(marc21xml)
     data = overdo.do(marc21json)
     assert not data.get('documentType')
-    assert data.get('organisation') == {
-        '$ref': 'https://sonar.ch/api/organisations/baage'
-    }
+    assert data.get('organisation') == [{
+        '$ref':
+        'https://sonar.ch/api/organisations/baage'
+    }]
 
     # Specific conversion for unisi
     marc21xml = """
@@ -111,9 +114,10 @@ def test_marc21_to_type_and_organisation(app, bucket_location,
     marc21json = create_record(marc21xml)
     data = overdo.do(marc21json)
     assert not data.get('documentType')
-    assert data.get('organisation') == {
-        '$ref': 'https://sonar.ch/api/organisations/usi'
-    }
+    assert data.get('organisation') == [{
+        '$ref':
+        'https://sonar.ch/api/organisations/usi'
+    }]
 
 
 def test_marc21_to_title_245():

--- a/tests/ui/documents/test_dc_schema.py
+++ b/tests/ui/documents/test_dc_schema.py
@@ -39,9 +39,9 @@ def minimal_document(db, bucket_location, organisation):
                     'value': 'Title of the document'
                 }]
             }],
-            'organisation': {
+            'organisation': [{
                 '$ref': 'https://sonar.ch/api/organisations/org'
-            }
+            }]
         },
         dbcommit=True,
         with_bucket=True)

--- a/tests/ui/documents/test_documents_utils.py
+++ b/tests/ui/documents/test_documents_utils.py
@@ -64,7 +64,7 @@ def test_publication_statement_text():
 def test_get_file_restriction(app, organisation, admin, monkeypatch):
     """Test if a file is restricted by embargo date and/or organisation."""
     # No view arg, file is allowed
-    assert utils.get_file_restriction({}, organisation) == {
+    assert utils.get_file_restriction({}, [organisation]) == {
         'restricted': False,
         'date': None
     }
@@ -74,27 +74,27 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
         req.request.args = {'view': 'global'}
 
         # No access property, file is allowed
-        assert utils.get_file_restriction({}, organisation) == {
+        assert utils.get_file_restriction({}, [organisation]) == {
             'date': None,
             'restricted': False
         }
 
         # No access property, file is allowed
-        assert utils.get_file_restriction({}, organisation) == {
+        assert utils.get_file_restriction({}, [organisation]) == {
             'date': None,
             'restricted': False
         }
 
         # Access property is open access, file is allowed
         assert utils.get_file_restriction({'access': 'coar:c_abf2'},
-                                          organisation) == {
+                                          [organisation]) == {
                                               'date': None,
                                               'restricted': False
                                           }
 
         # Embargo access, but no date specified, file is allowed
         assert utils.get_file_restriction({'access': 'coar:c_f1cf'},
-                                          organisation) == {
+                                          [organisation]) == {
                                               'date': None,
                                               'restricted': False
                                           }
@@ -104,7 +104,7 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
             {
                 'access': 'coar:c_f1cf',
                 'embargo_date': 'wrong'
-            }, organisation) == {
+            }, [organisation]) == {
                 'date': None,
                 'restricted': False
             }
@@ -114,7 +114,7 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
             {
                 'access': 'coar:c_f1cf',
                 'embargo_date': '2010-01-01'
-            }, organisation) == {
+            }, [organisation]) == {
                 'date': None,
                 'restricted': False
             }
@@ -124,7 +124,7 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
             {
                 'access': 'coar:c_f1cf',
                 'embargo_date': '2022-01-01'
-            }, organisation) == {
+            }, [organisation]) == {
                 'date': '01/01/2022',
                 'restricted': True
             }
@@ -135,7 +135,7 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
                 'access': 'coar:c_f1cf',
                 'restricted_outside_organisation': False,
                 'embargo_date': '2022-01-01'
-            }, organisation) == {
+            }, [organisation]) == {
                 'date': '01/01/2022',
                 'restricted': True
             }
@@ -147,7 +147,7 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
                 'access': 'coar:c_f1cf',
                 'restricted_outside_organisation': True,
                 'embargo_date': '2022-01-01'
-            }, {}) == {
+            }, []) == {
                 'date': '01/01/2022',
                 'restricted': True
             }
@@ -159,7 +159,7 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
                 'access': 'coar:c_f1cf',
                 'restricted_outside_organisation': True,
                 'embargo_date': '2022-01-01'
-            }, None) == {
+            }, []) == {
                 'date': '01/01/2022',
                 'restricted': True
             }
@@ -174,7 +174,7 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
                 'access': 'coar:c_f1cf',
                 'restricted_outside_organisation': True,
                 'embargo_date': '2022-01-01'
-            }, organisation) == {
+            }, [organisation]) == {
                 'date': '01/01/2022',
                 'restricted': True
             }
@@ -189,7 +189,7 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
                 'access': 'coar:c_f1cf',
                 'restricted_outside_organisation': True,
                 'embargo_date': '2022-01-01'
-            }, organisation) == {
+            }, [organisation]) == {
                 'date': None,
                 'restricted': False
             }
@@ -205,7 +205,7 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
                 'access': 'coar:c_f1cf',
                 'restricted_outside_organisation': True,
                 'embargo_date': '2022-01-01'
-            }, organisation) == {
+            }, [organisation]) == {
                 'date': '01/01/2022',
                 'restricted': True
             }
@@ -218,7 +218,7 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
                 'access': 'coar:c_f1cf',
                 'restricted_outside_organisation': True,
                 'embargo_date': '2022-01-01'
-            }, organisation) == {
+            }, [organisation]) == {
                 'date': None,
                 'restricted': False
             }
@@ -229,7 +229,7 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
         # Restricted access, restriction is not defined, no access
         assert utils.get_file_restriction({
             'access': 'coar:c_16ec',
-        }, organisation) == {
+        }, [organisation]) == {
             'date': None,
             'restricted': True
         }
@@ -239,7 +239,7 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
             {
                 'access': 'coar:c_16ec',
                 'restricted_outside_organisation': False,
-            }, organisation) == {
+            }, [organisation]) == {
                 'date': None,
                 'restricted': True
             }
@@ -250,7 +250,7 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
             {
                 'access': 'coar:c_16ec',
                 'restricted_outside_organisation': True,
-            }, {}) == {
+            }, []) == {
                 'date': None,
                 'restricted': True
             }
@@ -261,7 +261,7 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
             {
                 'access': 'coar:c_16ec',
                 'restricted_outside_organisation': True,
-            }, None) == {
+            }, []) == {
                 'date': None,
                 'restricted': True
             }
@@ -275,7 +275,7 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
             {
                 'access': 'coar:c_16ec',
                 'restricted_outside_organisation': True,
-            }, organisation) == {
+            }, [organisation]) == {
                 'date': None,
                 'restricted': True
             }
@@ -289,7 +289,7 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
             {
                 'access': 'coar:c_16ec',
                 'restricted_outside_organisation': True,
-            }, organisation) == {
+            }, [organisation]) == {
                 'date': None,
                 'restricted': False
             }
@@ -304,7 +304,7 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
             {
                 'access': 'coar:c_16ec',
                 'restricted_outside_organisation': True,
-            }, organisation) == {
+            }, [organisation]) == {
                 'date': None,
                 'restricted': True
             }
@@ -316,7 +316,7 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
             {
                 'access': 'coar:c_16ec',
                 'restricted_outside_organisation': True,
-            }, organisation) == {
+            }, [organisation]) == {
                 'date': None,
                 'restricted': False
             }

--- a/tests/ui/documents/test_documents_views.py
+++ b/tests/ui/documents/test_documents_views.py
@@ -169,21 +169,22 @@ def test_has_external_urls_for_files(app):
     """Test if record has to point files to external URL or not."""
     assert views.has_external_urls_for_files({
         'pid': 1,
-        'organisation': {
+        'organisation': [{
             'pid': 'csal'
-        }
+        }]
     })
 
     assert not views.has_external_urls_for_files({
-        'pid': 1,
-        'organisation': {
+        'pid':
+        1,
+        'organisation': [{
             'pid': 'usi'
-        }
+        }]
     })
 
     assert not views.has_external_urls_for_files({
         'pid': 1,
-        'organisation': {}
+        'organisation': []
     })
 
     assert not views.has_external_urls_for_files({'pid': 1})
@@ -353,8 +354,10 @@ def test_contribution_text():
 
 def test_project_detail(app, client, project):
     """Test project detail page."""
-    assert client.get(url_for('documents.project_detail',
-                              pid_value=project['pid'])).status_code == 200
+    assert client.get(
+        url_for('documents.project_detail',
+                pid_value=project['pid'])).status_code == 200
 
-    assert client.get(url_for('documents.project_detail',
-                              pid_value='not-existing')).status_code == 404
+    assert client.get(
+        url_for('documents.project_detail',
+                pid_value='not-existing')).status_code == 404

--- a/tests/ui/organisations/test_jsonresolvers.py
+++ b/tests/ui/organisations/test_jsonresolvers.py
@@ -20,9 +20,9 @@
 
 def test_organisation_resolver(document):
     """Test organisation resolver."""
-    assert document['organisation'].get('$ref')
-    assert document['organisation'][
+    assert document['organisation'][0].get('$ref')
+    assert document['organisation'][0][
         '$ref'] == 'https://sonar.ch/api/organisations/org'
 
     assert document.replace_refs().get(
-        'organisation')['name'] == 'org'
+        'organisation')[0]['name'] == 'org'

--- a/tests/unit/documents/loaders/test_rerodoc_loader.py
+++ b/tests/unit/documents/loaders/test_rerodoc_loader.py
@@ -175,9 +175,9 @@ def test_rerodoc_loader(app, organisation):
         }],
         'documentType':
         'coar:c_6501',
-        'organisation': {
+        'organisation': [{
             '$ref': 'https://sonar.ch/api/organisations/org'
-        },
+        }],
         'classification': [{
             'type': 'bf:ClassificationUdc',
             'classificationPortion': '52'


### PR DESCRIPTION
* Allows to store multiple organisations for a document.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>