### PR TITLE
docker: force upgrade pip

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -57,4 +57,5 @@ RUN useradd invenio --uid ${INVENIO_USER_ID}  --home ${WORKING_DIR} && \
     chmod -R go+w ${WORKING_DIR}
 
 # Install dependencies
+RUN poetry run pip install --upgrade pip
 RUN poetry install --no-dev


### PR DESCRIPTION
Forces upgrade `pip` before installing libraries, to avoid an error.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>