### PR TITLE
organisations: update `allowedIps` description

### DIFF
--- a/sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0.json
+++ b/sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0.json
@@ -63,7 +63,7 @@
     },
     "allowedIps": {
       "title": "Allowed IP addresses",
-      "description": "List of IP addresses or ranges that allows to display files. One rule per line.",
+      "description": "List of IP addresses or ranges that allow access to private files (access: embargoed or restricted), which are accessible only within the organisation. Note: the bibliographic record (metadata) is always public. Enter one rule per line.",
       "type": "string",
       "minLength": 1,
       "form": {


### PR DESCRIPTION
* Updates the description for the field `allowedIps`.
* Closes #495.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>