### PR TITLE
editor: update JSON schema properties

### DIFF
--- a/sonar/common/jsonschemas/type-v1.0.0.json
+++ b/sonar/common/jsonschemas/type-v1.0.0.json
@@ -354,9 +354,6 @@
         "group": "------------"
       }
     ],
-    "templateOptions": {
-      "cssClass": "editor-title"
-    },
     "expressionProperties": {
       "templateOptions.required": "true"
     }

--- a/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
+++ b/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
@@ -311,7 +311,9 @@
           },
           "form": {
             "templateOptions": {
-              "cssClass": "editor-title"
+              "wrappers": [
+                "card"
+              ]
             }
           }
         },
@@ -541,7 +543,9 @@
           },
           "form": {
             "templateOptions": {
-              "cssClass": "editor-title"
+              "wrappers": [
+                "card"
+              ]
             }
           }
         },
@@ -620,7 +624,9 @@
           "form": {
             "hideExpression": "!['coar:c_3248', 'coar:c_5794', 'coar:c_6670', 'coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc'].includes(field.parent.model.documentType)",
             "templateOptions": {
-              "cssClass": "editor-title"
+              "wrappers": [
+                "card"
+              ]
             }
           }
         },
@@ -656,7 +662,9 @@
           },
           "form": {
             "templateOptions": {
-              "cssClass": "editor-title"
+              "wrappers": [
+                "card"
+              ]
             }
           }
         },
@@ -670,7 +678,9 @@
           },
           "form": {
             "templateOptions": {
-              "cssClass": "editor-title"
+              "wrappers": [
+                "card"
+              ]
             }
           }
         },
@@ -711,7 +721,9 @@
           },
           "form": {
             "templateOptions": {
-              "cssClass": "editor-title"
+              "wrappers": [
+                "card"
+              ]
             }
           }
         },
@@ -748,7 +760,9 @@
           },
           "form": {
             "templateOptions": {
-              "cssClass": "editor-title"
+              "wrappers": [
+                "card"
+              ]
             }
           }
         },
@@ -795,7 +809,9 @@
           "form": {
             "hideExpression": "!['coar:c_46ec', 'coar:c_7a1f', 'coar:c_db06', 'coar:c_bdcc', 'habilitation_thesis', 'advanced_studies_thesis', 'other'].includes(field.parent.model.documentType)",
             "templateOptions": {
-              "cssClass": "editor-title"
+              "wrappers": [
+                "card"
+              ]
             }
           }
         }
@@ -880,12 +896,21 @@
             }
           }
         }
+      },
+      "form": {
+        "templateOptions": {
+          "wrappers": [
+            "card"
+          ]
+        }
       }
     },
     "projects": {
       "title": "Research projects",
       "type": "array",
-      "default": [{}],
+      "default": [
+        {}
+      ],
       "minItems": 0,
       "items": {
         "title": "Research project",
@@ -1013,7 +1038,9 @@
                 },
                 "form": {
                   "templateOptions": {
-                    "cssClass": "editor-title"
+                    "wrappers": [
+                      "card"
+                    ]
                   }
                 }
               },
@@ -1046,7 +1073,9 @@
                 },
                 "form": {
                   "templateOptions": {
-                    "cssClass": "editor-title"
+                    "wrappers": [
+                      "card"
+                    ]
                   }
                 }
               }
@@ -1066,6 +1095,13 @@
             ]
           }
         ]
+      },
+      "form": {
+        "templateOptions": {
+          "wrappers": [
+            "card"
+          ]
+        }
       }
     },
     "diffusion": {

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -238,9 +238,6 @@
         ]
       },
       "form": {
-        "templateOptions": {
-          "cssClass": "editor-title"
-        },
         "expressionProperties": {
           "templateOptions.required": "true"
         }
@@ -337,11 +334,6 @@
           "type",
           "mainTitle"
         ]
-      },
-      "form": {
-        "templateOptions": {
-          "cssClass": "editor-title"
-        }
       }
     },
     "language": {
@@ -385,9 +377,6 @@
         ]
       },
       "form": {
-        "templateOptions": {
-          "cssClass": "editor-title"
-        },
         "expressionProperties": {
           "templateOptions.required": "true"
         }
@@ -434,9 +423,6 @@
         "hide": true,
         "navigation": {
           "essential": true
-        },
-        "templateOptions": {
-          "cssClass": "editor-title"
         }
       }
     },
@@ -532,6 +518,7 @@
               ]
             },
             "form": {
+              "hide": true,
               "expressionProperties": {
                 "templateOptions.required": "field.parent.model.type && field.parent.model.type !== 'bf:Publication'"
               }
@@ -571,9 +558,6 @@
         ]
       },
       "form": {
-        "templateOptions": {
-          "cssClass": "editor-title"
-        },
         "expressionProperties": {
           "templateOptions.required": "!['coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc', 'coar:c_3e5a', 'coar:c_5794', 'coar:c_6670'].includes(field.parent.model.documentType)"
         }
@@ -585,10 +569,7 @@
       "type": "string",
       "minLength": 1,
       "form": {
-        "hide": true,
-        "templateOptions": {
-          "cssClass": "editor-title"
-        }
+        "hide": true
       }
     },
     "otherMaterialCharacteristics": {
@@ -597,10 +578,7 @@
       "type": "string",
       "minLength": 1,
       "form": {
-        "hide": true,
-        "templateOptions": {
-          "cssClass": "editor-title"
-        }
+        "hide": true
       }
     },
     "formats": {
@@ -614,10 +592,7 @@
         "minLength": 1
       },
       "form": {
-        "hide": true,
-        "templateOptions": {
-          "cssClass": "editor-title"
-        }
+        "hide": true
       }
     },
     "additionalMaterials": {
@@ -626,10 +601,7 @@
       "type": "string",
       "minLength": 1,
       "form": {
-        "hide": true,
-        "templateOptions": {
-          "cssClass": "editor-title"
-        }
+        "hide": true
       }
     },
     "series": {
@@ -657,10 +629,7 @@
         ]
       },
       "form": {
-        "hide": true,
-        "templateOptions": {
-          "cssClass": "editor-title"
-        }
+        "hide": true
       }
     },
     "notes": {
@@ -673,10 +642,7 @@
         "minLength": 1
       },
       "form": {
-        "hide": true,
-        "templateOptions": {
-          "cssClass": "editor-title"
-        }
+        "hide": true
       }
     },
     "abstracts": {
@@ -706,9 +672,6 @@
         "hide": true,
         "navigation": {
           "essential": true
-        },
-        "templateOptions": {
-          "cssClass": "editor-title"
         }
       }
     },
@@ -914,9 +877,6 @@
         "hide": true,
         "navigation": {
           "essential": true
-        },
-        "templateOptions": {
-          "cssClass": "editor-title"
         }
       }
     },
@@ -966,9 +926,6 @@
         "hide": true,
         "navigation": {
           "essential": true
-        },
-        "templateOptions": {
-          "cssClass": "editor-title"
         }
       }
     },
@@ -1021,10 +978,7 @@
         ]
       },
       "form": {
-        "hide": true,
-        "templateOptions": {
-          "cssClass": "editor-title"
-        }
+        "hide": true
       }
     },
     "specificCollections": {
@@ -1040,9 +994,6 @@
         "hide": true,
         "navigation": {
           "essential": true
-        },
-        "templateOptions": {
-          "cssClass": "editor-title"
         }
       }
     },
@@ -1127,9 +1078,6 @@
         "hide": true,
         "navigation": {
           "essential": true
-        },
-        "templateOptions": {
-          "cssClass": "editor-title"
         }
       }
     },
@@ -1143,10 +1091,7 @@
         "minLength": 1
       },
       "form": {
-        "hide": true,
-        "templateOptions": {
-          "cssClass": "editor-title"
-        }
+        "hide": true
       }
     },
     "dissertation": {
@@ -1188,10 +1133,7 @@
         "degree"
       ],
       "form": {
-        "hide": true,
-        "templateOptions": {
-          "cssClass": "editor-title"
-        }
+        "hide": true
       },
       "hideExpression": "!['coar:c_46ec', 'coar:c_7a1f', 'coar:c_db06', 'coar:c_bdcc', 'habilitation_thesis', 'advanced_studies_thesis', 'other'].includes(field.parent.model.documentType)"
     },
@@ -1217,10 +1159,7 @@
         "license"
       ],
       "form": {
-        "hide": true,
-        "templateOptions": {
-          "cssClass": "editor-title"
-        }
+        "hide": true
       }
     },
     "contribution": {
@@ -1456,9 +1395,6 @@
         "hide": true,
         "navigation": {
           "essential": true
-        },
-        "templateOptions": {
-          "cssClass": "editor-title"
         }
       }
     },
@@ -1777,11 +1713,9 @@
         ]
       },
       "form": {
+        "hide": true,
         "expressionProperties": {
           "templateOptions.required": "['coar:c_3248', 'coar:c_5794', 'coar:c_6670', 'coar:c_3e5a', 'coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc'].includes(field.parent.model.documentType)"
-        },
-        "templateOptions": {
-          "cssClass": "editor-title"
         }
       }
     },
@@ -1814,9 +1748,6 @@
         "hide": true,
         "navigation": {
           "essential": true
-        },
-        "templateOptions": {
-          "cssClass": "editor-title"
         }
       }
     },
@@ -1827,7 +1758,10 @@
     },
     "hiddenFromPublic": {
       "title": "Hidden to public",
-      "type": "boolean"
+      "type": "boolean",
+      "form": {
+        "hide": true
+      }
     }
   },
   "propertiesOrder": [

--- a/sonar/modules/projects/jsonschemas/projects/project-v1.0.0_src.json
+++ b/sonar/modules/projects/jsonschemas/projects/project-v1.0.0_src.json
@@ -17,12 +17,7 @@
     "name": {
       "title": "Name",
       "type": "string",
-      "minLength": 1,
-      "form": {
-        "templateOptions": {
-          "cssClass": "editor-title"
-        }
-      }
+      "minLength": 1
     },
     "description": {
       "title": "Description",
@@ -31,7 +26,6 @@
       "form": {
         "type": "textarea",
         "templateOptions": {
-          "cssClass": "editor-title",
           "rows": 5
         }
       }
@@ -44,8 +38,7 @@
       "pattern": "^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$",
       "form": {
         "templateOptions": {
-          "placeholder": "Example: 2020-12-01",
-          "cssClass": "editor-title"
+          "placeholder": "Example: 2020-12-01"
         }
       }
     },
@@ -57,8 +50,7 @@
       "pattern": "^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$",
       "form": {
         "templateOptions": {
-          "placeholder": "Example: 2020-12-01",
-          "cssClass": "editor-title"
+          "placeholder": "Example: 2020-12-01"
         }
       }
     },
@@ -117,9 +109,6 @@
         "hide": true,
         "navigation": {
           "essential": true
-        },
-        "templateOptions": {
-          "cssClass": "editor-title"
         }
       }
     },
@@ -211,9 +200,6 @@
         "hide": true,
         "navigation": {
           "essential": true
-        },
-        "templateOptions": {
-          "cssClass": "editor-title"
         }
       }
     },
@@ -260,9 +246,6 @@
         "hide": true,
         "navigation": {
           "essential": true
-        },
-        "templateOptions": {
-          "cssClass": "editor-title"
         }
       }
     },
@@ -285,9 +268,6 @@
         "$ref"
       ],
       "form": {
-        "templateOptions": {
-          "cssClass": "editor-title"
-        },
         "expressionProperties": {
           "templateOptions.required": "true"
         }
@@ -313,9 +293,6 @@
         "$ref"
       ],
       "form": {
-        "templateOptions": {
-          "cssClass": "editor-title"
-        },
         "expressionProperties": {
           "templateOptions.required": "true"
         }


### PR DESCRIPTION
* Updates JSON schema properties after upgrading ng-core version as the behavior of the editor has changed.
* Removes `editor-title` CSS class.
* Adds `hide` property for `provisionActivity.statement`, `partOf` and `hiddenFromPublic` fields.
* Adds manually `card` wrapper to deposit fields.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>