### PR TITLE
users: remove Flask user

### DIFF
--- a/sonar/modules/users/api.py
+++ b/sonar/modules/users/api.py
@@ -156,8 +156,8 @@ class UserRecord(SonarRecord):
         # Remove roles from user account.
         self.remove_roles()
 
-        # Deactivate account.
-        datastore.deactivate_user(self.user)
+        # Delete account.
+        datastore.delete_user(self.user)
 
         return super(UserRecord, self).delete(force=force,
                                               dbcommit=dbcommit,

--- a/tests/ui/users/test_users_api.py
+++ b/tests/ui/users/test_users_api.py
@@ -138,8 +138,7 @@ def test_delete(app, admin):
     with app.app_context():
         datastore = app.extensions['security'].datastore
         user = datastore.find_user(email='orgadmin@rero.ch')
-        assert not user.roles
-        assert not user.is_active
+        assert not user
 
 
 def test_update(app, admin, roles):


### PR DESCRIPTION
* removes Flask user when an user record is deleted.
* Closes #491.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>