### PR TITLE
json schemas: configure options tree for select

### DIFF
--- a/sonar/common/jsonschemas/classification-v1.0.0.json
+++ b/sonar/common/jsonschemas/classification-v1.0.0.json
@@ -91,445 +91,413 @@
     "931"
   ],
   "form": {
-    "type": "enum",
+    "templateOptions": {
+      "sort": false,
+      "wrappers": [
+        "card"
+      ]
+    },
     "options": [
       {
         "label": "classification_root_1",
         "value": "root_1",
-        "level": 0,
-        "disabled": true
-      },
-      {
-        "label": "classification_004",
-        "value": "004",
-        "level": 1
-      },
-      {
-        "label": "classification_6",
-        "value": "6",
-        "level": 1
-      },
-      {
-        "label": "classification_63",
-        "value": "63",
-        "level": 2
-      },
-      {
-        "label": "classification_66",
-        "value": "66",
-        "level": 2
-      },
-      {
-        "label": "classification_663",
-        "value": "663",
-        "level": 3
-      },
-      {
-        "label": "classification_664",
-        "value": "664",
-        "level": 3
-      },
-      {
-        "label": "classification_620.1",
-        "value": "620.1",
-        "level": 2
-      },
-      {
-        "label": "classification_620.9",
-        "value": "620.9",
-        "level": 2
-      },
-      {
-        "label": "classification_621",
-        "value": "621",
-        "level": 2
-      },
-      {
-        "label": "classification_621.01",
-        "value": "621.01",
-        "level": 2
-      },
-      {
-        "label": "classification_621.3",
-        "value": "621.3",
-        "level": 2
-      },
-      {
-        "label": "classification_621.38",
-        "value": "621.38",
-        "level": 2
-      },
-      {
-        "label": "classification_621.39",
-        "value": "621.39",
-        "level": 2
-      },
-      {
-        "label": "classification_621.762",
-        "value": "621.762",
-        "level": 2
-      },
-      {
-        "label": "classification_681",
-        "value": "681",
-        "level": 2
-      },
-      {
-        "label": "classification_61",
-        "value": "61",
-        "level": 1
-      },
-      {
-        "label": "classification_61_2",
-        "value": "61",
-        "level": 2
-      },
-      {
-        "label": "classification_613.2",
-        "value": "613.2",
-        "level": 3
-      },
-      {
-        "label": "classification_614.253.5",
-        "value": "614.253.5",
-        "level": 3
-      },
-      {
-        "label": "classification_615",
-        "value": "615",
-        "level": 2
-      },
-      {
-        "label": "classification_615.8",
-        "value": "615.8",
-        "level": 3
-      },
-      {
-        "label": "classification_615.84",
-        "value": "615.84",
-        "level": 3
-      },
-      {
-        "label": "classification_616",
-        "value": "616",
-        "level": 2
-      },
-      {
-        "label": "classification_616.31",
-        "value": "616.31",
-        "level": 2
-      },
-      {
-        "label": "classification_616-083",
-        "value": "616-083",
-        "level": 2
+        "disabled": true,
+        "children": [
+          {
+            "label": "classification_004",
+            "value": "004"
+          },
+          {
+            "label": "classification_6",
+            "value": "6",
+            "children": [
+              {
+                "label": "classification_63",
+                "value": "63"
+              },
+              {
+                "label": "classification_66",
+                "value": "66",
+                "children": [
+                  {
+                    "label": "classification_663",
+                    "value": "663"
+                  },
+                  {
+                    "label": "classification_664",
+                    "value": "664"
+                  }
+                ]
+              },
+              {
+                "label": "classification_620.1",
+                "value": "620.1"
+              },
+              {
+                "label": "classification_620.9",
+                "value": "620.9"
+              },
+              {
+                "label": "classification_621",
+                "value": "621"
+              },
+              {
+                "label": "classification_621.01",
+                "value": "621.01"
+              },
+              {
+                "label": "classification_621.3",
+                "value": "621.3"
+              },
+              {
+                "label": "classification_621.38",
+                "value": "621.38"
+              },
+              {
+                "label": "classification_621.39",
+                "value": "621.39"
+              },
+              {
+                "label": "classification_621.762",
+                "value": "621.762"
+              },
+              {
+                "label": "classification_681",
+                "value": "681"
+              }
+            ]
+          },
+          {
+            "label": "classification_61",
+            "value": "61",
+            "children": [
+              {
+                "label": "classification_61_2",
+                "value": "61",
+                "children": [
+                  {
+                    "label": "classification_613.2",
+                    "value": "613.2"
+                  },
+                  {
+                    "label": "classification_614.253.5",
+                    "value": "614.253.5"
+                  }
+                ]
+              },
+              {
+                "label": "classification_615",
+                "value": "615",
+                "children": [
+                  {
+                    "label": "classification_615.8",
+                    "value": "615.8"
+                  },
+                  {
+                    "label": "classification_615.84",
+                    "value": "615.84"
+                  }
+                ]
+              },
+              {
+                "label": "classification_616",
+                "value": "616"
+              },
+              {
+                "label": "classification_616.31",
+                "value": "616.31"
+              },
+              {
+                "label": "classification_616-083",
+                "value": "616-083"
+              }
+            ]
+          }
+        ]
       },
       {
         "label": "classification_root_2",
         "value": "root_2",
-        "level": 0,
-        "disabled": true
-      },
-      {
-        "label": "classification_51",
-        "value": "51",
-        "level": 1
-      },
-      {
-        "label": "classification_519.2",
-        "value": "519.2",
-        "level": 2
-      },
-      {
-        "label": "classification_52",
-        "value": "52",
-        "level": 1
-      },
-      {
-        "label": "classification_524.8",
-        "value": "524.8",
-        "level": 2
-      },
-      {
-        "label": "classification_53",
-        "value": "53",
-        "level": 1
-      },
-      {
-        "label": "classification_54",
-        "value": "54",
-        "level": 1
-      },
-      {
-        "label": "classification_543",
-        "value": "543",
-        "level": 2
-      },
-      {
-        "label": "classification_548",
-        "value": "548",
-        "level": 2
-      },
-      {
-        "label": "classification_549",
-        "value": "549",
-        "level": 2
-      },
-      {
-        "label": "classification_574",
-        "value": "574",
-        "level": 1
-      },
-      {
-        "label": "classification_55/56",
-        "value": "55/56",
-        "level": 1
-      },
-      {
-        "label": "classification_55",
-        "value": "55",
-        "level": 2
-      },
-      {
-        "label": "classification_551",
-        "value": "551",
-        "level": 3
-      },
-      {
-        "label": "classification_556",
-        "value": "556",
-        "level": 3
-      },
-      {
-        "label": "classification_56",
-        "value": "56",
-        "level": 2
-      },
-      {
-        "label": "classification_57/59",
-        "value": "57/59",
-        "level": 1
-      },
-      {
-        "label": "classification_57",
-        "value": "57",
-        "level": 2
-      },
-      {
-        "label": "classification_58",
-        "value": "58",
-        "level": 2
-      },
-      {
-        "label": "classification_59",
-        "value": "59",
-        "level": 2
-      },
-      {
-        "label": "classification_60",
-        "value": "60",
-        "level": 2
+        "disabled": true,
+        "children": [
+          {
+            "label": "classification_51",
+            "value": "51",
+            "children": [
+              {
+                "label": "classification_519.2",
+                "value": "519.2"
+              }
+            ]
+          },
+          {
+            "label": "classification_52",
+            "value": "52",
+            "children": [
+              {
+                "label": "classification_524.8",
+                "value": "524.8"
+              }
+            ]
+          },
+          {
+            "label": "classification_53",
+            "value": "53"
+          },
+          {
+            "label": "classification_54",
+            "value": "54",
+            "children": [
+              {
+                "label": "classification_543",
+                "value": "543"
+              },
+              {
+                "label": "classification_548",
+                "value": "548"
+              },
+              {
+                "label": "classification_549",
+                "value": "549"
+              }
+            ]
+          },
+          {
+            "label": "classification_574",
+            "value": "574"
+          },
+          {
+            "label": "classification_55/56",
+            "value": "55/56",
+            "children": [
+              {
+                "label": "classification_55",
+                "value": "55",
+                "children": [
+                  {
+                    "label": "classification_551",
+                    "value": "551"
+                  },
+                  {
+                    "label": "classification_556",
+                    "value": "556"
+                  }
+                ]
+              },
+              {
+                "label": "classification_56",
+                "value": "56"
+              }
+            ]
+          },
+          {
+            "label": "classification_57/59",
+            "value": "57/59",
+            "children": [
+              {
+                "label": "classification_57",
+                "value": "57"
+              },
+              {
+                "label": "classification_58",
+                "value": "58"
+              },
+              {
+                "label": "classification_59",
+                "value": "59"
+              },
+              {
+                "label": "classification_60",
+                "value": "60"
+              }
+            ]
+          }
+        ]
       },
       {
         "label": "classification_root_3",
         "value": "root_3",
-        "level": 0,
-        "disabled": true
-      },
-      {
-        "label": "classification_1",
-        "value": "1",
-        "level": 1
-      },
-      {
-        "label": "classification_16",
-        "value": "16",
-        "level": 2
-      },
-      {
-        "label": "classification_2",
-        "value": "2",
-        "level": 1
-      },
-      {
-        "label": "classification_294/299",
-        "value": "294/299",
-        "level": 2
-      },
-      {
-        "label": "classification_3",
-        "value": "3",
-        "level": 1
-      },
-      {
-        "label": "classification_31",
-        "value": "31",
-        "level": 2
-      },
-      {
-        "label": "classification_7",
-        "value": "7",
-        "level": 1
-      },
-      {
-        "label": "classification_7.071",
-        "value": "7.071",
-        "level": 2
-      },
-      {
-        "label": "classification_78",
-        "value": "78",
-        "level": 2
-      },
-      {
-        "label": "classification_73/77",
-        "value": "73/77",
-        "level": 2
-      },
-      {
-        "label": "classification_75",
-        "value": "75",
-        "level": 3
-      },
-      {
-        "label": "classification_77",
-        "value": "77",
-        "level": 3
-      },
-      {
-        "label": "classification_32",
-        "value": "32",
-        "level": 1
-      },
-      {
-        "label": "classification_33",
-        "value": "33",
-        "level": 1
-      },
-      {
-        "label": "classification_34",
-        "value": "34",
-        "level": 1
-      },
-      {
-        "label": "classification_35",
-        "value": "35",
-        "level": 1
-      },
-      {
-        "label": "classification_36",
-        "value": "36",
-        "level": 1
-      },
-      {
-        "label": "classification_37",
-        "value": "37",
-        "level": 1
-      },
-      {
-        "label": "classification_370",
-        "value": "370",
-        "level": 2
-      },
-      {
-        "label": "classification_376",
-        "value": "376",
-        "level": 2
-      },
-      {
-        "label": "classification_378.6",
-        "value": "378.6",
-        "level": 2
-      },
-      {
-        "label": "classification_39",
-        "value": "39",
-        "level": 2
-      },
-      {
-        "label": "classification_65",
-        "value": "65",
-        "level": 1
-      },
-      {
-        "label": "classification_02",
-        "value": "02",
-        "level": 2
-      },
-      {
-        "label": "classification_72",
-        "value": "72",
-        "level": 1
-      },
-      {
-        "label": "classification_71",
-        "value": "71",
-        "level": 2
-      },
-      {
-        "label": "classification_81",
-        "value": "81",
-        "level": 1
-      },
-      {
-        "label": "classification_81´28",
-        "value": "81´28",
-        "level": 2
-      },
-      {
-        "label": "classification_82",
-        "value": "82",
-        "level": 1
-      },
-      {
-        "label": "classification_91",
-        "value": "91",
-        "level": 1
-      },
-      {
-        "label": "classification_159.9",
-        "value": "159.9",
-        "level": 1
-      },
-      {
-        "label": "classification_159.953",
-        "value": "159.953",
-        "level": 2
-      },
-      {
-        "label": "classification_796",
-        "value": "796",
-        "level": 1
-      },
-      {
-        "label": "classification_93/94",
-        "value": "93/94",
-        "level": 1
-      },
-      {
-        "label": "classification_94",
-        "value": "94",
-        "level": 2
-      },
-      {
-        "label": "classification_902",
-        "value": "902",
-        "level": 2
-      },
-      {
-        "label": "classification_903",
-        "value": "903",
-        "level": 2
-      },
-      {
-        "label": "classification_929.5",
-        "value": "929.5",
-        "level": 2
-      },
-      {
-        "label": "classification_931",
-        "value": "931",
-        "level": 2
+        "disabled": true,
+        "children": [
+          {
+            "label": "classification_1",
+            "value": "1",
+            "children": [
+              {
+                "label": "classification_16",
+                "value": "16"
+              }
+            ]
+          },
+          {
+            "label": "classification_2",
+            "value": "2",
+            "children": [
+              {
+                "label": "classification_294/299",
+                "value": "294/299"
+              }
+            ]
+          },
+          {
+            "label": "classification_3",
+            "value": "3",
+            "children": [
+              {
+                "label": "classification_31",
+                "value": "31"
+              }
+            ]
+          },
+          {
+            "label": "classification_7",
+            "value": "7",
+            "children": [
+              {
+                "label": "classification_7.071",
+                "value": "7.071"
+              },
+              {
+                "label": "classification_78",
+                "value": "78"
+              },
+              {
+                "label": "classification_73/77",
+                "value": "73/77",
+                "children": [
+                  {
+                    "label": "classification_75",
+                    "value": "75"
+                  },
+                  {
+                    "label": "classification_77",
+                    "value": "77"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "label": "classification_32",
+            "value": "32"
+          },
+          {
+            "label": "classification_33",
+            "value": "33"
+          },
+          {
+            "label": "classification_34",
+            "value": "34"
+          },
+          {
+            "label": "classification_35",
+            "value": "35"
+          },
+          {
+            "label": "classification_36",
+            "value": "36"
+          },
+          {
+            "label": "classification_37",
+            "value": "37",
+            "children": [
+              {
+                "label": "classification_370",
+                "value": "370"
+              },
+              {
+                "label": "classification_376",
+                "value": "376"
+              },
+              {
+                "label": "classification_378.6",
+                "value": "378.6"
+              },
+              {
+                "label": "classification_39",
+                "value": "39"
+              }
+            ]
+          },
+          {
+            "label": "classification_65",
+            "value": "65",
+            "children": [
+              {
+                "label": "classification_02",
+                "value": "02"
+              }
+            ]
+          },
+          {
+            "label": "classification_72",
+            "value": "72",
+            "children": [
+              {
+                "label": "classification_71",
+                "value": "71"
+              }
+            ]
+          },
+          {
+            "label": "classification_81",
+            "value": "81",
+            "children": [
+              {
+                "label": "classification_81´28",
+                "value": "81´28"
+              }
+            ]
+          },
+          {
+            "label": "classification_82",
+            "value": "82"
+          },
+          {
+            "label": "classification_91",
+            "value": "91"
+          },
+          {
+            "label": "classification_159.9",
+            "value": "159.9",
+            "children": [
+              {
+                "label": "classification_159.953",
+                "value": "159.953"
+              }
+            ]
+          },
+          {
+            "label": "classification_796",
+            "value": "796"
+          },
+          {
+            "label": "classification_93/94",
+            "value": "93/94",
+            "children": [
+              {
+                "label": "classification_94",
+                "value": "94"
+              },
+              {
+                "label": "classification_902",
+                "value": "902"
+              },
+              {
+                "label": "classification_903",
+                "value": "903"
+              },
+              {
+                "label": "classification_929.5",
+                "value": "929.5"
+              },
+              {
+                "label": "classification_931",
+                "value": "931"
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/sonar/common/jsonschemas/language-v1.0.0.json
+++ b/sonar/common/jsonschemas/language-v1.0.0.json
@@ -489,2448 +489,1956 @@
     "zza"
   ],
   "form": {
-    "type": "enum",
+    "templateOptions": {
+      "sort": true,
+      "wrappers": [
+        "card"
+      ]
+    },
     "options": [
       {
-        "label": "lang_eng",
-        "value": "eng"
-      },
-      {
-        "label": "lang_fre",
-        "value": "fre"
-      },
-      {
-        "label": "lang_ger",
-        "value": "ger"
-      },
-      {
-        "label": "lang_ita",
-        "value": "ita"
-      },
-      {
         "label": "lang_aar",
-        "value": "aar",
-        "group": "------------"
+        "value": "aar"
       },
       {
         "label": "lang_abk",
-        "value": "abk",
-        "group": "------------"
+        "value": "abk"
       },
       {
         "label": "lang_ace",
-        "value": "ace",
-        "group": "------------"
+        "value": "ace"
       },
       {
         "label": "lang_ach",
-        "value": "ach",
-        "group": "------------"
+        "value": "ach"
       },
       {
         "label": "lang_ada",
-        "value": "ada",
-        "group": "------------"
+        "value": "ada"
       },
       {
         "label": "lang_ady",
-        "value": "ady",
-        "group": "------------"
+        "value": "ady"
       },
       {
         "label": "lang_afa",
-        "value": "afa",
-        "group": "------------"
+        "value": "afa"
       },
       {
         "label": "lang_afh",
-        "value": "afh",
-        "group": "------------"
+        "value": "afh"
       },
       {
         "label": "lang_afr",
-        "value": "afr",
-        "group": "------------"
+        "value": "afr"
       },
       {
         "label": "lang_ain",
-        "value": "ain",
-        "group": "------------"
+        "value": "ain"
       },
       {
         "label": "lang_aka",
-        "value": "aka",
-        "group": "------------"
+        "value": "aka"
       },
       {
         "label": "lang_akk",
-        "value": "akk",
-        "group": "------------"
+        "value": "akk"
       },
       {
         "label": "lang_alb",
-        "value": "alb",
-        "group": "------------"
+        "value": "alb"
       },
       {
         "label": "lang_ale",
-        "value": "ale",
-        "group": "------------"
+        "value": "ale"
       },
       {
         "label": "lang_alg",
-        "value": "alg",
-        "group": "------------"
+        "value": "alg"
       },
       {
         "label": "lang_alt",
-        "value": "alt",
-        "group": "------------"
+        "value": "alt"
       },
       {
         "label": "lang_amh",
-        "value": "amh",
-        "group": "------------"
+        "value": "amh"
       },
       {
         "label": "lang_ang",
-        "value": "ang",
-        "group": "------------"
+        "value": "ang"
       },
       {
         "label": "lang_anp",
-        "value": "anp",
-        "group": "------------"
+        "value": "anp"
       },
       {
         "label": "lang_apa",
-        "value": "apa",
-        "group": "------------"
+        "value": "apa"
       },
       {
         "label": "lang_ara",
-        "value": "ara",
-        "group": "------------"
+        "value": "ara"
       },
       {
         "label": "lang_arc",
-        "value": "arc",
-        "group": "------------"
+        "value": "arc"
       },
       {
         "label": "lang_arg",
-        "value": "arg",
-        "group": "------------"
+        "value": "arg"
       },
       {
         "label": "lang_arm",
-        "value": "arm",
-        "group": "------------"
+        "value": "arm"
       },
       {
         "label": "lang_arn",
-        "value": "arn",
-        "group": "------------"
+        "value": "arn"
       },
       {
         "label": "lang_arp",
-        "value": "arp",
-        "group": "------------"
+        "value": "arp"
       },
       {
         "label": "lang_art",
-        "value": "art",
-        "group": "------------"
+        "value": "art"
       },
       {
         "label": "lang_arw",
-        "value": "arw",
-        "group": "------------"
+        "value": "arw"
       },
       {
         "label": "lang_asm",
-        "value": "asm",
-        "group": "------------"
+        "value": "asm"
       },
       {
         "label": "lang_ast",
-        "value": "ast",
-        "group": "------------"
+        "value": "ast"
       },
       {
         "label": "lang_ath",
-        "value": "ath",
-        "group": "------------"
+        "value": "ath"
       },
       {
         "label": "lang_aus",
-        "value": "aus",
-        "group": "------------"
+        "value": "aus"
       },
       {
         "label": "lang_ava",
-        "value": "ava",
-        "group": "------------"
+        "value": "ava"
       },
       {
         "label": "lang_ave",
-        "value": "ave",
-        "group": "------------"
+        "value": "ave"
       },
       {
         "label": "lang_awa",
-        "value": "awa",
-        "group": "------------"
+        "value": "awa"
       },
       {
         "label": "lang_aym",
-        "value": "aym",
-        "group": "------------"
+        "value": "aym"
       },
       {
         "label": "lang_aze",
-        "value": "aze",
-        "group": "------------"
+        "value": "aze"
       },
       {
         "label": "lang_bad",
-        "value": "bad",
-        "group": "------------"
+        "value": "bad"
       },
       {
         "label": "lang_bai",
-        "value": "bai",
-        "group": "------------"
+        "value": "bai"
       },
       {
         "label": "lang_bak",
-        "value": "bak",
-        "group": "------------"
+        "value": "bak"
       },
       {
         "label": "lang_bal",
-        "value": "bal",
-        "group": "------------"
+        "value": "bal"
       },
       {
         "label": "lang_bam",
-        "value": "bam",
-        "group": "------------"
+        "value": "bam"
       },
       {
         "label": "lang_ban",
-        "value": "ban",
-        "group": "------------"
+        "value": "ban"
       },
       {
         "label": "lang_baq",
-        "value": "baq",
-        "group": "------------"
+        "value": "baq"
       },
       {
         "label": "lang_bas",
-        "value": "bas",
-        "group": "------------"
+        "value": "bas"
       },
       {
         "label": "lang_bat",
-        "value": "bat",
-        "group": "------------"
+        "value": "bat"
       },
       {
         "label": "lang_bej",
-        "value": "bej",
-        "group": "------------"
+        "value": "bej"
       },
       {
         "label": "lang_bel",
-        "value": "bel",
-        "group": "------------"
+        "value": "bel"
       },
       {
         "label": "lang_bem",
-        "value": "bem",
-        "group": "------------"
+        "value": "bem"
       },
       {
         "label": "lang_ben",
-        "value": "ben",
-        "group": "------------"
+        "value": "ben"
       },
       {
         "label": "lang_ber",
-        "value": "ber",
-        "group": "------------"
+        "value": "ber"
       },
       {
         "label": "lang_bho",
-        "value": "bho",
-        "group": "------------"
+        "value": "bho"
       },
       {
         "label": "lang_bih",
-        "value": "bih",
-        "group": "------------"
+        "value": "bih"
       },
       {
         "label": "lang_bik",
-        "value": "bik",
-        "group": "------------"
+        "value": "bik"
       },
       {
         "label": "lang_bin",
-        "value": "bin",
-        "group": "------------"
+        "value": "bin"
       },
       {
         "label": "lang_bis",
-        "value": "bis",
-        "group": "------------"
+        "value": "bis"
       },
       {
         "label": "lang_bla",
-        "value": "bla",
-        "group": "------------"
+        "value": "bla"
       },
       {
         "label": "lang_bnt",
-        "value": "bnt",
-        "group": "------------"
+        "value": "bnt"
       },
       {
         "label": "lang_bos",
-        "value": "bos",
-        "group": "------------"
+        "value": "bos"
       },
       {
         "label": "lang_bra",
-        "value": "bra",
-        "group": "------------"
+        "value": "bra"
       },
       {
         "label": "lang_bre",
-        "value": "bre",
-        "group": "------------"
+        "value": "bre"
       },
       {
         "label": "lang_btk",
-        "value": "btk",
-        "group": "------------"
+        "value": "btk"
       },
       {
         "label": "lang_bua",
-        "value": "bua",
-        "group": "------------"
+        "value": "bua"
       },
       {
         "label": "lang_bug",
-        "value": "bug",
-        "group": "------------"
+        "value": "bug"
       },
       {
         "label": "lang_bul",
-        "value": "bul",
-        "group": "------------"
+        "value": "bul"
       },
       {
         "label": "lang_bur",
-        "value": "bur",
-        "group": "------------"
+        "value": "bur"
       },
       {
         "label": "lang_byn",
-        "value": "byn",
-        "group": "------------"
+        "value": "byn"
       },
       {
         "label": "lang_cad",
-        "value": "cad",
-        "group": "------------"
+        "value": "cad"
       },
       {
         "label": "lang_cai",
-        "value": "cai",
-        "group": "------------"
+        "value": "cai"
       },
       {
         "label": "lang_car",
-        "value": "car",
-        "group": "------------"
+        "value": "car"
       },
       {
         "label": "lang_cat",
-        "value": "cat",
-        "group": "------------"
+        "value": "cat"
       },
       {
         "label": "lang_cau",
-        "value": "cau",
-        "group": "------------"
+        "value": "cau"
       },
       {
         "label": "lang_ceb",
-        "value": "ceb",
-        "group": "------------"
+        "value": "ceb"
       },
       {
         "label": "lang_cel",
-        "value": "cel",
-        "group": "------------"
+        "value": "cel"
       },
       {
         "label": "lang_cha",
-        "value": "cha",
-        "group": "------------"
+        "value": "cha"
       },
       {
         "label": "lang_chb",
-        "value": "chb",
-        "group": "------------"
+        "value": "chb"
       },
       {
         "label": "lang_che",
-        "value": "che",
-        "group": "------------"
+        "value": "che"
       },
       {
         "label": "lang_chg",
-        "value": "chg",
-        "group": "------------"
+        "value": "chg"
       },
       {
         "label": "lang_chi",
-        "value": "chi",
-        "group": "------------"
+        "value": "chi"
       },
       {
         "label": "lang_chk",
-        "value": "chk",
-        "group": "------------"
+        "value": "chk"
       },
       {
         "label": "lang_chm",
-        "value": "chm",
-        "group": "------------"
+        "value": "chm"
       },
       {
         "label": "lang_chn",
-        "value": "chn",
-        "group": "------------"
+        "value": "chn"
       },
       {
         "label": "lang_cho",
-        "value": "cho",
-        "group": "------------"
+        "value": "cho"
       },
       {
         "label": "lang_chp",
-        "value": "chp",
-        "group": "------------"
+        "value": "chp"
       },
       {
         "label": "lang_chr",
-        "value": "chr",
-        "group": "------------"
+        "value": "chr"
       },
       {
         "label": "lang_chu",
-        "value": "chu",
-        "group": "------------"
+        "value": "chu"
       },
       {
         "label": "lang_chv",
-        "value": "chv",
-        "group": "------------"
+        "value": "chv"
       },
       {
         "label": "lang_chy",
-        "value": "chy",
-        "group": "------------"
+        "value": "chy"
       },
       {
         "label": "lang_cmc",
-        "value": "cmc",
-        "group": "------------"
+        "value": "cmc"
       },
       {
         "label": "lang_cnr",
-        "value": "cnr",
-        "group": "------------"
+        "value": "cnr"
       },
       {
         "label": "lang_cop",
-        "value": "cop",
-        "group": "------------"
+        "value": "cop"
       },
       {
         "label": "lang_cor",
-        "value": "cor",
-        "group": "------------"
+        "value": "cor"
       },
       {
         "label": "lang_cos",
-        "value": "cos",
-        "group": "------------"
+        "value": "cos"
       },
       {
         "label": "lang_cpe",
-        "value": "cpe",
-        "group": "------------"
+        "value": "cpe"
       },
       {
         "label": "lang_cpf",
-        "value": "cpf",
-        "group": "------------"
+        "value": "cpf"
       },
       {
         "label": "lang_cpp",
-        "value": "cpp",
-        "group": "------------"
+        "value": "cpp"
       },
       {
         "label": "lang_cre",
-        "value": "cre",
-        "group": "------------"
+        "value": "cre"
       },
       {
         "label": "lang_crh",
-        "value": "crh",
-        "group": "------------"
+        "value": "crh"
       },
       {
         "label": "lang_crp",
-        "value": "crp",
-        "group": "------------"
+        "value": "crp"
       },
       {
         "label": "lang_csb",
-        "value": "csb",
-        "group": "------------"
+        "value": "csb"
       },
       {
         "label": "lang_cus",
-        "value": "cus",
-        "group": "------------"
+        "value": "cus"
       },
       {
         "label": "lang_cze",
-        "value": "cze",
-        "group": "------------"
+        "value": "cze"
       },
       {
         "label": "lang_dak",
-        "value": "dak",
-        "group": "------------"
+        "value": "dak"
       },
       {
         "label": "lang_dan",
-        "value": "dan",
-        "group": "------------"
+        "value": "dan"
       },
       {
         "label": "lang_dar",
-        "value": "dar",
-        "group": "------------"
+        "value": "dar"
       },
       {
         "label": "lang_day",
-        "value": "day",
-        "group": "------------"
+        "value": "day"
       },
       {
         "label": "lang_del",
-        "value": "del",
-        "group": "------------"
+        "value": "del"
       },
       {
         "label": "lang_den",
-        "value": "den",
-        "group": "------------"
+        "value": "den"
       },
       {
         "label": "lang_dgr",
-        "value": "dgr",
-        "group": "------------"
+        "value": "dgr"
       },
       {
         "label": "lang_din",
-        "value": "din",
-        "group": "------------"
+        "value": "din"
       },
       {
         "label": "lang_div",
-        "value": "div",
-        "group": "------------"
+        "value": "div"
       },
       {
         "label": "lang_doi",
-        "value": "doi",
-        "group": "------------"
+        "value": "doi"
       },
       {
         "label": "lang_dra",
-        "value": "dra",
-        "group": "------------"
+        "value": "dra"
       },
       {
         "label": "lang_dsb",
-        "value": "dsb",
-        "group": "------------"
+        "value": "dsb"
       },
       {
         "label": "lang_dua",
-        "value": "dua",
-        "group": "------------"
+        "value": "dua"
       },
       {
         "label": "lang_dum",
-        "value": "dum",
-        "group": "------------"
+        "value": "dum"
       },
       {
         "label": "lang_dut",
-        "value": "dut",
-        "group": "------------"
+        "value": "dut"
       },
       {
         "label": "lang_dyu",
-        "value": "dyu",
-        "group": "------------"
+        "value": "dyu"
       },
       {
         "label": "lang_dzo",
-        "value": "dzo",
-        "group": "------------"
+        "value": "dzo"
       },
       {
         "label": "lang_efi",
-        "value": "efi",
-        "group": "------------"
+        "value": "efi"
       },
       {
         "label": "lang_egy",
-        "value": "egy",
-        "group": "------------"
+        "value": "egy"
       },
       {
         "label": "lang_eka",
-        "value": "eka",
-        "group": "------------"
+        "value": "eka"
       },
       {
         "label": "lang_elx",
-        "value": "elx",
-        "group": "------------"
+        "value": "elx"
       },
       {
         "label": "lang_eng",
         "value": "eng",
-        "group": "------------"
+        "preferred": true
       },
       {
         "label": "lang_enm",
-        "value": "enm",
-        "group": "------------"
+        "value": "enm"
       },
       {
         "label": "lang_epo",
-        "value": "epo",
-        "group": "------------"
+        "value": "epo"
       },
       {
         "label": "lang_est",
-        "value": "est",
-        "group": "------------"
+        "value": "est"
       },
       {
         "label": "lang_ewe",
-        "value": "ewe",
-        "group": "------------"
+        "value": "ewe"
       },
       {
         "label": "lang_ewo",
-        "value": "ewo",
-        "group": "------------"
+        "value": "ewo"
       },
       {
         "label": "lang_fan",
-        "value": "fan",
-        "group": "------------"
+        "value": "fan"
       },
       {
         "label": "lang_fao",
-        "value": "fao",
-        "group": "------------"
+        "value": "fao"
       },
       {
         "label": "lang_fat",
-        "value": "fat",
-        "group": "------------"
+        "value": "fat"
       },
       {
         "label": "lang_fij",
-        "value": "fij",
-        "group": "------------"
+        "value": "fij"
       },
       {
         "label": "lang_fil",
-        "value": "fil",
-        "group": "------------"
+        "value": "fil"
       },
       {
         "label": "lang_fin",
-        "value": "fin",
-        "group": "------------"
+        "value": "fin"
       },
       {
         "label": "lang_fiu",
-        "value": "fiu",
-        "group": "------------"
+        "value": "fiu"
       },
       {
         "label": "lang_fon",
-        "value": "fon",
-        "group": "------------"
+        "value": "fon"
       },
       {
         "label": "lang_fre",
         "value": "fre",
-        "group": "------------"
+        "preferred": true
       },
       {
         "label": "lang_frm",
-        "value": "frm",
-        "group": "------------"
+        "value": "frm"
       },
       {
         "label": "lang_fro",
-        "value": "fro",
-        "group": "------------"
+        "value": "fro"
       },
       {
         "label": "lang_frr",
-        "value": "frr",
-        "group": "------------"
+        "value": "frr"
       },
       {
         "label": "lang_frs",
-        "value": "frs",
-        "group": "------------"
+        "value": "frs"
       },
       {
         "label": "lang_fry",
-        "value": "fry",
-        "group": "------------"
+        "value": "fry"
       },
       {
         "label": "lang_ful",
-        "value": "ful",
-        "group": "------------"
+        "value": "ful"
       },
       {
         "label": "lang_fur",
-        "value": "fur",
-        "group": "------------"
+        "value": "fur"
       },
       {
         "label": "lang_gaa",
-        "value": "gaa",
-        "group": "------------"
+        "value": "gaa"
       },
       {
         "label": "lang_gay",
-        "value": "gay",
-        "group": "------------"
+        "value": "gay"
       },
       {
         "label": "lang_gba",
-        "value": "gba",
-        "group": "------------"
+        "value": "gba"
       },
       {
         "label": "lang_gem",
-        "value": "gem",
-        "group": "------------"
+        "value": "gem"
       },
       {
         "label": "lang_geo",
-        "value": "geo",
-        "group": "------------"
+        "value": "geo"
       },
       {
         "label": "lang_ger",
         "value": "ger",
-        "group": "------------"
+        "preferred": true
       },
       {
         "label": "lang_gez",
-        "value": "gez",
-        "group": "------------"
+        "value": "gez"
       },
       {
         "label": "lang_gil",
-        "value": "gil",
-        "group": "------------"
+        "value": "gil"
       },
       {
         "label": "lang_gla",
-        "value": "gla",
-        "group": "------------"
+        "value": "gla"
       },
       {
         "label": "lang_gle",
-        "value": "gle",
-        "group": "------------"
+        "value": "gle"
       },
       {
         "label": "lang_glg",
-        "value": "glg",
-        "group": "------------"
+        "value": "glg"
       },
       {
         "label": "lang_glv",
-        "value": "glv",
-        "group": "------------"
+        "value": "glv"
       },
       {
         "label": "lang_gmh",
-        "value": "gmh",
-        "group": "------------"
+        "value": "gmh"
       },
       {
         "label": "lang_goh",
-        "value": "goh",
-        "group": "------------"
+        "value": "goh"
       },
       {
         "label": "lang_gon",
-        "value": "gon",
-        "group": "------------"
+        "value": "gon"
       },
       {
         "label": "lang_gor",
-        "value": "gor",
-        "group": "------------"
+        "value": "gor"
       },
       {
         "label": "lang_got",
-        "value": "got",
-        "group": "------------"
+        "value": "got"
       },
       {
         "label": "lang_grb",
-        "value": "grb",
-        "group": "------------"
+        "value": "grb"
       },
       {
         "label": "lang_grc",
-        "value": "grc",
-        "group": "------------"
+        "value": "grc"
       },
       {
         "label": "lang_gre",
-        "value": "gre",
-        "group": "------------"
+        "value": "gre"
       },
       {
         "label": "lang_grn",
-        "value": "grn",
-        "group": "------------"
+        "value": "grn"
       },
       {
         "label": "lang_gsw",
-        "value": "gsw",
-        "group": "------------"
+        "value": "gsw"
       },
       {
         "label": "lang_guj",
-        "value": "guj",
-        "group": "------------"
+        "value": "guj"
       },
       {
         "label": "lang_gwi",
-        "value": "gwi",
-        "group": "------------"
+        "value": "gwi"
       },
       {
         "label": "lang_hai",
-        "value": "hai",
-        "group": "------------"
+        "value": "hai"
       },
       {
         "label": "lang_hat",
-        "value": "hat",
-        "group": "------------"
+        "value": "hat"
       },
       {
         "label": "lang_hau",
-        "value": "hau",
-        "group": "------------"
+        "value": "hau"
       },
       {
         "label": "lang_haw",
-        "value": "haw",
-        "group": "------------"
+        "value": "haw"
       },
       {
         "label": "lang_heb",
-        "value": "heb",
-        "group": "------------"
+        "value": "heb"
       },
       {
         "label": "lang_her",
-        "value": "her",
-        "group": "------------"
+        "value": "her"
       },
       {
         "label": "lang_hil",
-        "value": "hil",
-        "group": "------------"
+        "value": "hil"
       },
       {
         "label": "lang_him",
-        "value": "him",
-        "group": "------------"
+        "value": "him"
       },
       {
         "label": "lang_hin",
-        "value": "hin",
-        "group": "------------"
+        "value": "hin"
       },
       {
         "label": "lang_hit",
-        "value": "hit",
-        "group": "------------"
+        "value": "hit"
       },
       {
         "label": "lang_hmn",
-        "value": "hmn",
-        "group": "------------"
+        "value": "hmn"
       },
       {
         "label": "lang_hmo",
-        "value": "hmo",
-        "group": "------------"
+        "value": "hmo"
       },
       {
         "label": "lang_hrv",
-        "value": "hrv",
-        "group": "------------"
+        "value": "hrv"
       },
       {
         "label": "lang_hsb",
-        "value": "hsb",
-        "group": "------------"
+        "value": "hsb"
       },
       {
         "label": "lang_hun",
-        "value": "hun",
-        "group": "------------"
+        "value": "hun"
       },
       {
         "label": "lang_hup",
-        "value": "hup",
-        "group": "------------"
+        "value": "hup"
       },
       {
         "label": "lang_iba",
-        "value": "iba",
-        "group": "------------"
+        "value": "iba"
       },
       {
         "label": "lang_ibo",
-        "value": "ibo",
-        "group": "------------"
+        "value": "ibo"
       },
       {
         "label": "lang_ice",
-        "value": "ice",
-        "group": "------------"
+        "value": "ice"
       },
       {
         "label": "lang_ido",
-        "value": "ido",
-        "group": "------------"
+        "value": "ido"
       },
       {
         "label": "lang_iii",
-        "value": "iii",
-        "group": "------------"
+        "value": "iii"
       },
       {
         "label": "lang_ijo",
-        "value": "ijo",
-        "group": "------------"
+        "value": "ijo"
       },
       {
         "label": "lang_iku",
-        "value": "iku",
-        "group": "------------"
+        "value": "iku"
       },
       {
         "label": "lang_ile",
-        "value": "ile",
-        "group": "------------"
+        "value": "ile"
       },
       {
         "label": "lang_ilo",
-        "value": "ilo",
-        "group": "------------"
+        "value": "ilo"
       },
       {
         "label": "lang_ina",
-        "value": "ina",
-        "group": "------------"
+        "value": "ina"
       },
       {
         "label": "lang_inc",
-        "value": "inc",
-        "group": "------------"
+        "value": "inc"
       },
       {
         "label": "lang_ind",
-        "value": "ind",
-        "group": "------------"
+        "value": "ind"
       },
       {
         "label": "lang_ine",
-        "value": "ine",
-        "group": "------------"
+        "value": "ine"
       },
       {
         "label": "lang_inh",
-        "value": "inh",
-        "group": "------------"
+        "value": "inh"
       },
       {
         "label": "lang_ipk",
-        "value": "ipk",
-        "group": "------------"
+        "value": "ipk"
       },
       {
         "label": "lang_ira",
-        "value": "ira",
-        "group": "------------"
+        "value": "ira"
       },
       {
         "label": "lang_iro",
-        "value": "iro",
-        "group": "------------"
+        "value": "iro"
       },
       {
         "label": "lang_ita",
         "value": "ita",
-        "group": "------------"
+        "preferred": true
       },
       {
         "label": "lang_jav",
-        "value": "jav",
-        "group": "------------"
+        "value": "jav"
       },
       {
         "label": "lang_jbo",
-        "value": "jbo",
-        "group": "------------"
+        "value": "jbo"
       },
       {
         "label": "lang_jpn",
-        "value": "jpn",
-        "group": "------------"
+        "value": "jpn"
       },
       {
         "label": "lang_jpr",
-        "value": "jpr",
-        "group": "------------"
+        "value": "jpr"
       },
       {
         "label": "lang_jrb",
-        "value": "jrb",
-        "group": "------------"
+        "value": "jrb"
       },
       {
         "label": "lang_kaa",
-        "value": "kaa",
-        "group": "------------"
+        "value": "kaa"
       },
       {
         "label": "lang_kab",
-        "value": "kab",
-        "group": "------------"
+        "value": "kab"
       },
       {
         "label": "lang_kac",
-        "value": "kac",
-        "group": "------------"
+        "value": "kac"
       },
       {
         "label": "lang_kal",
-        "value": "kal",
-        "group": "------------"
+        "value": "kal"
       },
       {
         "label": "lang_kam",
-        "value": "kam",
-        "group": "------------"
+        "value": "kam"
       },
       {
         "label": "lang_kan",
-        "value": "kan",
-        "group": "------------"
+        "value": "kan"
       },
       {
         "label": "lang_kar",
-        "value": "kar",
-        "group": "------------"
+        "value": "kar"
       },
       {
         "label": "lang_kas",
-        "value": "kas",
-        "group": "------------"
+        "value": "kas"
       },
       {
         "label": "lang_kau",
-        "value": "kau",
-        "group": "------------"
+        "value": "kau"
       },
       {
         "label": "lang_kaw",
-        "value": "kaw",
-        "group": "------------"
+        "value": "kaw"
       },
       {
         "label": "lang_kaz",
-        "value": "kaz",
-        "group": "------------"
+        "value": "kaz"
       },
       {
         "label": "lang_kbd",
-        "value": "kbd",
-        "group": "------------"
+        "value": "kbd"
       },
       {
         "label": "lang_kha",
-        "value": "kha",
-        "group": "------------"
+        "value": "kha"
       },
       {
         "label": "lang_khi",
-        "value": "khi",
-        "group": "------------"
+        "value": "khi"
       },
       {
         "label": "lang_khm",
-        "value": "khm",
-        "group": "------------"
+        "value": "khm"
       },
       {
         "label": "lang_kho",
-        "value": "kho",
-        "group": "------------"
+        "value": "kho"
       },
       {
         "label": "lang_kik",
-        "value": "kik",
-        "group": "------------"
+        "value": "kik"
       },
       {
         "label": "lang_kin",
-        "value": "kin",
-        "group": "------------"
+        "value": "kin"
       },
       {
         "label": "lang_kir",
-        "value": "kir",
-        "group": "------------"
+        "value": "kir"
       },
       {
         "label": "lang_kmb",
-        "value": "kmb",
-        "group": "------------"
+        "value": "kmb"
       },
       {
         "label": "lang_kok",
-        "value": "kok",
-        "group": "------------"
+        "value": "kok"
       },
       {
         "label": "lang_kom",
-        "value": "kom",
-        "group": "------------"
+        "value": "kom"
       },
       {
         "label": "lang_kon",
-        "value": "kon",
-        "group": "------------"
+        "value": "kon"
       },
       {
         "label": "lang_kor",
-        "value": "kor",
-        "group": "------------"
+        "value": "kor"
       },
       {
         "label": "lang_kos",
-        "value": "kos",
-        "group": "------------"
+        "value": "kos"
       },
       {
         "label": "lang_kpe",
-        "value": "kpe",
-        "group": "------------"
+        "value": "kpe"
       },
       {
         "label": "lang_krc",
-        "value": "krc",
-        "group": "------------"
+        "value": "krc"
       },
       {
         "label": "lang_krl",
-        "value": "krl",
-        "group": "------------"
+        "value": "krl"
       },
       {
         "label": "lang_kro",
-        "value": "kro",
-        "group": "------------"
+        "value": "kro"
       },
       {
         "label": "lang_kru",
-        "value": "kru",
-        "group": "------------"
+        "value": "kru"
       },
       {
         "label": "lang_kua",
-        "value": "kua",
-        "group": "------------"
+        "value": "kua"
       },
       {
         "label": "lang_kum",
-        "value": "kum",
-        "group": "------------"
+        "value": "kum"
       },
       {
         "label": "lang_kur",
-        "value": "kur",
-        "group": "------------"
+        "value": "kur"
       },
       {
         "label": "lang_kut",
-        "value": "kut",
-        "group": "------------"
+        "value": "kut"
       },
       {
         "label": "lang_lad",
-        "value": "lad",
-        "group": "------------"
+        "value": "lad"
       },
       {
         "label": "lang_lah",
-        "value": "lah",
-        "group": "------------"
+        "value": "lah"
       },
       {
         "label": "lang_lam",
-        "value": "lam",
-        "group": "------------"
+        "value": "lam"
       },
       {
         "label": "lang_lao",
-        "value": "lao",
-        "group": "------------"
+        "value": "lao"
       },
       {
         "label": "lang_lat",
-        "value": "lat",
-        "group": "------------"
+        "value": "lat"
       },
       {
         "label": "lang_lav",
-        "value": "lav",
-        "group": "------------"
+        "value": "lav"
       },
       {
         "label": "lang_lez",
-        "value": "lez",
-        "group": "------------"
+        "value": "lez"
       },
       {
         "label": "lang_lim",
-        "value": "lim",
-        "group": "------------"
+        "value": "lim"
       },
       {
         "label": "lang_lin",
-        "value": "lin",
-        "group": "------------"
+        "value": "lin"
       },
       {
         "label": "lang_lit",
-        "value": "lit",
-        "group": "------------"
+        "value": "lit"
       },
       {
         "label": "lang_lol",
-        "value": "lol",
-        "group": "------------"
+        "value": "lol"
       },
       {
         "label": "lang_loz",
-        "value": "loz",
-        "group": "------------"
+        "value": "loz"
       },
       {
         "label": "lang_ltz",
-        "value": "ltz",
-        "group": "------------"
+        "value": "ltz"
       },
       {
         "label": "lang_lua",
-        "value": "lua",
-        "group": "------------"
+        "value": "lua"
       },
       {
         "label": "lang_lub",
-        "value": "lub",
-        "group": "------------"
+        "value": "lub"
       },
       {
         "label": "lang_lug",
-        "value": "lug",
-        "group": "------------"
+        "value": "lug"
       },
       {
         "label": "lang_lui",
-        "value": "lui",
-        "group": "------------"
+        "value": "lui"
       },
       {
         "label": "lang_lun",
-        "value": "lun",
-        "group": "------------"
+        "value": "lun"
       },
       {
         "label": "lang_luo",
-        "value": "luo",
-        "group": "------------"
+        "value": "luo"
       },
       {
         "label": "lang_lus",
-        "value": "lus",
-        "group": "------------"
+        "value": "lus"
       },
       {
         "label": "lang_mac",
-        "value": "mac",
-        "group": "------------"
+        "value": "mac"
       },
       {
         "label": "lang_mad",
-        "value": "mad",
-        "group": "------------"
+        "value": "mad"
       },
       {
         "label": "lang_mag",
-        "value": "mag",
-        "group": "------------"
+        "value": "mag"
       },
       {
         "label": "lang_mah",
-        "value": "mah",
-        "group": "------------"
+        "value": "mah"
       },
       {
         "label": "lang_mai",
-        "value": "mai",
-        "group": "------------"
+        "value": "mai"
       },
       {
         "label": "lang_mak",
-        "value": "mak",
-        "group": "------------"
+        "value": "mak"
       },
       {
         "label": "lang_mal",
-        "value": "mal",
-        "group": "------------"
+        "value": "mal"
       },
       {
         "label": "lang_man",
-        "value": "man",
-        "group": "------------"
+        "value": "man"
       },
       {
         "label": "lang_mao",
-        "value": "mao",
-        "group": "------------"
+        "value": "mao"
       },
       {
         "label": "lang_map",
-        "value": "map",
-        "group": "------------"
+        "value": "map"
       },
       {
         "label": "lang_mar",
-        "value": "mar",
-        "group": "------------"
+        "value": "mar"
       },
       {
         "label": "lang_mas",
-        "value": "mas",
-        "group": "------------"
+        "value": "mas"
       },
       {
         "label": "lang_may",
-        "value": "may",
-        "group": "------------"
+        "value": "may"
       },
       {
         "label": "lang_mdf",
-        "value": "mdf",
-        "group": "------------"
+        "value": "mdf"
       },
       {
         "label": "lang_mdr",
-        "value": "mdr",
-        "group": "------------"
+        "value": "mdr"
       },
       {
         "label": "lang_men",
-        "value": "men",
-        "group": "------------"
+        "value": "men"
       },
       {
         "label": "lang_mga",
-        "value": "mga",
-        "group": "------------"
+        "value": "mga"
       },
       {
         "label": "lang_mic",
-        "value": "mic",
-        "group": "------------"
+        "value": "mic"
       },
       {
         "label": "lang_min",
-        "value": "min",
-        "group": "------------"
+        "value": "min"
       },
       {
         "label": "lang_mis",
-        "value": "mis",
-        "group": "------------"
+        "value": "mis"
       },
       {
         "label": "lang_mkh",
-        "value": "mkh",
-        "group": "------------"
+        "value": "mkh"
       },
       {
         "label": "lang_mlg",
-        "value": "mlg",
-        "group": "------------"
+        "value": "mlg"
       },
       {
         "label": "lang_mlt",
-        "value": "mlt",
-        "group": "------------"
+        "value": "mlt"
       },
       {
         "label": "lang_mnc",
-        "value": "mnc",
-        "group": "------------"
+        "value": "mnc"
       },
       {
         "label": "lang_mni",
-        "value": "mni",
-        "group": "------------"
+        "value": "mni"
       },
       {
         "label": "lang_mno",
-        "value": "mno",
-        "group": "------------"
+        "value": "mno"
       },
       {
         "label": "lang_moh",
-        "value": "moh",
-        "group": "------------"
+        "value": "moh"
       },
       {
         "label": "lang_mon",
-        "value": "mon",
-        "group": "------------"
+        "value": "mon"
       },
       {
         "label": "lang_mos",
-        "value": "mos",
-        "group": "------------"
+        "value": "mos"
       },
       {
         "label": "lang_mul",
-        "value": "mul",
-        "group": "------------"
+        "value": "mul"
       },
       {
         "label": "lang_mun",
-        "value": "mun",
-        "group": "------------"
+        "value": "mun"
       },
       {
         "label": "lang_mus",
-        "value": "mus",
-        "group": "------------"
+        "value": "mus"
       },
       {
         "label": "lang_mwl",
-        "value": "mwl",
-        "group": "------------"
+        "value": "mwl"
       },
       {
         "label": "lang_mwr",
-        "value": "mwr",
-        "group": "------------"
+        "value": "mwr"
       },
       {
         "label": "lang_myn",
-        "value": "myn",
-        "group": "------------"
+        "value": "myn"
       },
       {
         "label": "lang_myv",
-        "value": "myv",
-        "group": "------------"
+        "value": "myv"
       },
       {
         "label": "lang_nah",
-        "value": "nah",
-        "group": "------------"
+        "value": "nah"
       },
       {
         "label": "lang_nai",
-        "value": "nai",
-        "group": "------------"
+        "value": "nai"
       },
       {
         "label": "lang_nap",
-        "value": "nap",
-        "group": "------------"
+        "value": "nap"
       },
       {
         "label": "lang_nau",
-        "value": "nau",
-        "group": "------------"
+        "value": "nau"
       },
       {
         "label": "lang_nav",
-        "value": "nav",
-        "group": "------------"
+        "value": "nav"
       },
       {
         "label": "lang_nbl",
-        "value": "nbl",
-        "group": "------------"
+        "value": "nbl"
       },
       {
         "label": "lang_nde",
-        "value": "nde",
-        "group": "------------"
+        "value": "nde"
       },
       {
         "label": "lang_ndo",
-        "value": "ndo",
-        "group": "------------"
+        "value": "ndo"
       },
       {
         "label": "lang_nds",
-        "value": "nds",
-        "group": "------------"
+        "value": "nds"
       },
       {
         "label": "lang_nep",
-        "value": "nep",
-        "group": "------------"
+        "value": "nep"
       },
       {
         "label": "lang_new",
-        "value": "new",
-        "group": "------------"
+        "value": "new"
       },
       {
         "label": "lang_nia",
-        "value": "nia",
-        "group": "------------"
+        "value": "nia"
       },
       {
         "label": "lang_nic",
-        "value": "nic",
-        "group": "------------"
+        "value": "nic"
       },
       {
         "label": "lang_niu",
-        "value": "niu",
-        "group": "------------"
+        "value": "niu"
       },
       {
         "label": "lang_nno",
-        "value": "nno",
-        "group": "------------"
+        "value": "nno"
       },
       {
         "label": "lang_nob",
-        "value": "nob",
-        "group": "------------"
+        "value": "nob"
       },
       {
         "label": "lang_nog",
-        "value": "nog",
-        "group": "------------"
+        "value": "nog"
       },
       {
         "label": "lang_non",
-        "value": "non",
-        "group": "------------"
+        "value": "non"
       },
       {
         "label": "lang_nor",
-        "value": "nor",
-        "group": "------------"
+        "value": "nor"
       },
       {
         "label": "lang_nqo",
-        "value": "nqo",
-        "group": "------------"
+        "value": "nqo"
       },
       {
         "label": "lang_nso",
-        "value": "nso",
-        "group": "------------"
+        "value": "nso"
       },
       {
         "label": "lang_nub",
-        "value": "nub",
-        "group": "------------"
+        "value": "nub"
       },
       {
         "label": "lang_nwc",
-        "value": "nwc",
-        "group": "------------"
+        "value": "nwc"
       },
       {
         "label": "lang_nya",
-        "value": "nya",
-        "group": "------------"
+        "value": "nya"
       },
       {
         "label": "lang_nym",
-        "value": "nym",
-        "group": "------------"
+        "value": "nym"
       },
       {
         "label": "lang_nyn",
-        "value": "nyn",
-        "group": "------------"
+        "value": "nyn"
       },
       {
         "label": "lang_nyo",
-        "value": "nyo",
-        "group": "------------"
+        "value": "nyo"
       },
       {
         "label": "lang_nzi",
-        "value": "nzi",
-        "group": "------------"
+        "value": "nzi"
       },
       {
         "label": "lang_oci",
-        "value": "oci",
-        "group": "------------"
+        "value": "oci"
       },
       {
         "label": "lang_oji",
-        "value": "oji",
-        "group": "------------"
+        "value": "oji"
       },
       {
         "label": "lang_ori",
-        "value": "ori",
-        "group": "------------"
+        "value": "ori"
       },
       {
         "label": "lang_orm",
-        "value": "orm",
-        "group": "------------"
+        "value": "orm"
       },
       {
         "label": "lang_osa",
-        "value": "osa",
-        "group": "------------"
+        "value": "osa"
       },
       {
         "label": "lang_oss",
-        "value": "oss",
-        "group": "------------"
+        "value": "oss"
       },
       {
         "label": "lang_ota",
-        "value": "ota",
-        "group": "------------"
+        "value": "ota"
       },
       {
         "label": "lang_oto",
-        "value": "oto",
-        "group": "------------"
+        "value": "oto"
       },
       {
         "label": "lang_paa",
-        "value": "paa",
-        "group": "------------"
+        "value": "paa"
       },
       {
         "label": "lang_pag",
-        "value": "pag",
-        "group": "------------"
+        "value": "pag"
       },
       {
         "label": "lang_pal",
-        "value": "pal",
-        "group": "------------"
+        "value": "pal"
       },
       {
         "label": "lang_pam",
-        "value": "pam",
-        "group": "------------"
+        "value": "pam"
       },
       {
         "label": "lang_pan",
-        "value": "pan",
-        "group": "------------"
+        "value": "pan"
       },
       {
         "label": "lang_pap",
-        "value": "pap",
-        "group": "------------"
+        "value": "pap"
       },
       {
         "label": "lang_pau",
-        "value": "pau",
-        "group": "------------"
+        "value": "pau"
       },
       {
         "label": "lang_peo",
-        "value": "peo",
-        "group": "------------"
+        "value": "peo"
       },
       {
         "label": "lang_per",
-        "value": "per",
-        "group": "------------"
+        "value": "per"
       },
       {
         "label": "lang_phi",
-        "value": "phi",
-        "group": "------------"
+        "value": "phi"
       },
       {
         "label": "lang_phn",
-        "value": "phn",
-        "group": "------------"
+        "value": "phn"
       },
       {
         "label": "lang_pli",
-        "value": "pli",
-        "group": "------------"
+        "value": "pli"
       },
       {
         "label": "lang_pol",
-        "value": "pol",
-        "group": "------------"
+        "value": "pol"
       },
       {
         "label": "lang_pon",
-        "value": "pon",
-        "group": "------------"
+        "value": "pon"
       },
       {
         "label": "lang_por",
-        "value": "por",
-        "group": "------------"
+        "value": "por"
       },
       {
         "label": "lang_pra",
-        "value": "pra",
-        "group": "------------"
+        "value": "pra"
       },
       {
         "label": "lang_pro",
-        "value": "pro",
-        "group": "------------"
+        "value": "pro"
       },
       {
         "label": "lang_pus",
-        "value": "pus",
-        "group": "------------"
+        "value": "pus"
       },
       {
         "label": "lang_que",
-        "value": "que",
-        "group": "------------"
+        "value": "que"
       },
       {
         "label": "lang_raj",
-        "value": "raj",
-        "group": "------------"
+        "value": "raj"
       },
       {
         "label": "lang_rap",
-        "value": "rap",
-        "group": "------------"
+        "value": "rap"
       },
       {
         "label": "lang_rar",
-        "value": "rar",
-        "group": "------------"
+        "value": "rar"
       },
       {
         "label": "lang_roa",
-        "value": "roa",
-        "group": "------------"
+        "value": "roa"
       },
       {
         "label": "lang_roh",
-        "value": "roh",
-        "group": "------------"
+        "value": "roh"
       },
       {
         "label": "lang_rom",
-        "value": "rom",
-        "group": "------------"
+        "value": "rom"
       },
       {
         "label": "lang_rum",
-        "value": "rum",
-        "group": "------------"
+        "value": "rum"
       },
       {
         "label": "lang_run",
-        "value": "run",
-        "group": "------------"
+        "value": "run"
       },
       {
         "label": "lang_rup",
-        "value": "rup",
-        "group": "------------"
+        "value": "rup"
       },
       {
         "label": "lang_rus",
-        "value": "rus",
-        "group": "------------"
+        "value": "rus"
       },
       {
         "label": "lang_sad",
-        "value": "sad",
-        "group": "------------"
+        "value": "sad"
       },
       {
         "label": "lang_sag",
-        "value": "sag",
-        "group": "------------"
+        "value": "sag"
       },
       {
         "label": "lang_sah",
-        "value": "sah",
-        "group": "------------"
+        "value": "sah"
       },
       {
         "label": "lang_sai",
-        "value": "sai",
-        "group": "------------"
+        "value": "sai"
       },
       {
         "label": "lang_sal",
-        "value": "sal",
-        "group": "------------"
+        "value": "sal"
       },
       {
         "label": "lang_sam",
-        "value": "sam",
-        "group": "------------"
+        "value": "sam"
       },
       {
         "label": "lang_san",
-        "value": "san",
-        "group": "------------"
+        "value": "san"
       },
       {
         "label": "lang_sas",
-        "value": "sas",
-        "group": "------------"
+        "value": "sas"
       },
       {
         "label": "lang_sat",
-        "value": "sat",
-        "group": "------------"
+        "value": "sat"
       },
       {
         "label": "lang_scn",
-        "value": "scn",
-        "group": "------------"
+        "value": "scn"
       },
       {
         "label": "lang_sco",
-        "value": "sco",
-        "group": "------------"
+        "value": "sco"
       },
       {
         "label": "lang_sel",
-        "value": "sel",
-        "group": "------------"
+        "value": "sel"
       },
       {
         "label": "lang_sem",
-        "value": "sem",
-        "group": "------------"
+        "value": "sem"
       },
       {
         "label": "lang_sga",
-        "value": "sga",
-        "group": "------------"
+        "value": "sga"
       },
       {
         "label": "lang_sgn",
-        "value": "sgn",
-        "group": "------------"
+        "value": "sgn"
       },
       {
         "label": "lang_shn",
-        "value": "shn",
-        "group": "------------"
+        "value": "shn"
       },
       {
         "label": "lang_sid",
-        "value": "sid",
-        "group": "------------"
+        "value": "sid"
       },
       {
         "label": "lang_sin",
-        "value": "sin",
-        "group": "------------"
+        "value": "sin"
       },
       {
         "label": "lang_sio",
-        "value": "sio",
-        "group": "------------"
+        "value": "sio"
       },
       {
         "label": "lang_sit",
-        "value": "sit",
-        "group": "------------"
+        "value": "sit"
       },
       {
         "label": "lang_sla",
-        "value": "sla",
-        "group": "------------"
+        "value": "sla"
       },
       {
         "label": "lang_slo",
-        "value": "slo",
-        "group": "------------"
+        "value": "slo"
       },
       {
         "label": "lang_slv",
-        "value": "slv",
-        "group": "------------"
+        "value": "slv"
       },
       {
         "label": "lang_sma",
-        "value": "sma",
-        "group": "------------"
+        "value": "sma"
       },
       {
         "label": "lang_sme",
-        "value": "sme",
-        "group": "------------"
+        "value": "sme"
       },
       {
         "label": "lang_smi",
-        "value": "smi",
-        "group": "------------"
+        "value": "smi"
       },
       {
         "label": "lang_smj",
-        "value": "smj",
-        "group": "------------"
+        "value": "smj"
       },
       {
         "label": "lang_smn",
-        "value": "smn",
-        "group": "------------"
+        "value": "smn"
       },
       {
         "label": "lang_smo",
-        "value": "smo",
-        "group": "------------"
+        "value": "smo"
       },
       {
         "label": "lang_sms",
-        "value": "sms",
-        "group": "------------"
+        "value": "sms"
       },
       {
         "label": "lang_sna",
-        "value": "sna",
-        "group": "------------"
+        "value": "sna"
       },
       {
         "label": "lang_snd",
-        "value": "snd",
-        "group": "------------"
+        "value": "snd"
       },
       {
         "label": "lang_snk",
-        "value": "snk",
-        "group": "------------"
+        "value": "snk"
       },
       {
         "label": "lang_sog",
-        "value": "sog",
-        "group": "------------"
+        "value": "sog"
       },
       {
         "label": "lang_som",
-        "value": "som",
-        "group": "------------"
+        "value": "som"
       },
       {
         "label": "lang_son",
-        "value": "son",
-        "group": "------------"
+        "value": "son"
       },
       {
         "label": "lang_sot",
-        "value": "sot",
-        "group": "------------"
+        "value": "sot"
       },
       {
         "label": "lang_spa",
-        "value": "spa",
-        "group": "------------"
+        "value": "spa"
       },
       {
         "label": "lang_srd",
-        "value": "srd",
-        "group": "------------"
+        "value": "srd"
       },
       {
         "label": "lang_srn",
-        "value": "srn",
-        "group": "------------"
+        "value": "srn"
       },
       {
         "label": "lang_srp",
-        "value": "srp",
-        "group": "------------"
+        "value": "srp"
       },
       {
         "label": "lang_srr",
-        "value": "srr",
-        "group": "------------"
+        "value": "srr"
       },
       {
         "label": "lang_ssa",
-        "value": "ssa",
-        "group": "------------"
+        "value": "ssa"
       },
       {
         "label": "lang_ssw",
-        "value": "ssw",
-        "group": "------------"
+        "value": "ssw"
       },
       {
         "label": "lang_suk",
-        "value": "suk",
-        "group": "------------"
+        "value": "suk"
       },
       {
         "label": "lang_sun",
-        "value": "sun",
-        "group": "------------"
+        "value": "sun"
       },
       {
         "label": "lang_sus",
-        "value": "sus",
-        "group": "------------"
+        "value": "sus"
       },
       {
         "label": "lang_sux",
-        "value": "sux",
-        "group": "------------"
+        "value": "sux"
       },
       {
         "label": "lang_swa",
-        "value": "swa",
-        "group": "------------"
+        "value": "swa"
       },
       {
         "label": "lang_swe",
-        "value": "swe",
-        "group": "------------"
+        "value": "swe"
       },
       {
         "label": "lang_syc",
-        "value": "syc",
-        "group": "------------"
+        "value": "syc"
       },
       {
         "label": "lang_syr",
-        "value": "syr",
-        "group": "------------"
+        "value": "syr"
       },
       {
         "label": "lang_tah",
-        "value": "tah",
-        "group": "------------"
+        "value": "tah"
       },
       {
         "label": "lang_tai",
-        "value": "tai",
-        "group": "------------"
+        "value": "tai"
       },
       {
         "label": "lang_tam",
-        "value": "tam",
-        "group": "------------"
+        "value": "tam"
       },
       {
         "label": "lang_tat",
-        "value": "tat",
-        "group": "------------"
+        "value": "tat"
       },
       {
         "label": "lang_tel",
-        "value": "tel",
-        "group": "------------"
+        "value": "tel"
       },
       {
         "label": "lang_tem",
-        "value": "tem",
-        "group": "------------"
+        "value": "tem"
       },
       {
         "label": "lang_ter",
-        "value": "ter",
-        "group": "------------"
+        "value": "ter"
       },
       {
         "label": "lang_tet",
-        "value": "tet",
-        "group": "------------"
+        "value": "tet"
       },
       {
         "label": "lang_tgk",
-        "value": "tgk",
-        "group": "------------"
+        "value": "tgk"
       },
       {
         "label": "lang_tgl",
-        "value": "tgl",
-        "group": "------------"
+        "value": "tgl"
       },
       {
         "label": "lang_tha",
-        "value": "tha",
-        "group": "------------"
+        "value": "tha"
       },
       {
         "label": "lang_tib",
-        "value": "tib",
-        "group": "------------"
+        "value": "tib"
       },
       {
         "label": "lang_tig",
-        "value": "tig",
-        "group": "------------"
+        "value": "tig"
       },
       {
         "label": "lang_tir",
-        "value": "tir",
-        "group": "------------"
+        "value": "tir"
       },
       {
         "label": "lang_tiv",
-        "value": "tiv",
-        "group": "------------"
+        "value": "tiv"
       },
       {
         "label": "lang_tkl",
-        "value": "tkl",
-        "group": "------------"
+        "value": "tkl"
       },
       {
         "label": "lang_tlh",
-        "value": "tlh",
-        "group": "------------"
+        "value": "tlh"
       },
       {
         "label": "lang_tli",
-        "value": "tli",
-        "group": "------------"
+        "value": "tli"
       },
       {
         "label": "lang_tmh",
-        "value": "tmh",
-        "group": "------------"
+        "value": "tmh"
       },
       {
         "label": "lang_tog",
-        "value": "tog",
-        "group": "------------"
+        "value": "tog"
       },
       {
         "label": "lang_ton",
-        "value": "ton",
-        "group": "------------"
+        "value": "ton"
       },
       {
         "label": "lang_tpi",
-        "value": "tpi",
-        "group": "------------"
+        "value": "tpi"
       },
       {
         "label": "lang_tsi",
-        "value": "tsi",
-        "group": "------------"
+        "value": "tsi"
       },
       {
         "label": "lang_tsn",
-        "value": "tsn",
-        "group": "------------"
+        "value": "tsn"
       },
       {
         "label": "lang_tso",
-        "value": "tso",
-        "group": "------------"
+        "value": "tso"
       },
       {
         "label": "lang_tuk",
-        "value": "tuk",
-        "group": "------------"
+        "value": "tuk"
       },
       {
         "label": "lang_tum",
-        "value": "tum",
-        "group": "------------"
+        "value": "tum"
       },
       {
         "label": "lang_tup",
-        "value": "tup",
-        "group": "------------"
+        "value": "tup"
       },
       {
         "label": "lang_tur",
-        "value": "tur",
-        "group": "------------"
+        "value": "tur"
       },
       {
         "label": "lang_tut",
-        "value": "tut",
-        "group": "------------"
+        "value": "tut"
       },
       {
         "label": "lang_tvl",
-        "value": "tvl",
-        "group": "------------"
+        "value": "tvl"
       },
       {
         "label": "lang_twi",
-        "value": "twi",
-        "group": "------------"
+        "value": "twi"
       },
       {
         "label": "lang_tyv",
-        "value": "tyv",
-        "group": "------------"
+        "value": "tyv"
       },
       {
         "label": "lang_udm",
-        "value": "udm",
-        "group": "------------"
+        "value": "udm"
       },
       {
         "label": "lang_uga",
-        "value": "uga",
-        "group": "------------"
+        "value": "uga"
       },
       {
         "label": "lang_uig",
-        "value": "uig",
-        "group": "------------"
+        "value": "uig"
       },
       {
         "label": "lang_ukr",
-        "value": "ukr",
-        "group": "------------"
+        "value": "ukr"
       },
       {
         "label": "lang_umb",
-        "value": "umb",
-        "group": "------------"
+        "value": "umb"
       },
       {
         "label": "lang_und",
-        "value": "und",
-        "group": "------------"
+        "value": "und"
       },
       {
         "label": "lang_urd",
-        "value": "urd",
-        "group": "------------"
+        "value": "urd"
       },
       {
         "label": "lang_uzb",
-        "value": "uzb",
-        "group": "------------"
+        "value": "uzb"
       },
       {
         "label": "lang_vai",
-        "value": "vai",
-        "group": "------------"
+        "value": "vai"
       },
       {
         "label": "lang_ven",
-        "value": "ven",
-        "group": "------------"
+        "value": "ven"
       },
       {
         "label": "lang_vie",
-        "value": "vie",
-        "group": "------------"
+        "value": "vie"
       },
       {
         "label": "lang_vol",
-        "value": "vol",
-        "group": "------------"
+        "value": "vol"
       },
       {
         "label": "lang_vot",
-        "value": "vot",
-        "group": "------------"
+        "value": "vot"
       },
       {
         "label": "lang_wak",
-        "value": "wak",
-        "group": "------------"
+        "value": "wak"
       },
       {
         "label": "lang_wal",
-        "value": "wal",
-        "group": "------------"
+        "value": "wal"
       },
       {
         "label": "lang_war",
-        "value": "war",
-        "group": "------------"
+        "value": "war"
       },
       {
         "label": "lang_was",
-        "value": "was",
-        "group": "------------"
+        "value": "was"
       },
       {
         "label": "lang_wel",
-        "value": "wel",
-        "group": "------------"
+        "value": "wel"
       },
       {
         "label": "lang_wen",
-        "value": "wen",
-        "group": "------------"
+        "value": "wen"
       },
       {
         "label": "lang_wln",
-        "value": "wln",
-        "group": "------------"
+        "value": "wln"
       },
       {
         "label": "lang_wol",
-        "value": "wol",
-        "group": "------------"
+        "value": "wol"
       },
       {
         "label": "lang_xal",
-        "value": "xal",
-        "group": "------------"
+        "value": "xal"
       },
       {
         "label": "lang_xho",
-        "value": "xho",
-        "group": "------------"
+        "value": "xho"
       },
       {
         "label": "lang_yao",
-        "value": "yao",
-        "group": "------------"
+        "value": "yao"
       },
       {
         "label": "lang_yap",
-        "value": "yap",
-        "group": "------------"
+        "value": "yap"
       },
       {
         "label": "lang_yid",
-        "value": "yid",
-        "group": "------------"
+        "value": "yid"
       },
       {
         "label": "lang_yor",
-        "value": "yor",
-        "group": "------------"
+        "value": "yor"
       },
       {
         "label": "lang_ypk",
-        "value": "ypk",
-        "group": "------------"
+        "value": "ypk"
       },
       {
         "label": "lang_zap",
-        "value": "zap",
-        "group": "------------"
+        "value": "zap"
       },
       {
         "label": "lang_zbl",
-        "value": "zbl",
-        "group": "------------"
+        "value": "zbl"
       },
       {
         "label": "lang_zen",
-        "value": "zen",
-        "group": "------------"
+        "value": "zen"
       },
       {
         "label": "lang_zha",
-        "value": "zha",
-        "group": "------------"
+        "value": "zha"
       },
       {
         "label": "lang_znd",
-        "value": "znd",
-        "group": "------------"
+        "value": "znd"
       },
       {
         "label": "lang_zul",
-        "value": "zul",
-        "group": "------------"
+        "value": "zul"
       },
       {
         "label": "lang_zun",
-        "value": "zun",
-        "group": "------------"
+        "value": "zun"
       },
       {
         "label": "lang_zxx",
-        "value": "zxx",
-        "group": "------------"
+        "value": "zxx"
       },
       {
         "label": "lang_zza",
-        "value": "zza",
-        "group": "------------"
+        "value": "zza"
       }
     ]
   }

--- a/sonar/common/jsonschemas/license-v1.0.0.json
+++ b/sonar/common/jsonschemas/license-v1.0.0.json
@@ -13,6 +13,11 @@
     "Not OA / Rights reserved"
   ],
   "form": {
+    "templateOptions": {
+      "wrappers": [
+        "card"
+      ]
+    },
     "options": [
       {
         "label": "CC0",

--- a/sonar/common/jsonschemas/type-v1.0.0.json
+++ b/sonar/common/jsonschemas/type-v1.0.0.json
@@ -51,307 +51,220 @@
     "coar:c_1843"
   ],
   "form": {
-    "type": "enum",
+    "templateOptions": {
+      "sort": false,
+      "wrappers": [
+        "card"
+      ]
+    },
     "options": [
       {
         "label": "document_type_coar:c_2f33",
-        "value": "coar:c_2f33"
-      },
-      {
-        "label": "document_type_coar:c_3248",
-        "value": "coar:c_3248"
-      },
-      {
-        "label": "document_type_coar:c_5794",
-        "value": "coar:c_5794"
-      },
-      {
-        "label": "document_type_coar:c_6501",
-        "value": "coar:c_6501"
-      },
-      {
-        "label": "document_type_coar:c_816b",
-        "value": "coar:c_816b"
-      },
-      {
-        "label": "document_type_coar:c_7a1f",
-        "value": "coar:c_7a1f"
-      },
-      {
-        "label": "document_type_coar:c_db06",
-        "value": "coar:c_db06"
-      },
-      {
-        "label": "document_type_coar:c_bdcc",
-        "value": "coar:c_bdcc"
-      },
-      {
-        "label": "document_type_coar:c_2f33",
         "value": "coar:c_2f33",
-        "group": "------------"
+        "preferred": true
       },
       {
         "label": "document_type_coar:c_3248",
         "value": "coar:c_3248",
-        "group": "------------"
+        "preferred": true
       },
       {
         "label": "document_type_coar:c_c94f",
         "value": "coar:c_c94f",
-        "group": "------------"
-      },
-      {
-        "label": "document_type_coar:c_5794",
-        "value": "coar:c_5794",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_18cp",
-        "value": "coar:c_18cp",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_6670",
-        "value": "coar:c_6670",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_18co",
-        "value": "coar:c_18co",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_f744",
-        "value": "coar:c_f744",
-        "group": "------------",
-        "level": 1
+        "children": [
+          {
+            "label": "document_type_coar:c_5794",
+            "value": "coar:c_5794",
+            "preferred": true
+          },
+          {
+            "label": "document_type_coar:c_18cp",
+            "value": "coar:c_18cp"
+          },
+          {
+            "label": "document_type_coar:c_6670",
+            "value": "coar:c_6670"
+          },
+          {
+            "label": "document_type_coar:c_18co",
+            "value": "coar:c_18co"
+          },
+          {
+            "label": "document_type_coar:c_f744",
+            "value": "coar:c_f744"
+          }
+        ]
       },
       {
         "label": "document_type_coar:c_ddb1",
-        "value": "coar:c_ddb1",
-        "group": "------------"
+        "value": "coar:c_ddb1"
       },
       {
         "label": "document_type_coar:c_3e5a",
         "value": "coar:c_3e5a",
-        "group": "------------"
-      },
-      {
-        "label": "document_type_coar:c_beb9",
-        "value": "coar:c_beb9",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_6501",
-        "value": "coar:c_6501",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_998f",
-        "value": "coar:c_998f",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_dcae04bc",
-        "value": "coar:c_dcae04bc",
-        "group": "------------",
-        "level": 1
+        "children": [
+          {
+            "label": "document_type_coar:c_beb9",
+            "value": "coar:c_beb9"
+          },
+          {
+            "label": "document_type_coar:c_6501",
+            "value": "coar:c_6501",
+            "preferred": true
+          },
+          {
+            "label": "document_type_coar:c_998f",
+            "value": "coar:c_998f"
+          },
+          {
+            "label": "document_type_coar:c_dcae04bc",
+            "value": "coar:c_dcae04bc"
+          }
+        ]
       },
       {
         "label": "document_type_coar:c_8544",
-        "value": "coar:c_8544",
-        "group": "------------"
+        "value": "coar:c_8544"
       },
       {
         "label": "document_type_non_textual_object",
         "value": "non_textual_object",
-        "group": "------------"
-      },
-      {
-        "label": "document_type_coar:c_8a7e",
-        "value": "coar:c_8a7e",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_ecc8",
-        "value": "coar:c_ecc8",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_12cc",
-        "value": "coar:c_12cc",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_18cc",
-        "value": "coar:c_18cc",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_18cw",
-        "value": "coar:c_18cw",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_5ce6",
-        "value": "coar:c_5ce6",
-        "group": "------------",
-        "level": 1
+        "children": [
+          {
+            "label": "document_type_coar:c_8a7e",
+            "value": "coar:c_8a7e"
+          },
+          {
+            "label": "document_type_coar:c_ecc8",
+            "value": "coar:c_ecc8"
+          },
+          {
+            "label": "document_type_coar:c_12cc",
+            "value": "coar:c_12cc"
+          },
+          {
+            "label": "document_type_coar:c_18cc",
+            "value": "coar:c_18cc"
+          },
+          {
+            "label": "document_type_coar:c_18cw",
+            "value": "coar:c_18cw"
+          },
+          {
+            "label": "document_type_coar:c_5ce6",
+            "value": "coar:c_5ce6"
+          }
+        ]
       },
       {
         "label": "document_type_coar:c_15cd",
-        "group": "------------",
         "value": "coar:c_15cd"
       },
       {
         "label": "document_type_coar:c_2659",
-        "group": "------------",
-        "value": "coar:c_2659"
-      },
-      {
-        "label": "document_type_coar:c_0640",
-        "value": "coar:c_0640",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_2cd9",
-        "value": "coar:c_2cd9",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_2fe3",
-        "value": "coar:c_2fe3",
-        "group": "------------",
-        "level": 1
+        "value": "coar:c_2659",
+        "children": [
+          {
+            "label": "document_type_coar:c_0640",
+            "value": "coar:c_0640"
+          },
+          {
+            "label": "document_type_coar:c_2cd9",
+            "value": "coar:c_2cd9"
+          },
+          {
+            "label": "document_type_coar:c_2fe3",
+            "value": "coar:c_2fe3"
+          }
+        ]
       },
       {
         "label": "document_type_coar:c_816b",
         "value": "coar:c_816b",
-        "group": "------------"
+        "preferred": true
       },
       {
         "label": "document_type_coar:c_93fc",
         "value": "coar:c_93fc",
-        "group": "------------"
-      },
-      {
-        "label": "document_type_coar:c_18ww",
-        "value": "coar:c_18ww",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_18wz",
-        "value": "coar:c_18wz",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_18wq",
-        "value": "coar:c_18wq",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_186u",
-        "value": "coar:c_186u",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_18op",
-        "value": "coar:c_18op",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_ba1f",
-        "value": "coar:c_ba1f",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_18hj",
-        "value": "coar:c_18hj",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_18ws",
-        "value": "coar:c_18ws",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_18gh",
-        "value": "coar:c_18gh",
-        "group": "------------",
-        "level": 1
+        "children": [
+          {
+            "label": "document_type_coar:c_18ww",
+            "value": "coar:c_18ww"
+          },
+          {
+            "label": "document_type_coar:c_18wz",
+            "value": "coar:c_18wz"
+          },
+          {
+            "label": "document_type_coar:c_18wq",
+            "value": "coar:c_18wq"
+          },
+          {
+            "label": "document_type_coar:c_186u",
+            "value": "coar:c_186u"
+          },
+          {
+            "label": "document_type_coar:c_18op",
+            "value": "coar:c_18op"
+          },
+          {
+            "label": "document_type_coar:c_ba1f",
+            "value": "coar:c_ba1f"
+          },
+          {
+            "label": "document_type_coar:c_18hj",
+            "value": "coar:c_18hj"
+          },
+          {
+            "label": "document_type_coar:c_18ws",
+            "value": "coar:c_18ws"
+          },
+          {
+            "label": "document_type_coar:c_18gh",
+            "value": "coar:c_18gh"
+          }
+        ]
       },
       {
         "label": "document_type_coar:c_46ec",
         "value": "coar:c_46ec",
-        "group": "------------"
-      },
-      {
-        "label": "document_type_coar:c_7a1f",
-        "value": "coar:c_7a1f",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_db06",
-        "value": "coar:c_db06",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_coar:c_bdcc",
-        "value": "coar:c_bdcc",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_habilitation_thesis",
-        "value": "habilitation_thesis",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_advanced_studies_thesis",
-        "value": "advanced_studies_thesis",
-        "group": "------------",
-        "level": 1
-      },
-      {
-        "label": "document_type_other",
-        "value": "other",
-        "group": "------------",
-        "level": 1
+        "children": [
+          {
+            "label": "document_type_coar:c_7a1f",
+            "value": "coar:c_7a1f",
+            "preferred": true
+          },
+          {
+            "label": "document_type_coar:c_db06",
+            "value": "coar:c_db06",
+            "preferred": true
+          },
+          {
+            "label": "document_type_coar:c_bdcc",
+            "value": "coar:c_bdcc",
+            "preferred": true
+          },
+          {
+            "label": "document_type_habilitation_thesis",
+            "value": "habilitation_thesis"
+          },
+          {
+            "label": "document_type_advanced_studies_thesis",
+            "value": "advanced_studies_thesis"
+          },
+          {
+            "label": "document_type_other",
+            "value": "other"
+          }
+        ]
       },
       {
         "label": "document_type_coar:c_8042",
-        "value": "coar:c_8042",
-        "group": "------------"
+        "value": "coar:c_8042"
       },
       {
         "label": "document_type_coar:c_1843",
-        "value": "coar:c_1843",
-        "group": "------------"
+        "value": "coar:c_1843"
       }
     ],
     "expressionProperties": {

--- a/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
+++ b/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
@@ -392,123 +392,110 @@
                   "pmid"
                 ],
                 "form": {
+                  "templateOptions": {
+                    "wrappers": [
+                      "card"
+                    ]
+                  },
                   "options": [
                     {
                       "label": "bf:Doi",
-                      "value": "bf:Doi"
+                      "value": "bf:Doi",
+                      "preferred": true
                     },
                     {
                       "label": "pmid",
-                      "value": "pmid"
+                      "value": "pmid",
+                      "preferred": true
                     },
                     {
                       "label": "bf:Isbn",
-                      "value": "bf:Isbn"
+                      "value": "bf:Isbn",
+                      "preferred": true
                     },
                     {
                       "label": "bf:AudioIssueNumber",
-                      "value": "bf:AudioIssueNumber",
-                      "group": "------------"
+                      "value": "bf:AudioIssueNumber"
                     },
                     {
                       "label": "bf:Ean",
-                      "value": "bf:Ean",
-                      "group": "------------"
+                      "value": "bf:Ean"
                     },
                     {
                       "label": "bf:Gtin14Number",
-                      "value": "bf:Gtin14Number",
-                      "group": "------------"
+                      "value": "bf:Gtin14Number"
                     },
                     {
                       "label": "bf:Identifier",
-                      "value": "bf:Identifier",
-                      "group": "------------"
+                      "value": "bf:Identifier"
                     },
                     {
                       "label": "bf:Isan",
-                      "value": "bf:Isan",
-                      "group": "------------"
+                      "value": "bf:Isan"
                     },
                     {
                       "label": "bf:Ismn",
-                      "value": "bf:Ismn",
-                      "group": "------------"
+                      "value": "bf:Ismn"
                     },
                     {
                       "label": "bf:Isrc",
-                      "value": "bf:Isrc",
-                      "group": "------------"
+                      "value": "bf:Isrc"
                     },
                     {
                       "label": "bf:Issn",
-                      "value": "bf:Issn",
-                      "group": "------------"
+                      "value": "bf:Issn"
                     },
                     {
                       "label": "bf:IssnL",
-                      "value": "bf:IssnL",
-                      "group": "------------"
+                      "value": "bf:IssnL"
                     },
                     {
                       "label": "bf:Local",
-                      "value": "bf:Local",
-                      "group": "------------"
+                      "value": "bf:Local"
                     },
                     {
                       "label": "bf:MatrixNumber",
-                      "value": "bf:MatrixNumber",
-                      "group": "------------"
+                      "value": "bf:MatrixNumber"
                     },
                     {
                       "label": "bf:MusicDistributorNumber",
-                      "value": "bf:MusicDistributorNumber",
-                      "group": "------------"
+                      "value": "bf:MusicDistributorNumber"
                     },
                     {
                       "label": "bf:MusicPlate",
-                      "value": "bf:MusicPlate",
-                      "group": "------------"
+                      "value": "bf:MusicPlate"
                     },
                     {
                       "label": "bf:MusicPublisherNumber",
-                      "value": "bf:MusicPublisherNumber",
-                      "group": "------------"
+                      "value": "bf:MusicPublisherNumber"
                     },
                     {
                       "label": "bf:PublisherNumber",
-                      "value": "bf:PublisherNumber",
-                      "group": "------------"
+                      "value": "bf:PublisherNumber"
                     },
                     {
                       "label": "bf:Upc",
-                      "value": "bf:Upc",
-                      "group": "------------"
+                      "value": "bf:Upc"
                     },
                     {
                       "label": "bf:Urn",
-                      "value": "bf:Urn",
-                      "group": "------------"
+                      "value": "bf:Urn"
                     },
                     {
                       "label": "bf:VideoRecordingNumber",
-                      "value": "bf:VideoRecordingNumber",
-                      "group": "------------"
+                      "value": "bf:VideoRecordingNumber"
                     },
                     {
                       "label": "uri",
-                      "value": "uri",
-                      "group": "------------"
+                      "value": "uri"
                     },
                     {
                       "label": "bf:ReportNumber",
-                      "value": "bf:ReportNumber",
-                      "group": "------------"
+                      "value": "bf:ReportNumber"
                     },
                     {
                       "label": "bf:Strn",
-                      "value": "bf:Strn",
-                      "group": "------------"
+                      "value": "bf:Strn"
                     }
                   ]
                 }
@@ -860,6 +847,11 @@
               "ctb"
             ],
             "form": {
+              "templateOptions": {
+                "wrappers": [
+                  "card"
+                ]
+              },
               "options": [
                 {
                   "label": "contribution_role_cre",
@@ -996,6 +988,11 @@
                         "coinvestigator"
                       ],
                       "form": {
+                        "templateOptions": {
+                          "wrappers": [
+                            "card"
+                          ]
+                        },
                         "options": [
                           {
                             "label": "investigator",

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -1021,16 +1021,15 @@
               "type": {
                 "title": "Type",
                 "type": "string",
-                "enum": [
-                  "bf:ClassificationUdc"
-                ],
+                "readOnly": true,
+                "const": "bf:ClassificationUdc",
+                "default": "bf:ClassificationUdc",
                 "form": {
-                  "options": [
-                    {
-                      "label": "bf:ClassificationUdc",
-                      "value": "bf:ClassificationUdc"
-                    }
-                  ]
+                  "templateOptions": {
+                    "wrappers": [
+                      "hide"
+                    ]
+                  }
                 }
               },
               "classificationPortion": {
@@ -1055,16 +1054,12 @@
                 "readOnly": true,
                 "const": "bf:ClassificationDdc",
                 "default": "bf:ClassificationDdc",
-                "enum": [
-                  "bf:ClassificationDdc"
-                ],
                 "form": {
-                  "options": [
-                    {
-                      "label": "bf:ClassificationDdc",
-                      "value": "bf:ClassificationDdc"
-                    }
-                  ]
+                  "templateOptions": {
+                    "wrappers": [
+                      "hide"
+                    ]
+                  }
                 }
               },
               "classificationPortion": {

--- a/sonar/theme/views.py
+++ b/sonar/theme/views.py
@@ -228,7 +228,7 @@ def schemas(record_type):
             if 'isShared' in schema.get('propertiesOrder', []):
                 schema['propertiesOrder'].remove('isShared')
 
-        return jsonify({'schema': prepare_schema(schema)})
+        return jsonify({'schema': schema})
     except JSONSchemaNotFound:
         abort(404)
 
@@ -261,36 +261,6 @@ def record_image_url(record, key=None):
                 return image_url(file)
 
     return None
-
-
-def prepare_schema(schema):
-    """Prepare schema before sending it."""
-    def hierarchize_form_options(schema):
-        """Hierarchize form options."""
-        if schema.get('properties'):
-            for key, value in schema['properties'].items():
-                if value.get('form', {}).get('options'):
-                    for option in value['form']['options']:
-                        if option.get('level'):
-                            option['label'] = "{spaces} {label}".format(
-                                spaces='-' * 2 * option['level'],
-                                label=option['label'])
-
-                if value.get('type') == 'array' and value['items'][
-                        'type'] == 'object':
-                    hierarchize_form_options(value['items'])
-
-                if value.get('type') == 'object':
-                    hierarchize_form_options(value)
-
-        for of_field in ['oneOf', 'anyOf', 'allOf', 'not']:
-            if schema.get(of_field):
-                for field in schema[of_field]:
-                    hierarchize_form_options(field)
-
-    hierarchize_form_options(schema)
-
-    return schema
 
 
 @blueprint.app_template_filter()


### PR DESCRIPTION
* Configures options tree for document type.
* Configures options tree for classification.
* Disables the options hierarchization before sending schema as it is done in frontend now.
* Closes #530.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>