### PR TITLE
documents: fix controlled affiliation matching

### DIFF
--- a/sonar/affiliations/affiliation_resolver.py
+++ b/sonar/affiliations/affiliation_resolver.py
@@ -60,7 +60,7 @@ class AffiliationResolver():
 
         for affiliations in self.affiliations:
             for affiliation in affiliations:
-                if fuzz.partial_ratio(searched_affiliation, affiliation) > 90:
+                if fuzz.partial_ratio(searched_affiliation, affiliation) > 92:
                     return affiliations[0]
 
         return None

--- a/tests/unit/affiliations/test_affiliation_resolver.py
+++ b/tests/unit/affiliations/test_affiliation_resolver.py
@@ -44,5 +44,13 @@ def test_resolve():
     assert affiliation_resolver.resolve(
         test_string) == 'Uni of Zurich and Hospital'
 
+    test_string = (
+        'Centre for Research in Environmental Epidemiology (CREAL), Barcelona '
+        '08003, Spain; CIBER Epidemiología y Salud Pública (CIBERESP), '
+        'Barcelona 08003, Spain; Universitat Pompeu Fabra (UPF), Barcelona '
+        '08003, Spain; Hospital del Mar Medical Research Institute (IMIM), '
+        'Barcelona 08003, Spain.')
+    assert not affiliation_resolver.resolve(test_string)
+
     test_string = 'Not existing'
     assert not affiliation_resolver.resolve(test_string)


### PR DESCRIPTION
* Increases the score for affiliation matching, to avoid the error reported in the issue.
* Fixes #465.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>