### PR TITLE
HEG import: split files

### DIFF
--- a/tests/unit/heg/cli/test_heg_cli_harvest.py
+++ b/tests/unit/heg/cli/test_heg_cli_harvest.py
@@ -17,6 +17,8 @@
 
 """Test HEG harvest CLI."""
 
+from shutil import copyfile
+
 from click.testing import CliRunner
 
 from sonar.heg.cli.harvest import import_records, queue_files
@@ -55,6 +57,14 @@ def test_import_records(app, script_info, monkeypatch):
     # OK, with file param
     app.config.update(SONAR_APP_HEG_DATA_DIRECTORY='./tests/unit/heg/data')
     result = runner.invoke(import_records, ['--file', 'HEG_data_1.json'],
+                           obj=script_info)
+    assert 'Process finished' in result.output
+
+    # OK, with file param and remove file
+    copyfile('./tests/unit/heg/data/HEG_data_1.json',
+             './tests/unit/heg/data/HEG_data_2.json')
+    result = runner.invoke(import_records,
+                           ['--file', 'HEG_data_2.json', '--remove-file'],
                            obj=script_info)
     assert 'Process finished' in result.output
 

--- a/tests/unit/heg/ftp/test_heg_repository.py
+++ b/tests/unit/heg/ftp/test_heg_repository.py
@@ -95,7 +95,8 @@ def test_queue_files(monkeypatch):
 
     repository = HEGRepository('candy.hesge.ch', 'SONAR/baseline/complete')
     repository.queue_files('data.zip', './data/heg')
-    assert os.path.exists('./data/heg/HEG_data_1.json')
+    assert not os.path.exists('./data/heg/HEG_data_1.json')
+    assert os.path.exists('./data/heg/HEG_data_1_1.json')
 
 
 def test_remove_files_from_target():


### PR DESCRIPTION
* Splits source files into smaller files of 500 records.
* Removes file after it has been processed.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>