### PR TITLE
HEG import: remove markup from abstract

### DIFF
--- a/sonar/heg/serializers/schemas/crossref.py
+++ b/sonar/heg/serializers/schemas/crossref.py
@@ -20,6 +20,7 @@
 import re
 
 from sonar.heg.serializers.schemas.heg import HEGSchema
+from sonar.modules.utils import remove_html
 
 
 class CrossrefSchema(HEGSchema):
@@ -55,7 +56,10 @@ class CrossrefSchema(HEGSchema):
         if not obj.get('abstract'):
             return None
 
-        return [{'value': obj['abstract'], 'language': obj['language']}]
+        return [{
+            'value': remove_html(obj['abstract']),
+            'language': obj['language']
+        }]
 
     def get_subjects(self, obj):
         """Get subjects."""
@@ -154,8 +158,10 @@ class CrossrefSchema(HEGSchema):
         for issn_type in obj.get('issn-type', []):
             if issn_type['type'] == 'electronic':
                 part_of['document']['identifiedBy'] = [{
-                    'type': 'bf:Issn',
-                    'value': issn_type['value']
+                    'type':
+                    'bf:Issn',
+                    'value':
+                    issn_type['value']
                 }]
 
         return [part_of]

--- a/sonar/heg/serializers/schemas/medline.py
+++ b/sonar/heg/serializers/schemas/medline.py
@@ -20,6 +20,7 @@
 import re
 
 from sonar.heg.serializers.schemas.heg import HEGSchema
+from sonar.modules.utils import remove_html
 
 
 class MedlineSchema(HEGSchema):
@@ -57,7 +58,10 @@ class MedlineSchema(HEGSchema):
         if not obj.get('abstract'):
             return None
 
-        return [{'value': obj['abstract'], 'language': obj['language']}]
+        return [{
+            'value': remove_html(obj['abstract']),
+            'language': obj['language']
+        }]
 
     def get_subjects(self, obj):
         """Get subjects."""

--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -151,7 +151,7 @@
         {% for abstract in abstracts %}
         <span id="lang-{{ abstract.language }}" class="abstract-container {{ '' if loop.first else 'd-none' }}">
           {% if abstract.value | length > 400 %}
-          <span data-abstract="{{ abstract.value | nl2br | safe }}">{{ abstract.value | truncate(400) }}</span> <a
+          <span data-abstract="{{ abstract.value | nl2br }}">{{ abstract.value | truncate(400) }}</span> <a
             href="#" class="showMore-abstract">{{ _('Show more') }}&hellip;</a>
           {% else %}
           {{ abstract.value | nl2br | safe }}

--- a/sonar/modules/utils.py
+++ b/sonar/modules/utils.py
@@ -215,3 +215,8 @@ def chunks(records, size):
     """
     for i in range(0, len(records), size):
         yield records[i:i + size]
+
+
+def remove_html(content):
+    """Remove html tags from content."""
+    return re.sub(re.compile('<.*?>'), '', content)

--- a/tests/ui/test_utils.py
+++ b/tests/ui/test_utils.py
@@ -26,7 +26,7 @@ from sonar.modules.documents.views import store_organisation
 from sonar.modules.utils import change_filename_extension, \
     create_thumbnail_from_file, format_date, get_current_language, \
     get_specific_theme, get_switch_aai_providers, get_view_code, \
-    is_ip_in_list
+    is_ip_in_list, remove_html
 
 
 def test_change_filename_extension(app):
@@ -159,3 +159,9 @@ def test_is_ip_in_list():
 
     # With network range
     assert is_ip_in_list('10.10.10.10', ['10.10.10.0/24'])
+
+
+def test_remove_html():
+    """Test remove html markup from string."""
+    assert remove_html('No HTML') == 'No HTML'
+    assert remove_html('<h1>Title</h1>') == 'Title'


### PR DESCRIPTION
* Removes markup from abstract when importing data from HEG.
* Removes the call of `safe` filter as it is useless.
* Closes #461.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>