### PR TITLE
HEG import: fix `es` language code

### DIFF
--- a/sonar/heg/serializers/schemas/heg.py
+++ b/sonar/heg/serializers/schemas/heg.py
@@ -40,8 +40,13 @@ class HEGSchema(Schema):
         """Pre-process record, before dumping."""
         # Store language
         if item.get('language'):
-            item['language'] = get_bibliographic_code_from_language(
-                item['language'])
+            language = item['language']
+
+            # As spanish code is `sp` in config.py
+            if language == 'es':
+                language = 'sp'
+
+            item['language'] = get_bibliographic_code_from_language(language)
         else:
             item['language'] = 'eng'
 

--- a/tests/unit/heg/cli/test_heg_cli_harvest.py
+++ b/tests/unit/heg/cli/test_heg_cli_harvest.py
@@ -43,7 +43,7 @@ def test_queue_files(app, script_info, monkeypatch):
     assert 'Files queued successfully' in result.output
 
 
-def test_import_records(app, script_info, monkeypatch):
+def test_import_records(app, script_info, monkeypatch, bucket_location):
     """Test import records."""
     # Data file not exist
     app.config.update(SONAR_APP_HEG_DATA_DIRECTORY='/non-existing/dir')

--- a/tests/unit/heg/serializers/schemas/test_heg_serializers_schemas_heg.py
+++ b/tests/unit/heg/serializers/schemas/test_heg_serializers_schemas_heg.py
@@ -35,6 +35,20 @@ def test_heg_schema(app):
         }]
     }
 
+    # With spanish language
+    data = {'_id': '111', 'language': 'es'}
+    assert HEGSchema().dump(data) == {
+        'documentType': 'coar:c_6501',
+        'identifiedBy': [{
+            'type': 'bf:Doi',
+            'value': '111'
+        }],
+        'language': [{
+            'type': 'bf:Language',
+            'value': 'spa'
+        }]
+    }
+
     # Without language
     data = {'_id': '111'}
     assert HEGSchema().dump(data) == {


### PR DESCRIPTION
Fixes an error when processing records with language code `es`. As the two digit code for spanish is `sp` in config.py.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>