### PR TITLE
documents: custom fields for documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ target/
 .DS_Store
 
 # Generated JSON schemas
+sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0.json
 sonar/modules/documents/jsonschemas/documents/document-v1.0.0.json
 sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0.json
 sonar/resources/projects/jsonschemas/projects/project-v1.0.0.json

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU Affero General Public License for more details.
 
+exclude sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0.json
 exclude sonar/modules/documents/jsonschemas/documents/document-v1.0.0.json
 exclude sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0.json
 exclude sonar/modules/projects/jsonschemas/projects/project-v1.0.0.json

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -88,6 +88,7 @@ cp ${assets_folder}/node_modules/pdfjs-dist/build/pdf.worker.min.js ${static_fol
 
 # Compile JSON schemas
 section "Compile JSON schemas" "info"
+invenio utils compile-json ./sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json -o ./sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0.json
 invenio utils compile-json ./sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json -o ./sonar/modules/documents/jsonschemas/documents/document-v1.0.0.json
 invenio utils compile-json ./sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json -o ./sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0.json
 invenio utils compile-json ./sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json -o ./sonar/resources/projects/jsonschemas/projects/project-v1.0.0.json

--- a/sonar/config.py
+++ b/sonar/config.py
@@ -499,7 +499,13 @@ RECORDS_REST_FACETS = {
             field='provisionActivity.startDate',
             interval='year',
             format='yyyy',
-        ))),
+        )),
+        customField1=dict(terms=dict(field='customField1.raw',
+                                     size=DEFAULT_AGGREGATION_SIZE)),
+        customField2=dict(terms=dict(field='customField2.raw',
+                                     size=DEFAULT_AGGREGATION_SIZE)),
+        customField3=dict(terms=dict(field='customField3.raw',
+                                     size=DEFAULT_AGGREGATION_SIZE))),
          filters={
              'sections':
              and_term_filter('sections'),
@@ -522,7 +528,13 @@ RECORDS_REST_FACETS = {
                           format='yyyy',
                           end_date_math='/y'),
              'open_access':
-             and_term_filter('isOpenAccess')
+             and_term_filter('isOpenAccess'),
+             'customField1':
+             and_term_filter('customField1.raw'),
+             'customField2':
+             and_term_filter('customField2.raw'),
+             'customField3':
+             and_term_filter('customField3.raw')
          }),
     'deposits':
     dict(aggs=dict(

--- a/sonar/json_schemas/__init__.py
+++ b/sonar/json_schemas/__init__.py
@@ -15,26 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# Extraction from Python source files
-[python: **.py]
-encoding = utf-8
-[python: **/manual_translations.txt]
-encoding = utf-8
-
-# Extraction from Jinja2 templates
-[jinja2: **/templates/**.html]
-encoding = utf-8
-extensions = jinja2.ext.autoescape, jinja2.ext.with_
-
-# Extraction from JavaScript files
-[javascript: **.js]
-encoding = utf-8
-extract_messages = $._, jQuery._
-
-# Extraction from json files (schema)
-[ignore: **/**/organisation-v1.0.0.json]
-[ignore: **/**/document-v1.0.0.json]
-[ignore: **/**/deposit-v1.0.0.json]
-[ignore: **/**/project-v1.0.0.json]
-[json: **.json]
-keys_to_translate = ['^title$', '^label$', '^description$', '^placeholder$', '^.*Message$']
+"""JSON schema class."""

--- a/sonar/json_schemas/documents_json_schema.py
+++ b/sonar/json_schemas/documents_json_schema.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Documents JSON schema class."""
+
+from sonar.modules.organisations.api import current_organisation
+from sonar.modules.utils import get_language_value
+
+from .json_schema_base import JSONSchemaBase
+
+
+class DocumentsJSONSchema(JSONSchemaBase):
+    """JSON schema for documents."""
+
+    def process(self):
+        """Document JSON schema custom process.
+
+        :returns: The processed schema.
+        """
+        schema = super().process()
+
+        # Change the label for field, depending on configuration in
+        # organisation.
+        for i in range(1, 4):
+            # Not dedicated, the custom fields are removed
+            if not current_organisation or not current_organisation.get(
+                    'isDedicated'):
+                schema['properties'].pop(f'customField{i}', None)
+                schema['propertiesOrder'].remove(f'customField{i}')
+            else:
+                if schema['properties'].get(
+                        f'customField{i}'
+                ) and current_organisation and current_organisation.get(
+                        f'documentsCustomField{i}', {}).get('label'):
+                    schema['properties'][f'customField{i}'][
+                        'title'] = get_language_value(
+                            current_organisation[f'documentsCustomField{i}']
+                            ['label'])
+
+        return schema

--- a/sonar/json_schemas/factory.py
+++ b/sonar/json_schemas/factory.py
@@ -15,26 +15,25 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# Extraction from Python source files
-[python: **.py]
-encoding = utf-8
-[python: **/manual_translations.txt]
-encoding = utf-8
+"""Factory for JSON schema."""
 
-# Extraction from Jinja2 templates
-[jinja2: **/templates/**.html]
-encoding = utf-8
-extensions = jinja2.ext.autoescape, jinja2.ext.with_
+from .documents_json_schema import DocumentsJSONSchema
+from .json_schema_base import JSONSchemaBase
 
-# Extraction from JavaScript files
-[javascript: **.js]
-encoding = utf-8
-extract_messages = $._, jQuery._
 
-# Extraction from json files (schema)
-[ignore: **/**/organisation-v1.0.0.json]
-[ignore: **/**/document-v1.0.0.json]
-[ignore: **/**/deposit-v1.0.0.json]
-[ignore: **/**/project-v1.0.0.json]
-[json: **.json]
-keys_to_translate = ['^title$', '^label$', '^description$', '^placeholder$', '^.*Message$']
+class JSONSchemaFactory():
+    """Factory for JSON schema."""
+
+    SCHEMAS = {'documents': DocumentsJSONSchema}
+
+    @staticmethod
+    def create(resource_type):
+        """Create instance of schema based on the given resource.
+
+        :param resource_type: String representing the type of resource.
+        :returns: The schema instance.
+        """
+        if JSONSchemaFactory.SCHEMAS.get(resource_type):
+            return JSONSchemaFactory.SCHEMAS[resource_type](resource_type)
+
+        return JSONSchemaBase(resource_type)

--- a/sonar/json_schemas/json_schema_base.py
+++ b/sonar/json_schemas/json_schema_base.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""JSON schema class."""
+
+import copy
+import re
+
+from invenio_jsonschemas import current_jsonschemas
+
+from sonar.modules.organisations.api import current_organisation
+from sonar.modules.utils import has_custom_resource
+
+
+class JSONSchemaBase:
+    """Base class for managing JSON schemas."""
+
+    _resource_type = None
+    _schema = None
+
+    def __init__(self, resource_type):
+        """Class initialization.
+
+        Stores the resource type and load the corresponding schema.
+
+        :param resource_type: Type of resource
+        """
+        self._resource_type = resource_type
+        self._load_schema()
+
+    def _load_schema(self):
+        """Process and return the JSON schema.
+
+        :returns: The schema corresponding to the resource.
+        """
+        rec_type = self._resource_type
+        rec_type = re.sub('ies$', 'y', rec_type)
+        rec_type = re.sub('s$', '', rec_type)
+
+        schema_name = f'{self._resource_type}/{rec_type}-v1.0.0.json'
+
+        if has_custom_resource(self._resource_type):
+            schema_name = f'{current_organisation["code"]}/{schema_name}'
+
+        self._schema = copy.deepcopy(
+            current_jsonschemas.get_schema(schema_name))
+
+    def get_schema(self):
+        """Return the schema loaded.
+
+        :returns: The loaded schema.
+        """
+        return self._schema
+
+    def process(self):
+        """Additional treatment for schema.
+
+        :returns: The processed schema.
+        """
+        return self._schema

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -1794,6 +1794,66 @@
           }
         ]
       }
+    },
+    "customField1": {
+      "title": "Custom field 1",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "form": {
+          "remoteTypeahead": {
+            "type": "documents",
+            "field": "customField1.suggest",
+            "suggest": "/api/suggestions/completion",
+            "allowAdd": true
+          }
+        }
+      },
+      "form": {
+        "hide": true
+      }
+    },
+    "customField2": {
+      "title": "Custom field 2",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "form": {
+          "remoteTypeahead": {
+            "type": "documents",
+            "field": "customField2.suggest",
+            "suggest": "/api/suggestions/completion",
+            "allowAdd": true
+          }
+        }
+      },
+      "form": {
+        "hide": true
+      }
+    },
+    "customField3": {
+      "title": "Custom field 3",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "form": {
+          "remoteTypeahead": {
+            "type": "documents",
+            "field": "customField3.suggest",
+            "suggest": "/api/suggestions/completion",
+            "allowAdd": true
+          }
+        }
+      },
+      "form": {
+        "hide": true
+      }
     }
   },
   "propertiesOrder": [
@@ -1821,7 +1881,10 @@
     "contentNote",
     "otherMaterialCharacteristics",
     "usageAndAccessPolicy",
-    "oa_status"
+    "oa_status",
+    "customField1",
+    "customField2",
+    "customField3"
   ],
   "required": [
     "$schema",

--- a/sonar/modules/documents/mappings/v7/documents/document-v1.0.0.json
+++ b/sonar/modules/documents/mappings/v7/documents/document-v1.0.0.json
@@ -527,6 +527,42 @@
       "isOpenAccess": {
         "type": "boolean"
       },
+      "customField1": {
+        "type": "text",
+        "fields": {
+          "raw": {
+            "type":  "keyword"
+          },
+          "suggest": {
+            "type": "completion",
+            "analyzer": "default"
+          }
+        }
+      },
+      "customField2": {
+        "type": "text",
+        "fields": {
+          "raw": {
+            "type":  "keyword"
+          },
+          "suggest": {
+            "type": "completion",
+            "analyzer": "default"
+          }
+        }
+      },
+      "customField3": {
+        "type": "text",
+        "fields": {
+          "raw": {
+            "type":  "keyword"
+          },
+          "suggest": {
+            "type": "completion",
+            "analyzer": "default"
+          }
+        }
+      },
       "_created": {
         "type": "date"
       },

--- a/sonar/modules/documents/marshmallow/json.py
+++ b/sonar/modules/documents/marshmallow/json.py
@@ -25,7 +25,7 @@ from flask import request
 from invenio_records_rest.schemas import Nested, StrictKeysMixin
 from invenio_records_rest.schemas.fields import GenFunction, \
     PersistentIdentifier, SanitizedUnicode
-from marshmallow import EXCLUDE, fields, pre_dump, pre_load
+from marshmallow import EXCLUDE, fields, pre_dump, pre_load, validate
 
 from sonar.modules.documents.api import DocumentRecord
 from sonar.modules.documents.permissions import DocumentPermission
@@ -101,6 +101,9 @@ class DocumentMetadataSchemaV1(StrictKeysMixin):
     oa_status = SanitizedUnicode()
     sections = fields.List(fields.Str())
     harvested = fields.Boolean()
+    customField1 = fields.List(fields.String(validate=validate.Length(min=1)))
+    customField2 = fields.List(fields.String(validate=validate.Length(min=1)))
+    customField3 = fields.List(fields.String(validate=validate.Length(min=1)))
     _bucket = SanitizedUnicode()
     _files = Nested(FileSchemaV1, many=True)
     _oai = fields.Dict()

--- a/sonar/modules/documents/query.py
+++ b/sonar/modules/documents/query.py
@@ -33,7 +33,8 @@ FIELDS = [
     'otherMaterialCharacteristics', 'formats', 'additionalMaterials',
     'series.*', 'notes', 'abstracts.*', 'identifiedBy.*', 'subjects.*',
     'otherEdition.*', 'classification.*', 'contentNote', 'dissertation.*',
-    'usageAndAccessPolicy', 'contribution.*', 'partOf.*', 'projects.*'
+    'usageAndAccessPolicy', 'contribution.*', 'partOf.*', 'projects.*',
+    'customField1', 'customField2', 'customField3'
 ]
 
 

--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -166,8 +166,8 @@ along with this program. If not, see
         {% for abstract in abstracts %}
         <span id="lang-{{ abstract.language }}" class="abstract-container {{ '' if loop.first else 'd-none' }}">
           {% if abstract.value | length > 400 %}
-          <span data-abstract="{{ abstract.value | nl2br }}">{{ abstract.value | truncate(400) }}</span> <a
-            href="#" class="showMore-abstract">{{ _('Show more') }}&hellip;</a>
+          <span data-abstract="{{ abstract.value | nl2br }}">{{ abstract.value | truncate(400) }}</span> <a href="#"
+            class="showMore-abstract">{{ _('Show more') }}&hellip;</a>
           {% else %}
           {{ abstract.value | nl2br | safe }}
           {% endif %}
@@ -266,6 +266,21 @@ along with this program. If not, see
         </dd>
         {% endfor %}
         {% endif %}
+
+        <!-- CUSTOM FIELDS -->
+        {% for i in range(1, 4) %}
+        {% if record['customField' + i|string] %}
+        <dt class="col-lg-3">
+          {% set label = record | get_custom_field_label(i) %}
+          {% if label %}
+          {{ label }}
+          {% else %}
+          {{ 'Custom field ' + i|string }}
+          {% endif%}
+        </dt>
+        <dd class="col-lg-9">{{ record['customField' + i|string] | join(', ') }}</dd>
+        {% endif %}
+        {% endfor %}
 
         <!-- LICENSE -->
         {% if record.usageAndAccessPolicy %}

--- a/sonar/modules/documents/views.py
+++ b/sonar/modules/documents/views.py
@@ -29,7 +29,7 @@ from invenio_records_ui.signals import record_viewed
 from sonar.modules.documents.utils import has_external_urls_for_files, \
     populate_files_properties
 from sonar.modules.utils import format_date, \
-    get_bibliographic_code_from_language
+    get_bibliographic_code_from_language, get_language_value
 
 from .utils import publication_statement_text
 
@@ -267,6 +267,23 @@ def contribution_text(contribution):
             role=contribution['role'][0])).lower()))
 
     return ' '.join(data)
+
+
+@blueprint.app_template_filter()
+def get_custom_field_label(record, custom_field_index):
+    """Get the label of a custom field.
+
+    :param record: Record object.
+    :param custom_field_index: Index position of the custom field.
+    :returns: The label found or None.
+    """
+    if record.get('organisation') and record['organisation'][0].get(
+            'documentsCustomField' + str(custom_field_index), {}).get('label'):
+        return get_language_value(
+            record['organisation'][0]['documentsCustomField' +
+                                      str(custom_field_index)]['label'])
+
+    return None
 
 
 def get_language_from_bibliographic_code(language_code):

--- a/sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json
+++ b/sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json
@@ -81,6 +81,147 @@
         "hideExpression": "!field.model.isDedicated"
       }
     },
+    "documentsCustomField1": {
+      "title": "Document custom field 1",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "title": "Labels",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "title": "Label",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "value": {
+                "title": "Value",
+                "type": "string",
+                "minLength": 1
+              },
+              "language": {
+                "$ref": "language-v1.0.0.json"
+              }
+            },
+            "propertiesOrder": [
+              "language",
+              "value"
+            ],
+            "required": [
+              "value",
+              "language"
+            ]
+          }
+        },
+        "includeInFacets": {
+          "title": "Include in facets",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "propertiesOrder": [
+        "label",
+        "includeInFacets"
+      ],
+      "form": {
+        "hideExpression": "!field.parent.model.isDedicated"
+      }
+    },
+    "documentsCustomField2": {
+      "title": "Document custom field 2",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "title": "Labels",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "title": "Label",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "value": {
+                "title": "Value",
+                "type": "string",
+                "minLength": 1
+              },
+              "language": {
+                "$ref": "language-v1.0.0.json"
+              }
+            },
+            "propertiesOrder": [
+              "language",
+              "value"
+            ],
+            "required": [
+              "value",
+              "language"
+            ]
+          }
+        },
+        "includeInFacets": {
+          "title": "Include in facets",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "propertiesOrder": [
+        "label",
+        "includeInFacets"
+      ],
+      "form": {
+        "hideExpression": "!field.parent.model.isDedicated"
+      }
+    },
+    "documentsCustomField3": {
+      "title": "Document custom field 3",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "title": "Labels",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "title": "Label",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "value": {
+                "title": "Value",
+                "type": "string",
+                "minLength": 1
+              },
+              "language": {
+                "$ref": "language-v1.0.0.json"
+              }
+            },
+            "propertiesOrder": [
+              "language",
+              "value"
+            ],
+            "required": [
+              "value",
+              "language"
+            ]
+          }
+        },
+        "includeInFacets": {
+          "title": "Include in facets",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "propertiesOrder": [
+        "label",
+        "includeInFacets"
+      ],
+      "form": {
+        "hideExpression": "!field.parent.model.isDedicated"
+      }
+    },
     "_bucket": {
       "title": "Bucket UUID",
       "type": "string",
@@ -149,7 +290,10 @@
     "isShared",
     "isDedicated",
     "platformName",
-    "allowedIps"
+    "allowedIps",
+    "documentsCustomField1",
+    "documentsCustomField2",
+    "documentsCustomField3"
   ],
   "required": [
     "pid",

--- a/sonar/modules/organisations/mappings/v7/organisations/organisation-v1.0.0.json
+++ b/sonar/modules/organisations/mappings/v7/organisations/organisation-v1.0.0.json
@@ -32,6 +32,63 @@
       "platformName": {
         "type": "text"
       },
+      "documentsCustomField1": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "object",
+            "properties": {
+              "language": {
+                "type": "keyword"
+              },
+              "value": {
+                "type": "text"
+              }
+            }
+          },
+          "includeInFacets": {
+            "type": "boolean"
+          }
+        }
+      },
+      "documentsCustomField2": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "object",
+            "properties": {
+              "language": {
+                "type": "keyword"
+              },
+              "value": {
+                "type": "text"
+              }
+            }
+          },
+          "includeInFacets": {
+            "type": "boolean"
+          }
+        }
+      },
+      "documentsCustomField3": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "object",
+            "properties": {
+              "language": {
+                "type": "keyword"
+              },
+              "value": {
+                "type": "text"
+              }
+            }
+          },
+          "includeInFacets": {
+            "type": "boolean"
+          }
+        }
+      },
       "_created": {
         "type": "date"
       },

--- a/sonar/modules/organisations/marshmallow/json.py
+++ b/sonar/modules/organisations/marshmallow/json.py
@@ -48,6 +48,9 @@ class OrganisationMetadataSchemaV1(StrictKeysMixin):
     isDedicated = fields.Boolean()
     allowedIps = SanitizedUnicode()
     platformName = SanitizedUnicode()
+    documentsCustomField1 = fields.Dict()
+    documentsCustomField2 = fields.Dict()
+    documentsCustomField3 = fields.Dict()
     # When loading, if $schema is not provided, it's retrieved by
     # Record.schema property.
     schema = GenFunction(load_only=True,

--- a/tests/api/documents/test_documents_permissions.py
+++ b/tests/api/documents/test_documents_permissions.py
@@ -62,6 +62,7 @@ def test_list(app, client, make_document, superuser, admin, moderator,
     res = client.get(url_for('invenio_records_rest.doc_list'))
     assert res.status_code == 200
     assert res.json['hits']['total']['value'] == 1
+    assert res.json['aggregations']['customField1']['name'] == 'Test'
     assert not res.json['aggregations'].get('organisation')
 
     # Logged as superuser
@@ -75,12 +76,14 @@ def test_list(app, client, make_document, superuser, admin, moderator,
     res = client.get(url_for('invenio_records_rest.doc_list', view='global'))
     assert res.status_code == 200
     assert res.json['hits']['total']['value'] == 2
+    assert not res.json['aggregations'].get('customField1')
     assert res.json['aggregations'].get('organisation')
 
     # Public search for organisation
     res = client.get(url_for('invenio_records_rest.doc_list', view='org'))
     assert res.status_code == 200
     assert res.json['hits']['total']['value'] == 1
+    assert res.json['aggregations']['customField1']['name'] == 'Test'
     assert not res.json['aggregations'].get('organisation')
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,7 +99,14 @@ def make_organisation(app, db, bucket_location, without_oaiset_signals):
             'code': code,
             'name': code,
             'isShared': True,
-            'isDedicated': False
+            'isDedicated': False,
+            'documentsCustomField1': {
+                'label': [{
+                    'language': 'eng',
+                    'value': 'Test'
+                }],
+                'includeInFacets': True
+            }
         }
 
         record = OrganisationRecord.get_record_by_pid(code)
@@ -360,7 +367,8 @@ def document_json(app, db, bucket_location, organisation):
             'grantingInstitution': 'Università della Svizzera italiana',
             'date': '2010-12-01',
             'jury_note': 'Jury note'
-        }
+        },
+        'customField1': ['Test']
     }
 
     return data

--- a/tests/ui/documents/test_documents_views.py
+++ b/tests/ui/documents/test_documents_views.py
@@ -366,3 +366,49 @@ def test_language_value(app):
     }]
     assert render_template_string('{{ values | language_value }}',
                                   values=values) == 'Value ENG'
+
+
+def test_get_custom_field_label(app):
+    """Test custom field label."""
+    record = {
+        'organisation': [{
+            'documentsCustomField1': {
+                'label': [{
+                    'language': 'eng',
+                    'value': 'Test ENG'
+                }, {
+                    'language': 'fre',
+                    'value': 'Test FRE'
+                }]
+            }
+        }]
+    }
+    assert render_template_string('{{ record | get_custom_field_label(1) }}',
+                                  record=record) == 'Test ENG'
+
+    # No organisation
+    record = {}
+    assert render_template_string('{{ record | get_custom_field_label(1) }}',
+                                  record=record) == 'None'
+
+    # No index for custom field
+    record = {
+        'organisation': [{
+            'documentsCustomField1': {
+                'label': [{
+                    'language': 'eng',
+                    'value': 'Test ENG'
+                }, {
+                    'language': 'fre',
+                    'value': 'Test FRE'
+                }]
+            }
+        }]
+    }
+    assert render_template_string('{{ record | get_custom_field_label(2) }}',
+                                  record=record) == 'None'
+
+    # No label
+    record = {'organisation': [{'documentsCustomField1': {}}]}
+    assert render_template_string('{{ record | get_custom_field_label(1) }}',
+                                  record=record) == 'None'

--- a/tests/unit/json_schemas/test_documents_json_schema.py
+++ b/tests/unit/json_schemas/test_documents_json_schema.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test documents JSON schema."""
+
+from sonar.json_schemas.documents_json_schema import DocumentsJSONSchema
+
+
+def test_process(app, monkeypatch):
+    """Test process."""
+    schema = DocumentsJSONSchema('documents')
+    result = schema.get_schema()
+    assert result['properties']['customField1']['title'] == 'Custom field 1'
+
+    # No current organisation
+    schema = DocumentsJSONSchema('documents')
+    result = schema.process()
+    assert not result['properties'].get('customField1')
+
+    # Custom label for field
+    monkeypatch.setattr(
+        'sonar.json_schemas.documents_json_schema.current_organisation', {
+            'isDedicated': True,
+            'documentsCustomField1': {
+                'label': [{
+                    'language': 'eng',
+                    'value': 'Test'
+                }]
+            }
+        })
+
+    schema = DocumentsJSONSchema('documents')
+    result = schema.process()
+    assert result['properties']['customField1']['title'] == 'Test'

--- a/tests/unit/json_schemas/test_json_schema.py
+++ b/tests/unit/json_schemas/test_json_schema.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test JSON schema."""
+
+import pytest
+
+from sonar.json_schemas.json_schema_base import JSONSchemaBase
+
+
+def test_load(app, monkeypatch):
+    """Test load."""
+    # Non existing schema
+    with pytest.raises(Exception) as exception:
+        schema = JSONSchemaBase('fakes')
+        assert str(
+            exception.value) == 'Schema "fakes/fake-v1.0.0.json" not found'
+
+    # Standard schema
+    schema = JSONSchemaBase('documents')
+    assert schema.get_schema()['title'] == 'Document'
+
+    # Schema for custom resource
+    monkeypatch.setattr(
+        'sonar.json_schemas.json_schema_base.current_organisation',
+        {'code': 'hepvs'})
+    monkeypatch.setattr(
+        'sonar.json_schemas.json_schema_base.has_custom_resource', lambda *
+        args, **kwargs: True)
+    schema = JSONSchemaBase('projects')
+    assert schema.get_schema()['title'] == 'Research project'

--- a/tests/unit/json_schemas/test_json_schema_factory.py
+++ b/tests/unit/json_schemas/test_json_schema_factory.py
@@ -15,26 +15,19 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# Extraction from Python source files
-[python: **.py]
-encoding = utf-8
-[python: **/manual_translations.txt]
-encoding = utf-8
+"""Test JSON schema factory."""
 
-# Extraction from Jinja2 templates
-[jinja2: **/templates/**.html]
-encoding = utf-8
-extensions = jinja2.ext.autoescape, jinja2.ext.with_
+from sonar.json_schemas.documents_json_schema import DocumentsJSONSchema
+from sonar.json_schemas.factory import JSONSchemaFactory
+from sonar.json_schemas.json_schema_base import JSONSchemaBase
 
-# Extraction from JavaScript files
-[javascript: **.js]
-encoding = utf-8
-extract_messages = $._, jQuery._
 
-# Extraction from json files (schema)
-[ignore: **/**/organisation-v1.0.0.json]
-[ignore: **/**/document-v1.0.0.json]
-[ignore: **/**/deposit-v1.0.0.json]
-[ignore: **/**/project-v1.0.0.json]
-[json: **.json]
-keys_to_translate = ['^title$', '^label$', '^description$', '^placeholder$', '^.*Message$']
+def test_create(app):
+    """Test schema object creation."""
+    # No custom schema
+    schema = JSONSchemaFactory.create('organisations')
+    assert isinstance(schema, JSONSchemaBase)
+
+    # Specific schema
+    schema = JSONSchemaFactory.create('documents')
+    assert isinstance(schema, DocumentsJSONSchema)


### PR DESCRIPTION
* Adds the support of custom fields for dedicated organisations documents.
* Adds the filters and aggregations for the custom fields.
* Creates a custom class for managing JSON schemas, with a factory to instantiate the right class.
* Configures JSON schema and Elasticsearch mapping for the three custom fields.
* Adjusts facets for custom fields depending on the context (dedicated view or not).
* Displays the custom fields in documents detail view.
* Adds properties in organisation (JSON schema and mapping) to configure the behavior of the custom fields.
* Refactors the view serving the JSON schema, to use the new class and factory.
* Closes #512.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>