### PR TITLE
permissions: improve permissions checks

### DIFF
--- a/sonar/modules/deposits/marshmallow/json.py
+++ b/sonar/modules/deposits/marshmallow/json.py
@@ -21,7 +21,6 @@ from __future__ import absolute_import, print_function
 
 from functools import partial
 
-from flask_security import current_user
 from invenio_records_rest.schemas import StrictKeysMixin
 from invenio_records_rest.schemas.fields import GenFunction, \
     PersistentIdentifier, SanitizedUnicode
@@ -30,6 +29,7 @@ from marshmallow import fields, pre_dump, pre_load
 from sonar.modules.deposits.api import DepositRecord
 from sonar.modules.deposits.permissions import DepositPermission
 from sonar.modules.serializers import schema_from_context
+from sonar.modules.users.api import current_user_record
 
 schema_from_deposit = partial(schema_from_context, schema=DepositRecord.schema)
 
@@ -65,9 +65,9 @@ class DepositMetadataSchemaV1(StrictKeysMixin):
         :returns: Dict of modified record.
         """
         item['permissions'] = {
-            'read': DepositPermission.read(current_user, item),
-            'update': DepositPermission.update(current_user, item),
-            'delete': DepositPermission.delete(current_user, item)
+            'read': DepositPermission.read(current_user_record, item),
+            'update': DepositPermission.update(current_user_record, item),
+            'delete': DepositPermission.delete(current_user_record, item)
         }
 
         return item

--- a/sonar/modules/deposits/permissions.py
+++ b/sonar/modules/deposits/permissions.py
@@ -20,7 +20,6 @@
 from sonar.modules.deposits.api import DepositRecord
 from sonar.modules.organisations.api import current_organisation
 from sonar.modules.permissions import RecordPermission
-from sonar.modules.users.api import current_user_record
 
 
 class DepositPermission(RecordPermission):
@@ -30,12 +29,12 @@ class DepositPermission(RecordPermission):
     def list(cls, user, record=None):
         """List permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True is action can be done.
         """
         # At least for submitters logged users.
-        if not current_user_record or not current_user_record.is_submitter:
+        if not user or not user.is_submitter:
             return False
 
         return True
@@ -44,48 +43,48 @@ class DepositPermission(RecordPermission):
     def create(cls, user, record=None):
         """Create permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True is action can be done.
         """
         # No logged user.
-        if not current_user_record:
+        if not user:
             return False
 
-        return current_user_record.is_submitter
+        return user.is_submitter
 
     @classmethod
     def read(cls, user, record):
         """Read permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True is action can be done.
         """
         # At least for submitters logged users.
-        if not current_user_record or not current_user_record.is_submitter:
+        if not user or not user.is_submitter:
             return False
 
         # Superuser is allowd
-        if current_user_record.is_superuser:
+        if user.is_superuser:
             return True
 
         deposit = DepositRecord.get_record_by_pid(record['pid'])
         deposit = deposit.replace_refs()
 
         # Moderators are allowed only for their organisation's deposits.
-        if current_user_record.is_moderator:
+        if user.is_moderator:
             return current_organisation['pid'] == deposit['user'][
                 'organisation']['pid']
 
         # Submitters have only access to their own deposits.
-        return current_user_record['pid'] == deposit['user']['pid']
+        return user['pid'] == deposit['user']['pid']
 
     @classmethod
     def update(cls, user, record):
         """Update permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True is action can be done.
         """
@@ -96,7 +95,7 @@ class DepositPermission(RecordPermission):
     def delete(cls, user, record):
         """Delete permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True is action can be done.
         """

--- a/sonar/modules/documents/marshmallow/json.py
+++ b/sonar/modules/documents/marshmallow/json.py
@@ -22,7 +22,6 @@ from __future__ import absolute_import, print_function
 from functools import partial
 
 from flask import request
-from flask_security import current_user
 from invenio_records_rest.schemas import Nested, StrictKeysMixin
 from invenio_records_rest.schemas.fields import GenFunction, \
     PersistentIdentifier, SanitizedUnicode
@@ -142,10 +141,14 @@ class DocumentMetadataSchemaV1(StrictKeysMixin):
         :param item: Dict representing the record.
         :returns: Modified dict.
         """
+        # For public views, no check for permissions
+        if request.args.get('view'):
+            return item
+
         item['permissions'] = {
-            'read': DocumentPermission.read(current_user, item),
-            'update': DocumentPermission.update(current_user, item),
-            'delete': DocumentPermission.delete(current_user, item)
+            'read': DocumentPermission.read(current_user_record, item),
+            'update': DocumentPermission.update(current_user_record, item),
+            'delete': DocumentPermission.delete(current_user_record, item)
         }
 
         return item

--- a/sonar/modules/documents/permissions.py
+++ b/sonar/modules/documents/permissions.py
@@ -20,10 +20,8 @@
 from flask import request
 
 from sonar.modules.documents.api import DocumentRecord
-from sonar.modules.organisations.api import OrganisationRecord, \
-    current_organisation
+from sonar.modules.organisations.api import current_organisation
 from sonar.modules.permissions import RecordPermission
-from sonar.modules.users.api import current_user_record
 
 
 class DocumentPermission(RecordPermission):
@@ -33,19 +31,19 @@ class DocumentPermission(RecordPermission):
     def list(cls, user, record=None):
         """List permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True is action can be done.
         """
         view = request.args.get('view')
 
-        # Documents are accessess in public view, but eventually filtered later
-        # by organisation
+        # Documents are accessible in public view, but eventually filtered
+        # later by organisation
         if view:
             return True
 
         # Only for moderators users.
-        if (not current_user_record or not current_user_record.is_moderator or
+        if (not user or not user.is_moderator or
                 not current_organisation):
             return False
 
@@ -55,27 +53,27 @@ class DocumentPermission(RecordPermission):
     def create(cls, user, record=None):
         """Create permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True is action can be done.
         """
         # Only for moderators users
-        return current_user_record and current_user_record.is_moderator
+        return user and user.is_moderator
 
     @classmethod
     def read(cls, user, record):
         """Read permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True is action can be done.
         """
         # Only for moderator users.
-        if not current_user_record or not current_user_record.is_moderator:
+        if not user or not user.is_moderator:
             return False
 
         # Superuser is allowed.
-        if current_user_record.is_superuser:
+        if user.is_superuser:
             return True
 
         document = DocumentRecord.get_record_by_pid(record['pid'])
@@ -93,7 +91,7 @@ class DocumentPermission(RecordPermission):
     def update(cls, user, record):
         """Update permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True is action can be done.
         """
@@ -104,12 +102,12 @@ class DocumentPermission(RecordPermission):
     def delete(cls, user, record):
         """Delete permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True is action can be done.
         """
         # Delete is only for admins.
-        if not current_user_record or not current_user_record.is_admin:
+        if not user or not user.is_admin:
             return False
 
         # Same rules as read

--- a/sonar/modules/organisations/marshmallow/json.py
+++ b/sonar/modules/organisations/marshmallow/json.py
@@ -21,7 +21,6 @@ from __future__ import absolute_import, print_function
 
 from functools import partial
 
-from flask_security import current_user
 from invenio_records_rest.schemas import StrictKeysMixin
 from invenio_records_rest.schemas.fields import GenFunction, \
     PersistentIdentifier, SanitizedUnicode
@@ -31,6 +30,7 @@ from sonar.modules.organisations.api import OrganisationRecord
 from sonar.modules.organisations.permissions import OrganisationPermission
 from sonar.modules.permissions import has_superuser_access
 from sonar.modules.serializers import schema_from_context
+from sonar.modules.users.api import current_user_record
 
 schema_from_organisation = partial(schema_from_context,
                                    schema=OrganisationRecord.schema)
@@ -76,9 +76,9 @@ class OrganisationMetadataSchemaV1(StrictKeysMixin):
         :returns: Modified dict.
         """
         item['permissions'] = {
-            'read': OrganisationPermission.read(current_user, item),
-            'update': OrganisationPermission.update(current_user, item),
-            'delete': OrganisationPermission.delete(current_user, item)
+            'read': OrganisationPermission.read(current_user_record, item),
+            'update': OrganisationPermission.update(current_user_record, item),
+            'delete': OrganisationPermission.delete(current_user_record, item)
         }
 
         return item

--- a/sonar/modules/organisations/permissions.py
+++ b/sonar/modules/organisations/permissions.py
@@ -19,7 +19,6 @@
 
 from sonar.modules.organisations.api import current_organisation
 from sonar.modules.permissions import RecordPermission
-from sonar.modules.users.api import current_user_record
 
 
 class OrganisationPermission(RecordPermission):
@@ -29,12 +28,12 @@ class OrganisationPermission(RecordPermission):
     def list(cls, user, record=None):
         """List permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True is action can be done.
         """
         # Only for admin users at least.
-        if not current_user_record or not current_user_record.is_admin:
+        if not user or not user.is_admin:
             return False
 
         return True
@@ -43,27 +42,27 @@ class OrganisationPermission(RecordPermission):
     def create(cls, user, record=None):
         """Create permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True is action can be done.
         """
         # Only superuser can create an organisation.
-        return current_user_record and current_user_record.is_superuser
+        return user and user.is_superuser
 
     @classmethod
     def read(cls, user, record):
         """Read permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True is action can be done.
         """
         # Only for admin users
-        if not current_user_record or not current_user_record.is_admin:
+        if not user or not user.is_admin:
             return False
 
         # Super user is allowed
-        if current_user_record.is_superuser:
+        if user.is_superuser:
             return True
 
         # For admin users, they can read only their own organisation.
@@ -73,7 +72,7 @@ class OrganisationPermission(RecordPermission):
     def update(cls, user, record):
         """Update permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True is action can be done.
         """
@@ -84,7 +83,7 @@ class OrganisationPermission(RecordPermission):
     def delete(cls, user, record):
         """Delete permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True if action can be done.
         """

--- a/sonar/modules/permissions.py
+++ b/sonar/modules/permissions.py
@@ -24,6 +24,8 @@ from flask_login import current_user
 from flask_principal import ActionNeed, RoleNeed
 from invenio_access import Permission
 
+from sonar.modules.users.api import current_user_record
+
 superuser_access_permission = Permission(ActionNeed('superuser-access'))
 admin_access_permission = Permission(ActionNeed('admin-access'))
 submitter_access_permission = Permission(RoleNeed('submitter'),
@@ -149,7 +151,7 @@ class RecordPermission:
         """
         self.record = record
         self.func = func
-        self.user = user or current_user
+        self.user = user or current_user_record
 
     def can(self):
         """Return the permission object determining if the action can be done.
@@ -188,11 +190,11 @@ class RecordPermission:
     def list(cls, user, record=None):
         """List permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True is action can be done.
         """
-        if user.is_anonymous:
+        if not user:
             return False
 
         return has_superuser_access()
@@ -201,11 +203,11 @@ class RecordPermission:
     def create(cls, user, record=None):
         """Create permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True is action can be done.
         """
-        if user.is_anonymous:
+        if not user:
             return False
 
         return has_superuser_access()
@@ -214,11 +216,11 @@ class RecordPermission:
     def read(cls, user, record):
         """Read permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True is action can be done.
         """
-        if user.is_anonymous:
+        if not user:
             return False
 
         return has_superuser_access()
@@ -227,11 +229,11 @@ class RecordPermission:
     def update(cls, user, record):
         """Update permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True is action can be done.
         """
-        if user.is_anonymous:
+        if not user:
             return False
 
         return has_superuser_access()
@@ -240,11 +242,11 @@ class RecordPermission:
     def delete(cls, user, record):
         """Delete permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True is action can be done.
         """
-        if user.is_anonymous:
+        if not user:
             return False
 
         return has_superuser_access()

--- a/sonar/modules/projects/marshmallow/json.py
+++ b/sonar/modules/projects/marshmallow/json.py
@@ -21,7 +21,6 @@ from __future__ import absolute_import, print_function
 
 from functools import partial
 
-from flask_security import current_user
 from invenio_records_rest.schemas import StrictKeysMixin
 from invenio_records_rest.schemas.fields import GenFunction, \
     PersistentIdentifier, SanitizedUnicode
@@ -77,9 +76,9 @@ class ProjectMetadataSchemaV1(StrictKeysMixin):
         :returns: Modified dict.
         """
         item['permissions'] = {
-            'read': ProjectPermission.read(current_user, item),
-            'update': ProjectPermission.update(current_user, item),
-            'delete': ProjectPermission.delete(current_user, item)
+            'read': ProjectPermission.read(current_user_record, item),
+            'update': ProjectPermission.update(current_user_record, item),
+            'delete': ProjectPermission.delete(current_user_record, item)
         }
 
         return item

--- a/sonar/modules/projects/permissions.py
+++ b/sonar/modules/projects/permissions.py
@@ -17,13 +17,10 @@
 
 """Permissions for projects."""
 
-from flask import request
-
 from sonar.modules.documents.api import DocumentRecord
 from sonar.modules.organisations.api import current_organisation
 from sonar.modules.permissions import RecordPermission
 from sonar.modules.projects.api import ProjectRecord
-from sonar.modules.users.api import current_user_record
 
 
 class ProjectPermission(RecordPermission):
@@ -33,18 +30,17 @@ class ProjectPermission(RecordPermission):
     def list(cls, user, record=None):
         """List permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param record: Record to check.
         :returns: True is action can be done.
         """
-        return (False if not current_user_record else
-                current_user_record.is_submitter)
+        return (False if not user else user.is_submitter)
 
     @classmethod
     def create(cls, user, record=None):
         """Create permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param record: Record to check.
         :returns: True is action can be done.
         """
@@ -54,12 +50,12 @@ class ProjectPermission(RecordPermission):
     def read(cls, user, record):
         """Read permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param record: Record to check.
         :returns: True is action can be done.
         """
         # At least for submitters logged users.
-        if not current_user_record or not current_user_record.is_submitter:
+        if not user or not user.is_submitter:
             return False
 
         return True
@@ -68,16 +64,16 @@ class ProjectPermission(RecordPermission):
     def update(cls, user, record):
         """Update permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param record: Record to check.
         :returns: True is action can be done.
         """
         # At least for submitters logged users.
-        if not current_user_record or not current_user_record.is_submitter:
+        if not user or not user.is_submitter:
             return False
 
         # Superuser is allowd
-        if current_user_record.is_superuser:
+        if user.is_superuser:
             return True
 
         project = ProjectRecord.get_record_by_pid(record['pid'])
@@ -85,18 +81,18 @@ class ProjectPermission(RecordPermission):
 
         # For admin or moderators users, they can update only their
         # organisation's projects.
-        if current_user_record.is_moderator:
+        if user.is_moderator:
             return current_organisation['pid'] == project['organisation'][
                 'pid']
 
         # For submitters, they can only modify their own projects
-        return current_user_record['pid'] == project['user']['pid']
+        return user['pid'] == project['user']['pid']
 
     @classmethod
     def delete(cls, user, record):
         """Delete permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param record: Record to check.
         :returns: True if action can be done.
         """

--- a/sonar/modules/users/marshmallow/json.py
+++ b/sonar/modules/users/marshmallow/json.py
@@ -21,14 +21,13 @@ from __future__ import absolute_import, print_function
 
 from functools import partial
 
-from flask_security import current_user
 from invenio_records_rest.schemas import StrictKeysMixin
 from invenio_records_rest.schemas.fields import GenFunction, \
     PersistentIdentifier, SanitizedUnicode
 from marshmallow import fields, pre_dump, pre_load
 
 from sonar.modules.serializers import schema_from_context
-from sonar.modules.users.api import UserRecord
+from sonar.modules.users.api import UserRecord, current_user_record
 from sonar.modules.users.permissions import UserPermission
 
 schema_from_user = partial(schema_from_context, schema=UserRecord.schema)
@@ -68,9 +67,8 @@ class UserMetadataSchemaV1(StrictKeysMixin):
             return data
 
         # Store current user organisation in new user.
-        user = UserRecord.get_user_by_current_user(current_user)
-        if user.get('organisation'):
-            data['organisation'] = user['organisation']
+        if current_user_record.get('organisation'):
+            data['organisation'] = current_user_record['organisation']
 
         return data
 
@@ -93,9 +91,9 @@ class UserMetadataSchemaV1(StrictKeysMixin):
         :returns: Modified dict of user data.
         """
         item['permissions'] = {
-            'read': UserPermission.read(current_user, item),
-            'update': UserPermission.update(current_user, item),
-            'delete': UserPermission.delete(current_user, item)
+            'read': UserPermission.read(current_user_record, item),
+            'update': UserPermission.update(current_user_record, item),
+            'delete': UserPermission.delete(current_user_record, item)
         }
 
         return item

--- a/sonar/modules/users/permissions.py
+++ b/sonar/modules/users/permissions.py
@@ -20,7 +20,7 @@
 from sonar.modules.organisations.api import OrganisationRecord, \
     current_organisation
 from sonar.modules.permissions import RecordPermission
-from sonar.modules.users.api import UserRecord, current_user_record
+from sonar.modules.users.api import UserRecord
 
 
 class UserPermission(RecordPermission):
@@ -30,11 +30,11 @@ class UserPermission(RecordPermission):
     def list(cls, user, record=None):
         """List permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True is action can be done.
         """
-        if not current_user_record:
+        if not user:
             return False
 
         return True
@@ -43,36 +43,36 @@ class UserPermission(RecordPermission):
     def create(cls, user, record=None):
         """Create permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True is action can be done.
         """
-        if not current_user_record:
+        if not user:
             return False
 
-        return current_user_record.is_admin
+        return user.is_admin
 
     @classmethod
     def read(cls, user, record):
         """Read permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True is action can be done.
         """
-        if not current_user_record:
+        if not user:
             return False
 
         # Can read himself in all cases
-        if current_user_record['pid'] == record['pid']:
+        if user['pid'] == record['pid']:
             return True
 
         # If not admin, no access
-        if not current_user_record.is_admin:
+        if not user.is_admin:
             return False
 
         # Superuser is allowed
-        if current_user_record.is_superuser:
+        if user.is_superuser:
             return True
 
         # Cannot read superusers records
@@ -91,7 +91,7 @@ class UserPermission(RecordPermission):
     def update(cls, user, record):
         """Update permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True is action can be done.
         """
@@ -102,20 +102,20 @@ class UserPermission(RecordPermission):
     def delete(cls, user, record):
         """Delete permission check.
 
-        :param user: Logged user.
+        :param user: Current user record.
         :param recor: Record to check.
         :returns: True is action can be done.
         """
         # At least for admin logged users.
-        if not current_user_record or not current_user_record.is_admin:
+        if not user or not user.is_admin:
             return False
 
         # Superuser is allowed
-        if current_user_record.is_superuser:
+        if user.is_superuser:
             return True
 
         # Cannot delete himself
-        if current_user_record['pid'] == record['pid']:
+        if user['pid'] == record['pid']:
             return False
 
         if not record.get('organisation'):

--- a/sonar/theme/views.py
+++ b/sonar/theme/views.py
@@ -39,12 +39,11 @@ from invenio_pidstore.models import PersistentIdentifier
 
 from sonar.modules.babel_extractors import translate
 from sonar.modules.deposits.permissions import DepositPermission
-from sonar.modules.documents.api import DocumentRecord
 from sonar.modules.documents.permissions import DocumentPermission
 from sonar.modules.organisations.permissions import OrganisationPermission
 from sonar.modules.permissions import can_access_manage_view
 from sonar.modules.projects.permissions import ProjectPermission
-from sonar.modules.users.api import UserRecord, current_user_record
+from sonar.modules.users.api import current_user_record
 from sonar.modules.users.permissions import UserPermission
 
 blueprint = Blueprint('sonar',
@@ -118,7 +117,7 @@ def logged_user():
     if current_user.is_anonymous:
         return jsonify({})
 
-    user = UserRecord.get_user_by_current_user(current_user)
+    user = current_user_record
 
     if user and 'resolve' in request.args:
         user = user.replace_refs()

--- a/tests/ui/documents/test_documents_utils.py
+++ b/tests/ui/documents/test_documents_utils.py
@@ -167,8 +167,8 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
         # Embargo access, restriction is outside organisation, user logged but
         # organisations are not corresponding --> file is locked
         monkeypatch.setattr(
-            'sonar.modules.organisations.api.OrganisationRecord.'
-            'get_organisation_by_user', lambda *args: {'pid': 'another-org'})
+            'sonar.modules.documents.utils.current_organisation',
+            {'pid': 'another-org'})
         assert utils.get_file_restriction(
             {
                 'access': 'coar:c_f1cf',
@@ -182,8 +182,8 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
         # Embargo access, restriction is outside organisation, user logged and
         # organisations are matching --> file is accessible
         monkeypatch.setattr(
-            'sonar.modules.organisations.api.OrganisationRecord.'
-            'get_organisation_by_user', lambda *args: {'pid': 'org'})
+            'sonar.modules.documents.utils.current_organisation',
+            {'pid': 'org'})
         assert utils.get_file_restriction(
             {
                 'access': 'coar:c_f1cf',
@@ -197,8 +197,8 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
         # Embargo access, restriction is outside organisation, user logged and
         # IP is not white listed --> file is locked
         monkeypatch.setattr(
-            'sonar.modules.organisations.api.OrganisationRecord.'
-            'get_organisation_by_user', lambda *args: {'pid': 'another-org'})
+            'sonar.modules.documents.utils.current_organisation',
+            {'pid': 'another-org'})
         organisation['allowedIps'] = ''
         assert utils.get_file_restriction(
             {
@@ -269,8 +269,8 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
         # Restricted access, restriction is outside organisation, user logged
         # but organisations are not corresponding --> file is locked
         monkeypatch.setattr(
-            'sonar.modules.organisations.api.OrganisationRecord.'
-            'get_organisation_by_user', lambda *args: {'pid': 'another-org'})
+            'sonar.modules.documents.utils.current_organisation',
+            {'pid': 'another-org'})
         assert utils.get_file_restriction(
             {
                 'access': 'coar:c_16ec',
@@ -283,8 +283,8 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
         # Restricted access, restriction is outside organisation, user logged
         # and organisations are matching --> file is accessible
         monkeypatch.setattr(
-            'sonar.modules.organisations.api.OrganisationRecord.'
-            'get_organisation_by_user', lambda *args: {'pid': 'org'})
+            'sonar.modules.documents.utils.current_organisation',
+            {'pid': 'org'})
         assert utils.get_file_restriction(
             {
                 'access': 'coar:c_16ec',
@@ -297,8 +297,8 @@ def test_get_file_restriction(app, organisation, admin, monkeypatch):
         # Restricted access, restriction is outside organisation, user logged
         # and IP is not white listed --> file is locked
         monkeypatch.setattr(
-            'sonar.modules.organisations.api.OrganisationRecord.'
-            'get_organisation_by_user', lambda *args: {'pid': 'another-org'})
+            'sonar.modules.documents.utils.current_organisation',
+            {'pid': 'another-org'})
         organisation['allowedIps'] = ''
         assert utils.get_file_restriction(
             {

--- a/tests/ui/organisations/test_organisations_api.py
+++ b/tests/ui/organisations/test_organisations_api.py
@@ -20,24 +20,6 @@
 from sonar.modules.organisations.api import OrganisationRecord
 
 
-def test_get_organisation_by_user(user):
-    """Test getting organisation by user."""
-    # No user passed
-    organisation = OrganisationRecord.get_organisation_by_user(None)
-    assert not organisation
-
-    # OK
-    organisation = OrganisationRecord.get_organisation_by_user(user)
-    assert 'code' in organisation
-    assert organisation['code'] == 'org'
-
-    user.pop('organisation')
-
-    # User has no organisation
-    organisation = OrganisationRecord.get_organisation_by_user(user)
-    assert not organisation
-
-
 def test_get_or_create(organisation):
     """Test get or create an organisation."""
     # Existing organisation

--- a/tests/ui/users/test_users_api.py
+++ b/tests/ui/users/test_users_api.py
@@ -45,25 +45,6 @@ def test_get_moderators(app, organisation, roles):
     assert not list(moderators)
 
 
-def test_get_user_by_current_user(app, client, user_without_role, user):
-    """Test getting a user with email taken from logged user."""
-    record = UserRecord.get_user_by_current_user(current_user)
-    assert record is None
-
-    login_user_via_view(client,
-                        email=user_without_role.email,
-                        password='123456')
-    record = UserRecord.get_user_by_current_user(current_user)
-    assert record is None
-
-    client.get(url_for_security('logout'))
-
-    login_user_via_view(client, email=user['email'], password='123456')
-    record = UserRecord.get_user_by_current_user(current_user)
-    assert 'email' in record
-    assert user['email'] == 'orguser@rero.ch'
-
-
 def test_get_reachable_roles(app):
     """Test get roles covered by the given role."""
     roles = UserRecord.get_reachable_roles(UserRecord.ROLE_MODERATOR)


### PR DESCRIPTION
* Avoids to check permissions if the call is done by the a public view.
* Uses user record instead of flask user in permissions.
* Avoids multiple calls when retrieving current user record.
* Avoids multiple calls when retrieving current organisation.
* Closes #245.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>