### PR TITLE
authentication: fix Switch edu-ID authentication

### DIFF
--- a/sonar/es_templates/v7/record.json
+++ b/sonar/es_templates/v7/record.json
@@ -20,6 +20,15 @@
             "icu_folding",
             "german_normalization"
           ]
+        },
+        "custom_keyword": {
+          "type": "custom",
+          "tokenizer": "keyword",
+          "filter": [
+            "lowercase",
+            "icu_folding",
+            "german_normalization"
+          ]
         }
       }
     }

--- a/sonar/modules/users/jsonschemas/users/user-v1.0.0.json
+++ b/sonar/modules/users/jsonschemas/users/user-v1.0.0.json
@@ -45,7 +45,9 @@
       "form": {
         "validation": {
           "validators": {
-            "valueAlreadyExists": {}
+            "valueAlreadyExists": {
+              "term": "email.analyzed"
+            }
           },
           "messages": {
             "pattern": "Email should have at least one `@` and  one `.`."

--- a/sonar/modules/users/mappings/v7/users/user-v1.0.0.json
+++ b/sonar/modules/users/mappings/v7/users/user-v1.0.0.json
@@ -24,7 +24,13 @@
         "type": "date"
       },
       "email": {
-        "type": "keyword"
+        "type": "keyword",
+        "fields": {
+          "analyzed": {
+            "type": "text",
+            "analyzer": "custom_keyword"
+          }
+        }
       },
       "street": {
         "type": "text"

--- a/tests/ui/shibboleth_authenticator/test_shibboleth_handlers.py
+++ b/tests/ui/shibboleth_authenticator/test_shibboleth_handlers.py
@@ -75,6 +75,9 @@ def test_authorized_signup_handler(app, roles, valid_sp_configuration,
         'sonar.modules.shibboleth_authenticator.handlers.oauth_get_user',
         lambda remote, account_info: None)
     monkeypatch.setattr(
+        'sonar.modules.shibboleth_authenticator.handlers.get_account_info',
+        lambda *args: {'user': {}})
+    monkeypatch.setattr(
         'sonar.modules.shibboleth_authenticator.handlers.oauth_register',
         lambda form: None)
     response = authorized_signup_handler(auth, 'idp')


### PR DESCRIPTION
* Fixes an issue when the accounts from Switch and Invenio are linked and the email address are not corresponding because of case sensivity.
* Closes #397.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>