### PR TITLE
dependencies: ignore vulnerability

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -27,7 +27,9 @@ if [[ -z "${VIRTUAL_ENV}" ]]; then
   exit 1
 fi
 
-safety check && \
+# TODO: remove the ignored ID when this will corrected in Invenio:
+# https://github.com/inveniosoftware/invenio-previewer/blob/master/setup.py#L59
+safety check -i 39462 && \
 pydocstyle sonar tests docs && \
 isort --check-only --diff "${SCRIPT_PATH}/.." && \
 sphinx-build -qnNW docs docs/_build/html && \


### PR DESCRIPTION
Ignores temporarily a vulnerability in `tornado` library, because the a vulnerable version is forced in `invenio-previewer`.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>