### PR TITLE
organisations: fix editor with admin role

### DIFF
--- a/sonar/theme/views.py
+++ b/sonar/theme/views.py
@@ -208,6 +208,15 @@ def schemas(record_type):
                 if 'organisation' in schema.get('propertiesOrder', []):
                     schema['propertiesOrder'].remove('organisation')
 
+        # Remove modes fields if user does not have superuser role.
+        if (record_type == 'organisations' and
+                not current_user_record.is_superuser):
+            if 'isDedicated' in schema.get('propertiesOrder', []):
+                schema['propertiesOrder'].remove('isDedicated')
+
+            if 'isShared' in schema.get('propertiesOrder', []):
+                schema['propertiesOrder'].remove('isShared')
+
         return jsonify({'schema': prepare_schema(schema)})
     except JSONSchemaNotFound:
         abort(404)

--- a/tests/api/organisations/test_organisations_permissions.py
+++ b/tests/api/organisations/test_organisations_permissions.py
@@ -223,11 +223,11 @@ def test_update(client, make_organisation, superuser, admin, moderator,
 
     # Logged as admin and try to modify organisation's modes
     org['isDedicated'] = True
-    org['isShared'] = True
     res = client.put(url_for('invenio_records_rest.org_item', pid_value='org'),
                      data=json.dumps(org.dumps()),
                      headers=headers)
-    assert res.status_code == 400
+    assert res.status_code == 200
+    assert not res.json['metadata']['isDedicated']
 
     # Logged as admin of other organisation
     res = client.put(url_for('invenio_records_rest.org_item',

--- a/tests/ui/test_views.py
+++ b/tests/ui/test_views.py
@@ -157,6 +157,12 @@ def test_schemas(client, admin, user):
     res = client.get(url_for('sonar.schemas', record_type='not_existing'))
     assert res.status_code == 404
 
+    # Organisations, with admin user --> no fields `isShared` and `isDedicated`
+    res = client.get(url_for('sonar.schemas', record_type='organisations'))
+    assert res.status_code == 200
+    assert 'isShared' not in res.json['schema']['propertiesOrder']
+    assert 'isDedicated' not in res.json['schema']['propertiesOrder']
+
     login_user_via_session(client, email=user['email'])
 
     res = client.get(url_for('sonar.schemas', record_type='users'))


### PR DESCRIPTION
* Fixes an error when editing the organisation with an admin role.
* Removes `isShared` and `isDedicated` fields if user does not have superuser role.
* Guesses `isShared` and `isDedicated` values from user's organisation when user does not have superuser role, during the serialization.
* Closes #492.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>