### PR TITLE
search: add filter for open access documents

### DIFF
--- a/sonar/config.py
+++ b/sonar/config.py
@@ -523,7 +523,9 @@ RECORDS_REST_FACETS = {
              'year':
              range_filter('provisionActivity.startDate',
                           format='yyyy',
-                          end_date_math='/y')
+                          end_date_math='/y'),
+             'open_access':
+             and_term_filter('isOpenAccess')
          }),
     'deposits':
     dict(aggs=dict(

--- a/sonar/heg/record/__init__.py
+++ b/sonar/heg/record/__init__.py
@@ -49,8 +49,9 @@ class HEGRecord():
                     SchemaFactory.create(source).dump(
                         self.data[record_source_key]), **record)
 
-        # Flag as hidden if no file provided
-        if not record.get('files'):
-            record['hiddenFromPublic'] = True
+        # If `oa_status` is `closed`, the first file is flagged as restricted.
+        if record.get('files'):
+            record['files'][0]['access'] = 'coar:c_16ec' if record.get(
+                'oa_status') == 'closed' else 'coar:c_abf2'
 
         return record

--- a/sonar/heg/serializers/schemas/unpaywall.py
+++ b/sonar/heg/serializers/schemas/unpaywall.py
@@ -40,6 +40,7 @@ class UnpaywallSchema(Schema):
         return [{
             'key': 'fulltext.pdf',
             'url': obj['best_oa_location']['url_for_pdf'],
+            'force_external_url': True,
             'label': 'Full-text',
             'type': 'file',
             'order': 0

--- a/sonar/modules/api.py
+++ b/sonar/modules/api.py
@@ -199,7 +199,9 @@ class SonarRecord(Record, FilesMixin):
 
             # Find the record PID.
             pid = PersistentIdentifier.query.filter_by(
-                object_uuid=records_buckets.record_id).first()
+                object_uuid=records_buckets.record_id).filter(
+                    ~PersistentIdentifier.pid_type.in_(['oai', 'rerod'])
+                ).first()
 
             if not pid:
                 raise Exception('Persistent identifier not found.')

--- a/sonar/modules/documents/ext.py
+++ b/sonar/modules/documents/ext.py
@@ -23,9 +23,8 @@ from invenio_indexer.signals import before_record_index
 from invenio_oaiharvester.signals import oaiharvest_finished
 from invenio_records.signals import before_record_insert, before_record_update
 
-from sonar.modules.documents.receivers import export_json, \
-    populate_fulltext_field, transform_harvested_records, \
-    update_oai_property
+from sonar.modules.documents.receivers import enrich_document_data, \
+    export_json, transform_harvested_records, update_oai_property
 
 from . import config
 
@@ -48,8 +47,7 @@ class Documents(object):
         oaiharvest_finished.connect(export_json, weak=False)
 
         # Connect to record index signal, to modify record before indexing.
-        before_record_index.connect(populate_fulltext_field,
-                                    weak=False)
+        before_record_index.connect(enrich_document_data, weak=False)
 
         # Adds `_oai` property
         before_record_insert.connect(update_oai_property)

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -1759,13 +1759,40 @@
     "oa_status": {
       "title": "Open access status",
       "type": "string",
-      "minLength": 1
-    },
-    "hiddenFromPublic": {
-      "title": "Hidden to public",
-      "type": "boolean",
+      "enum": [
+        "green",
+        "gold",
+        "hybrid",
+        "bronze",
+        "closed"
+      ],
       "form": {
-        "hide": true
+        "hide": true,
+        "navigation": {
+          "essential": true
+        },
+        "options": [
+          {
+            "label": "Green",
+            "value": "green"
+          },
+          {
+            "label": "Gold",
+            "value": "gold"
+          },
+          {
+            "label": "Hybrid",
+            "value": "hybrid"
+          },
+          {
+            "label": "Bronze",
+            "value": "bronze"
+          },
+          {
+            "label": "Closed",
+            "value": "closed"
+          }
+        ]
       }
     }
   },
@@ -1794,7 +1821,7 @@
     "contentNote",
     "otherMaterialCharacteristics",
     "usageAndAccessPolicy",
-    "hiddenFromPublic"
+    "oa_status"
   ],
   "required": [
     "$schema",

--- a/sonar/modules/documents/mappings/v7/documents/document-v1.0.0.json
+++ b/sonar/modules/documents/mappings/v7/documents/document-v1.0.0.json
@@ -524,7 +524,7 @@
       "oa_status": {
         "type": "keyword"
       },
-      "hiddenFromPublic": {
+      "isOpenAccess": {
         "type": "boolean"
       },
       "_created": {

--- a/sonar/modules/documents/marshmallow/json.py
+++ b/sonar/modules/documents/marshmallow/json.py
@@ -99,7 +99,6 @@ class DocumentMetadataSchemaV1(StrictKeysMixin):
     usageAndAccessPolicy = fields.Dict()
     projects = fields.List(fields.Dict())
     oa_status = SanitizedUnicode()
-    hiddenFromPublic = fields.Boolean()
     sections = fields.List(fields.Str())
     _bucket = SanitizedUnicode()
     _files = Nested(FileSchemaV1, many=True)

--- a/sonar/modules/documents/query.py
+++ b/sonar/modules/documents/query.py
@@ -84,12 +84,6 @@ def search_factory(self, search, query_parser=None):
         if view != current_app.config.get('SONAR_APP_DEFAULT_ORGANISATION'):
             search = search.filter('term', organisation__pid=view)
 
-        # Don't display records flagged as hidden
-        search = search.filter('bool',
-                               must_not={'term': {
-                                   'hiddenFromPublic': True
-                               }})
-
     # Admin
     else:
         # Filters records by user's organisation

--- a/sonar/modules/documents/receivers.py
+++ b/sonar/modules/documents/receivers.py
@@ -84,11 +84,11 @@ def transform_harvested_records(sender=None, records=None, **kwargs):
         count=len(records), time=time.time() - start_time))
 
 
-def populate_fulltext_field(sender=None,
-                            record=None,
-                            json=None,
-                            index=None,
-                            **kwargs):
+def enrich_document_data(sender=None,
+                         record=None,
+                         json=None,
+                         index=None,
+                         **kwargs):
     """Receive a signal before record is indexed, to add fulltext.
 
     This function is called just before a record is sent to index.
@@ -105,6 +105,9 @@ def populate_fulltext_field(sender=None,
     # Transform record in DocumentRecord
     if not isinstance(record, DocumentRecord):
         record = DocumentRecord.get_record(record.id)
+
+    # Check if record is open access.
+    json['isOpenAccess'] = record.is_open_access()
 
     # No files are present in record
     if not record.files:

--- a/tests/ui/documents/test_documents_receivers.py
+++ b/tests/ui/documents/test_documents_receivers.py
@@ -22,8 +22,8 @@ from os.path import exists, join
 
 from invenio_oaiharvester.tasks import get_records
 
-from sonar.modules.documents.receivers import chunks, export_json, \
-    populate_fulltext_field, transform_harvested_records
+from sonar.modules.documents.receivers import chunks, enrich_document_data, \
+    export_json, transform_harvested_records
 
 
 def test_transform_harvested_records(app, bucket_location,
@@ -61,7 +61,7 @@ def test_transform_harvested_records(app, bucket_location,
     assert captured.out == ''
 
 
-def test_populate_fulltext_field(app, db, document, pdf_file):
+def test_enrich_document_data(app, db, document, pdf_file):
     """Test add full text to document."""
     with open(pdf_file, 'rb') as file:
         content = file.read()
@@ -74,7 +74,7 @@ def test_populate_fulltext_field(app, db, document, pdf_file):
     db.session.commit()
 
     json = {}
-    populate_fulltext_field(record=document, index='documents', json=json)
+    enrich_document_data(record=document, index='documents', json=json)
 
     assert len(json['fulltext']) == 1
     assert json['fulltext'][0].startswith('PHYSICAL REVIEW B 99')

--- a/tests/ui/test_query.py
+++ b/tests/ui/test_query.py
@@ -18,8 +18,10 @@
 """Test elasticsearch query."""
 
 import pytest
+from elasticsearch_dsl import Search
+from invenio_search import current_search_client
 
-from sonar.modules.query import get_operator_and_query_type
+from sonar.modules.query import and_term_filter, get_operator_and_query_type
 
 
 def test_get_operator_and_query_type(app):
@@ -45,3 +47,61 @@ def test_get_operator_and_query_type(app):
         req.request.args = {'operator': 'AND'}
         assert get_operator_and_query_type('test') == ('AND',
                                                        'simple_query_string')
+
+
+def test_open_access_filter(app, document):
+    """Test open access filter."""
+    # No filter
+    search = Search(index='documents', using=current_search_client)
+    assert len(search.execute()) == 1
+
+    # No files associated with document --> not open access.
+    search = search.query(and_term_filter('isOpenAccess')([True]))
+    assert not search.execute()
+
+    # Files with document, no access property --> open access.
+    document.add_file(b'Test', 'test1.pdf')
+    document.commit()
+    document.reindex()
+    search = search.query(and_term_filter('isOpenAccess')([True]))
+    assert len(search.execute()) == 1
+
+    # Files with document, access property is closed --> not open access.
+    document.files['test1.pdf']['access'] = 'coar:c_16ec'
+    document.commit()
+    document.reindex()
+    search = search.query(and_term_filter('isOpenAccess')([True]))
+    assert not search.execute()
+
+    # Files with document, access property is open access --> open access.
+    document.files['test1.pdf']['access'] = 'coar:c_abf2'
+    document.commit()
+    document.reindex()
+    search = search.query(and_term_filter('isOpenAccess')([True]))
+    assert len(search.execute()) == 1
+
+    # Files with document, access property is embargo access and no date
+    # provided --> not open access.
+    document.files['test1.pdf']['access'] = 'coar:c_f1cf'
+    document.commit()
+    document.reindex()
+    search = search.query(and_term_filter('isOpenAccess')([True]))
+    assert not search.execute()
+
+    # Files with document, access property is embargo access and date is in the
+    # future --> not open access.
+    document.files['test1.pdf']['access'] = 'coar:c_f1cf'
+    document.files['test1.pdf']['embargo_date'] = '2025-01-01'
+    document.commit()
+    document.reindex()
+    search = search.query(and_term_filter('isOpenAccess')([True]))
+    assert not search.execute()
+
+    # Files with document, access property is embargo access and date is in the
+    # past --> open access.
+    document.files['test1.pdf']['access'] = 'coar:c_f1cf'
+    document.files['test1.pdf']['embargo_date'] = '2021-01-01'
+    document.commit()
+    document.reindex()
+    search = search.query(and_term_filter('isOpenAccess')([True]))
+    assert len(search.execute()) == 1

--- a/tests/unit/heg/record/test_heg_record.py
+++ b/tests/unit/heg/record/test_heg_record.py
@@ -52,6 +52,5 @@ def test_serialize(app):
                 'value': 'Unknown title'
             }],
             'type': 'bf:Title'
-        }],
-        'hiddenFromPublic': True
+        }]
     }

--- a/tests/unit/heg/serializers/schemas/test_heg_serializers_schemas_unpaywall.py
+++ b/tests/unit/heg/serializers/schemas/test_heg_serializers_schemas_unpaywall.py
@@ -37,7 +37,8 @@ def test_unpaywall_schema(app):
             'label': 'Full-text',
             'order': 0,
             'type': 'file',
-            'url': 'https://pdf.url'
+            'url': 'https://pdf.url',
+            'force_external_url': True
         }]
     }
 


### PR DESCRIPTION
* Adds a filter to search only for open access documents.
* Configures `oa_status` field to display it in editor.
* Sets the `access` property of the first files when the record is imported from HEG.
* Forces files to point to external URLs for records imported from HEG.
* Fixes an error when trying to retrieve the record corresponding to the file bucket and record has an OAI PID.
* Removes the useless `hiddenFromPublic` property in documents.
* Closes #511.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>