### PR TITLE
frontpage: remove banner

### DIFF
--- a/sonar/theme/templates/sonar/frontpage.html
+++ b/sonar/theme/templates/sonar/frontpage.html
@@ -58,8 +58,7 @@
   </div>
 </div>
 <div class="bg-secondary text-light text-center py-2">
-  <h6 class="m-0">{{ _('Software under development!') }}</h6>
-  {% if current_user_record.is_submitter %}
+  {% if config.ENV != 'production' and current_user_record.is_submitter %}
   <h6 class="m-0 mt-1">
     <strong>{{ _('Note: Publications manually deposited in this test portal might occasionally need to be deleted, for operational reasons.') }}</strong>
   </h6>


### PR DESCRIPTION
* Remove the banner indicating that the application is in development.
* Keeps the message that data can be erased, but only for non-production environments.
* Closes #107.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>