### PR TITLE
search: suggestions completion API endpoint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setup(
             'users = sonar.modules.users.views:blueprint',
             'monitoring = sonar.monitoring.views:blueprint',
             'translations = sonar.translations.rest:blueprint',
+            'suggestions = sonar.suggestions.rest:blueprint',
         ],
         'invenio_assets.webpack': [
             'sonar_theme = sonar.theme.webpack:theme'

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -1734,7 +1734,7 @@
             "form": {
               "remoteTypeahead": {
                 "type": "projects",
-                "field": "metdata.name.suggest",
+                "field": "metadata.name.suggest",
                 "label": "name"
               }
             }

--- a/sonar/modules/users/mappings/v7/users/user-v1.0.0.json
+++ b/sonar/modules/users/mappings/v7/users/user-v1.0.0.json
@@ -24,9 +24,8 @@
         "type": "text",
         "fields": {
           "suggest": {
-            "type": "text",
-            "analyzer": "autocomplete",
-            "search_analyzer": "standard"
+            "type": "completion",
+            "analyzer": "default"
           }
         }
       },

--- a/sonar/modules/users/marshmallow/json.py
+++ b/sonar/modules/users/marshmallow/json.py
@@ -47,6 +47,7 @@ class UserMetadataSchemaV1(StrictKeysMixin):
     phone = SanitizedUnicode()
     organisation = fields.Dict()
     role = SanitizedUnicode()
+    full_name = SanitizedUnicode()
     # When loading, if $schema is not provided, it's retrieved by
     # Record.schema property.
     schema = GenFunction(load_only=True,

--- a/sonar/proxies.py
+++ b/sonar/proxies.py
@@ -54,6 +54,10 @@ class SonarProxy():
         :param resource_type: Type of resource.
         :returns: A service instance
         """
+        if not self.resources.get(resource_type):
+            raise Exception(
+                f'No service configured for resource "{resource_type}"')
+
         return self.resources[resource_type].service
 
 

--- a/sonar/resources/projects/mappings/v7/projects/project-v1.0.0.json
+++ b/sonar/resources/projects/mappings/v7/projects/project-v1.0.0.json
@@ -18,9 +18,8 @@
             "type": "text",
             "fields": {
               "suggest": {
-                "type": "text",
-                "analyzer": "autocomplete",
-                "search_analyzer": "standard"
+                "type": "completion",
+                "analyzer": "default"
               }
             }
           },

--- a/sonar/suggestions/__init__.py
+++ b/sonar/suggestions/__init__.py
@@ -15,17 +15,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Test SONAR extension."""
-
-
-from sonar.proxies import sonar
-
-
-def test_get_endpoints(app):
-    """Test list endpoints."""
-    endpoints = sonar.endpoints
-    assert endpoints['doc'] == 'documents'
-    assert endpoints['depo'] == 'deposits'
-    assert endpoints['org'] == 'organisations'
-    assert endpoints['user'] == 'users'
-    assert endpoints['projects'] == 'projects'
+"""Suggestions."""

--- a/sonar/suggestions/rest.py
+++ b/sonar/suggestions/rest.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Suggestions rest views."""
+
+from flask import Blueprint, current_app, jsonify, request
+
+from sonar.proxies import sonar
+
+blueprint = Blueprint('suggestions', __name__, url_prefix='/suggestions')
+
+
+@blueprint.route('/completion', methods=['GET'])
+def completion():
+    """Suggestions completion."""
+    query = request.args.get('q')
+    field = request.args.get('field')
+    resource = request.args.get('resource')
+
+    if not query:
+        return jsonify({'error': 'No query parameter given'}), 400
+
+    if not field:
+        return jsonify({'error': 'No field parameter given'}), 400
+
+    if not resource:
+        return jsonify({'error': 'No resource parameter given'}), 400
+
+    # Suggestions from multiple fields possible
+    fields = field.split(',')
+
+    search = None
+    try:
+        service = sonar.service(resource)
+        search = service.config.search_cls(index=resource)
+    except Exception:
+        for doc_type, config in current_app.config.get(
+                'RECORDS_REST_ENDPOINTS').items():
+            if config.get('search_index') == resource:
+                search = config['search_class']()
+
+    if not search:
+        return jsonify({'error': 'Search class not found'}), 404
+
+    results = []
+
+    try:
+        search = search.source(excludes="*")
+
+        for field in fields:
+            search = search.suggest(field,
+                                    query,
+                                    completion={
+                                        'field': field,
+                                        'skip_duplicates': True
+                                    })
+        for i, suggestion in search.execute().suggest.to_dict().items():
+            results = results + [
+                option['text'] for option in suggestion[0]['options']
+            ]
+    except Exception:
+        return jsonify({'error': 'Bad request'}), 400
+
+    # Remove duplicates
+    results = list(dict.fromkeys(results))
+
+    # Sort items
+    results.sort()
+
+    return jsonify(results)

--- a/tests/api/suggestions/test_suggestions_rest.py
+++ b/tests/api/suggestions/test_suggestions_rest.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test suggestions rest."""
+
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+from invenio_search import current_search
+
+
+def test_completion(client, project, make_user):
+    """Test completion suggestions."""
+    # Ensure project is indexed
+    current_search.flush_and_refresh(index='projects')
+
+    user = make_user('admin', organisation='hepvs', access='admin-access')
+    login_user_via_session(client, email=user['email'])
+
+    # No query parameter
+    res = client.get(url_for('suggestions.completion'))
+    assert res.status_code == 400
+    assert res.json == {'error': 'No query parameter given'}
+
+    # No field parameter
+    res = client.get(url_for('suggestions.completion', q='test'))
+    assert res.status_code == 400
+    assert res.json == {'error': 'No field parameter given'}
+
+    # No resource parameter
+    res = client.get(
+        url_for('suggestions.completion',
+                q='Sp',
+                field='metadata.projectSponsor.suggest'))
+    assert res.status_code == 400
+    assert res.json == {'error': 'No resource parameter given'}
+
+    # Non existing resource
+    res = client.get(
+        url_for('suggestions.completion',
+                q='Sp',
+                field='metadata.projectSponsor.suggest',
+                resource='unknown'))
+    assert res.status_code == 404
+    assert res.json == {'error': 'Search class not found'}
+
+    # Unknown field
+    res = client.get(
+        url_for('suggestions.completion',
+                q='Sp',
+                field='unknown',
+                resource='projects'))
+    assert res.status_code == 400
+    assert res.json == {'error': 'Bad request'}
+
+    # Resource managed by invenio-records-resources
+    res = client.get(
+        url_for('suggestions.completion',
+                q='Pro',
+                field='metadata.name.suggest',
+                resource='projects'))
+    assert res.status_code == 200
+    assert res.json == ['Project 1']
+
+    # Old way resource
+    res = client.get(
+        url_for('suggestions.completion',
+                q='Hepvs',
+                field='full_name.suggest',
+                resource='users'))
+    assert res.status_code == 200
+    assert res.json == ['Hepvsadmin Doe']

--- a/tests/unit/test_sonar_proxy.py
+++ b/tests/unit/test_sonar_proxy.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test SONAR proxy."""
+
+import pytest
+
+from sonar.proxies import sonar
+from sonar.resources.projects.service import RecordService
+
+
+def test_get_endpoints(app):
+    """Test list endpoints."""
+    endpoints = sonar.endpoints
+    assert endpoints['doc'] == 'documents'
+    assert endpoints['depo'] == 'deposits'
+    assert endpoints['org'] == 'organisations'
+    assert endpoints['user'] == 'users'
+    assert endpoints['projects'] == 'projects'
+
+
+def test_service(app):
+    """Test service."""
+    service = sonar.service('projects')
+    assert isinstance(service, RecordService)
+
+    with pytest.raises(Exception) as exception:
+        sonar.service('unknown')
+    assert str(
+        exception.value) == 'No service configured for resource "unknown"'


### PR DESCRIPTION
* Adds a REST endpoint for getting suggestions completion.
* Set the type to `completion` for fields used in suggestions.
* Raises an exception if a resource is not found in SONAR proxy.
* Fixes a typo in remote typeahead in documents.
* Serializes `full_name` property in users marshmallow schema.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>