### PR TITLE
help: fix TOC links

### DIFF
--- a/sonar/theme/assets/scss/common/_theme.scss
+++ b/sonar/theme/assets/scss/common/_theme.scss
@@ -33,3 +33,8 @@
     display: none;
   }
 }
+
+// Avoid dropdown menu to appear under the wiki TOC.
+div.wiki-page div.sticky-top {
+  z-index: 900;
+}

--- a/sonar/theme/templates/sonar/page.html
+++ b/sonar/theme/templates/sonar/page.html
@@ -100,7 +100,9 @@
 
     {%- endblock head %}
 
+    {% block base_href %}
     <base href="/">
+    {% endblock base_href %}
   </head>
   <body ng-csp {% if body_css_classes %} class="{{ body_css_classes|join(' ') }}"{% endif %}{% if g.ln %} lang="{{ g.ln.split('_', 1)[0]|safe }}"{% if rtl_direction %} {{ rtl_direction|safe }}{% endif %}{% endif %} itemscope itemtype="http://schema.org/WebPage" data-spy="scroll" data-target=".scrollspy-target">
     {%- block outer_body %}

--- a/sonar/theme/templates/sonar/page_wiki.html
+++ b/sonar/theme/templates/sonar/page_wiki.html
@@ -16,6 +16,10 @@
 #}
 {% extends 'sonar/page.html' %}
 
+{% block base_href %}
+<base href="{{ request.path }}">
+{% endblock base_href %}
+
 {%- block css %}
 {{ super() }}
 <link href="{{ url_for('wiki.static', filename='css/wiki.css') }}" rel="stylesheet" />


### PR DESCRIPTION
* Fixes links in table of contents by adding a `base href` tag into the page.
* Closes #450.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>