### PR TITLE
documents: add `hiddenToPublic` property

### DIFF
--- a/sonar/heg/record/__init__.py
+++ b/sonar/heg/record/__init__.py
@@ -49,4 +49,8 @@ class HEGRecord():
                     SchemaFactory.create(source).dump(
                         self.data[record_source_key]), **record)
 
+        # Flag as hidden if no file provided
+        if not record.get('files'):
+            record['hiddenFromPublic'] = True
+
         return record

--- a/sonar/heg/serializers/schemas/unpaywall.py
+++ b/sonar/heg/serializers/schemas/unpaywall.py
@@ -17,7 +17,7 @@
 
 """Unpaywall schema."""
 
-from marshmallow import Schema, fields
+from marshmallow import Schema, fields, post_dump
 
 
 class UnpaywallSchema(Schema):
@@ -25,6 +25,11 @@ class UnpaywallSchema(Schema):
 
     files = fields.Method('get_files')
     oa_status = fields.Method('get_oa_status')
+
+    @post_dump
+    def remove_empty_values(self, data, **kwargs):
+        """Remove empty values before dumping data."""
+        return {key: value for key, value in data.items() if value}
 
     def get_files(self, obj):
         """Get files."""

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -1824,6 +1824,10 @@
       "title": "Open access status",
       "type": "string",
       "minLength": 1
+    },
+    "hiddenFromPublic": {
+      "title": "Hidden to public",
+      "type": "boolean"
     }
   },
   "propertiesOrder": [
@@ -1850,7 +1854,8 @@
     "additionalMaterials",
     "contentNote",
     "otherMaterialCharacteristics",
-    "usageAndAccessPolicy"
+    "usageAndAccessPolicy",
+    "hiddenFromPublic"
   ],
   "required": [
     "$schema",

--- a/sonar/modules/documents/mappings/v7/documents/document-v1.0.0.json
+++ b/sonar/modules/documents/mappings/v7/documents/document-v1.0.0.json
@@ -521,6 +521,9 @@
       "oa_status": {
         "type": "keyword"
       },
+      "hiddenFromPublic": {
+        "type": "boolean"
+      },
       "_created": {
         "type": "date"
       },

--- a/sonar/modules/documents/marshmallow/json.py
+++ b/sonar/modules/documents/marshmallow/json.py
@@ -100,6 +100,7 @@ class DocumentMetadataSchemaV1(StrictKeysMixin):
     usageAndAccessPolicy = fields.Dict()
     projects = fields.List(fields.Dict())
     oa_status = SanitizedUnicode()
+    hiddenFromPublic = fields.Boolean()
     _bucket = SanitizedUnicode()
     _files = Nested(FileSchemaV1, many=True)
     _oai = fields.Dict()

--- a/sonar/modules/documents/query.py
+++ b/sonar/modules/documents/query.py
@@ -84,9 +84,12 @@ def search_factory(self, search, query_parser=None):
         if view != current_app.config.get('SONAR_APP_DEFAULT_ORGANISATION'):
             search = search.filter('term', organisation__pid=view)
 
-        # Don't display records without file.
-        search = search.filter('bool', must={'exists': {'field': '_files'}})
-        search = search.filter('bool', must={'term': {'_files.type': 'file'}})
+        # Don't display records flagged as hidden
+        search = search.filter('bool',
+                               must_not={'term': {
+                                   'hiddenFromPublic': True
+                               }})
+
     # Admin
     else:
         # Filters records by user's organisation

--- a/sonar/modules/documents/views.py
+++ b/sonar/modules/documents/views.py
@@ -85,7 +85,7 @@ def detail(pid_value, view='global'):
     """Document detail page."""
     record = DocumentRecord.get_record_by_pid(pid_value)
 
-    if not record:
+    if not record or record.get('hiddenFromPublic'):
         abort(404)
 
     # Add restriction, link and thumbnail to files

--- a/tests/unit/heg/record/test_heg_record.py
+++ b/tests/unit/heg/record/test_heg_record.py
@@ -52,5 +52,6 @@ def test_serialize(app):
                 'value': 'Unknown title'
             }],
             'type': 'bf:Title'
-        }]
+        }],
+        'hiddenFromPublic': True
     }

--- a/tests/unit/heg/serializers/schemas/test_heg_serializers_schemas_unpaywall.py
+++ b/tests/unit/heg/serializers/schemas/test_heg_serializers_schemas_unpaywall.py
@@ -43,4 +43,4 @@ def test_unpaywall_schema(app):
 
     # Without images
     data = {'_id': '111', 'oa_status': 'green'}
-    assert UnpaywallSchema().dump(data) == {'oa_status': 'green', 'files': []}
+    assert UnpaywallSchema().dump(data) == {'oa_status': 'green'}


### PR DESCRIPTION
Adds a property to hide records in public views. This is needed for example for HEG, when a record has no file attached.

* Adds the `hiddenToPublic` property to documents.
* Does not search for records having the flag activated.
* Throws a 404 in detail view when the flag is activated.
* Removes empty properties when `Unpaywall` record is serialized.
* Flags HEG record as hidden if no file is linked to it.
* Closes #464.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>