### PR TITLE
view: change the view routes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,8 +21,6 @@ from __future__ import print_function
 
 import os
 
-import sphinx.environment
-
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/poetry.lock
+++ b/poetry.lock
@@ -89,6 +89,17 @@ tests = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six
 tests_no_zope = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
 
 [[package]]
+category = "dev"
+description = "Removes unused imports and unused variables"
+name = "autoflake"
+optional = false
+python-versions = "*"
+version = "1.4"
+
+[package.dependencies]
+pyflakes = ">=1.1.0"
+
+[[package]]
 category = "main"
 description = "Tools to handle automatic semantic versioning in python"
 name = "autosemver"
@@ -1067,6 +1078,7 @@ WTForms = "*"
 reference = "647dd97880e2105948071b041286f318bf2628f7"
 type = "git"
 url = "https://github.com/rero/flask-wiki.git"
+
 [[package]]
 category = "main"
 description = "Simple integration of Flask and WTForms."
@@ -1807,6 +1819,7 @@ tests = ["check-manifest (>=0.35)", "coverage (>=4.3.4)", "isort (4.2.2)", "mock
 reference = "fe55e095a8e78b36cfad875f752f2facc2908bae"
 type = "git"
 url = "https://github.com/inveniosoftware/invenio-oaiharvester.git"
+
 [[package]]
 category = "main"
 description = "Invenio module that implements OAI-PMH server."
@@ -3053,6 +3066,14 @@ version = "6.0.0"
 snowballstemmer = "*"
 
 [[package]]
+category = "dev"
+description = "passive checker of Python programs"
+name = "pyflakes"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.3.1"
+
+[[package]]
 category = "main"
 description = "Pygments is a syntax highlighting package written in Python."
 name = "pygments"
@@ -3790,7 +3811,7 @@ test = ["pytest"]
 [[package]]
 category = "main"
 description = "Backported and Experimental Type Hints for Python 3.5+"
-marker = "python_version < \"3.8\" or python_version >= \"3.7\" and python_version < \"3.8\""
+marker = "python_version < \"3.8\" or python_version >= \"3.7\" and python_version < \"3.8\" or python_version >= \"3.7\" and python_version < \"3.8\" and (python_version < \"3.8\" or python_version >= \"3.7\" and python_version < \"3.8\")"
 name = "typing-extensions"
 optional = false
 python-versions = "*"
@@ -4037,7 +4058,7 @@ version = "0.12.0"
 [[package]]
 category = "main"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-marker = "python_version < \"3.8\" or python_version >= \"3.7\" and python_version < \"3.8\""
+marker = "python_version < \"3.8\" or python_version >= \"3.7\" and python_version < \"3.8\" or python_version >= \"3.7\" and python_version < \"3.8\" and (python_version < \"3.8\" or python_version >= \"3.7\" and python_version < \"3.8\")"
 name = "zipp"
 optional = false
 python-versions = ">=3.6"
@@ -4048,7 +4069,7 @@ docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "9dde16f4603dc5d0940797e5e701a67e4236099b5e0174f74cddb7277e86901f"
+content-hash = "580ac6c66221541b5bea041440e62a7695bfa5f72c946d38aa4871d99cda51bc"
 lock-version = "1.0"
 python-versions = ">= 3.6, <3.8"
 
@@ -4084,6 +4105,9 @@ atomicwrites = [
 attrs = [
     {file = "attrs-20.3.0-py2.py3-none-any.whl", hash = "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6"},
     {file = "attrs-20.3.0.tar.gz", hash = "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"},
+]
+autoflake = [
+    {file = "autoflake-1.4.tar.gz", hash = "sha256:61a353012cff6ab94ca062823d1fb2f692c4acda51c76ff83a8d77915fba51ea"},
 ]
 autosemver = [
     {file = "autosemver-0.5.5.tar.gz", hash = "sha256:0af1e8a9c3604545c067311f1c26403e8f0d60b5d9561c0217e14eee21c98b02"},
@@ -4238,6 +4262,7 @@ click-repl = [
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 counter-robots = [
     {file = "counter-robots-2018.6.tar.gz", hash = "sha256:6c231604a4bfa9b93d47d484e7e38219f231bdd15436561b0f4a2afc8a9f5b42"},
@@ -4787,6 +4812,7 @@ lxml = [
     {file = "lxml-4.6.3.tar.gz", hash = "sha256:39b78571b3b30645ac77b95f7c69d1bffc4cf8c3b157c435a34da72e78c82468"},
 ]
 mako = [
+    {file = "Mako-1.1.4-py2.py3-none-any.whl", hash = "sha256:aea166356da44b9b830c8023cd9b557fa856bd8b4035d6de771ca027dfc5cc6e"},
     {file = "Mako-1.1.4.tar.gz", hash = "sha256:17831f0b7087c313c0ffae2bcbbd3c1d5ba9eeac9c38f2eb7b50e8c99fe9d5ab"},
 ]
 markdown = [
@@ -4816,20 +4842,39 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp35-cp35m-win32.whl", hash = "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1"},
     {file = "MarkupSafe-1.1.1-cp35-cp35m-win_amd64.whl", hash = "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d53bc011414228441014aa71dbec320c66468c1030aae3a6e29778a3382d96e5"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:3b8a6499709d29c2e2399569d96719a1b21dcd94410a586a18526b143ec8470f"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:84dee80c15f1b560d55bcfe6d47b27d070b4681c699c572af2e3c7cc90a3b8e0"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:b1dba4527182c95a0db8b6060cc98ac49b9e2f5e64320e2b56e47cb2831978c7"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-win32.whl", hash = "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:bf5aa3cbcfdf57fa2ee9cd1822c862ef23037f5c832ad09cfea57fa846dec193"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:6fffc775d90dcc9aed1b89219549b329a9250d918fd0b8fa8d93d154918422e1"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:a6a744282b7718a2a62d2ed9d993cad6f5f585605ad352c11de459f4108df0a1"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:195d7d2c4fbb0ee8139a6cf67194f3973a6b3042d742ebe0a9ed36d8b6f0c07f"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:acf08ac40292838b3cbbb06cfe9b2cb9ec78fce8baca31ddb87aaac2e2dc3bc2"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d9be0ba6c527163cbed5e0857c451fcd092ce83947944d6c14bc95441203f032"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:caabedc8323f1e93231b52fc32bdcde6db817623d33e100708d9a68e1f53b26b"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d73a845f227b0bfe8a7455ee623525ee656a9e2e749e4742706d80a6065d5e2c"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:98bae9582248d6cf62321dcb52aaf5d9adf0bad3b40582925ef7c7f0ed85fceb"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:2beec1e0de6924ea551859edb9e7679da6e4870d32cb766240ce17e0a0ba2014"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:7fed13866cf14bba33e7176717346713881f56d9d2bcebab207f7a036f41b850"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:6f1e273a344928347c1290119b493a1f0303c52f5a5eae5f16d74f48c15d4a85"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:feb7b34d6325451ef96bc0e36e1a6c0c1c64bc1fbec4b854f4529e51887b1621"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-win32.whl", hash = "sha256:22c178a091fc6630d0d045bdb5992d2dfe14e3259760e713c490da5323866c39"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7d644ddb4dbd407d31ffb699f1d140bc35478da613b441c582aeb7c43838dd8"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
 marshmallow = [
@@ -5024,6 +5069,8 @@ psycopg2-binary = [
     {file = "psycopg2_binary-2.8.6-cp39-cp39-macosx_10_9_x86_64.macosx_10_9_intel.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:89705f45ce07b2dfa806ee84439ec67c5d9a0ef20154e0e475e2b2ed392a5b83"},
     {file = "psycopg2_binary-2.8.6-cp39-cp39-manylinux1_i686.whl", hash = "sha256:42ec1035841b389e8cc3692277a0bd81cdfe0b65d575a2c8862cec7a80e62e52"},
     {file = "psycopg2_binary-2.8.6-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7312e931b90fe14f925729cde58022f5d034241918a5c4f9797cac62f6b3a9dd"},
+    {file = "psycopg2_binary-2.8.6-cp39-cp39-win32.whl", hash = "sha256:6422f2ff0919fd720195f64ffd8f924c1395d30f9a495f31e2392c2efafb5056"},
+    {file = "psycopg2_binary-2.8.6-cp39-cp39-win_amd64.whl", hash = "sha256:15978a1fbd225583dd8cdaf37e67ccc278b5abecb4caf6b2d6b8e2b948e953f6"},
 ]
 ptyprocess = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
@@ -5047,6 +5094,10 @@ pycparser = [
 pydocstyle = [
     {file = "pydocstyle-6.0.0-py3-none-any.whl", hash = "sha256:d4449cf16d7e6709f63192146706933c7a334af7c0f083904799ccb851c50f6d"},
     {file = "pydocstyle-6.0.0.tar.gz", hash = "sha256:164befb520d851dbcf0e029681b91f4f599c62c5cd8933fd54b1bfbd50e89e1f"},
+]
+pyflakes = [
+    {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
+    {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
 ]
 pygments = [
     {file = "Pygments-2.8.1-py3-none-any.whl", hash = "sha256:534ef71d539ae97d4c3a4cf7d6f110f214b0e687e92f9cb9d2a3b0d3101289c8"},
@@ -5150,18 +5201,26 @@ pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
     {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
     {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
     {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
     {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
     {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
     {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
     {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
     {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6"},
     {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
     {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ mock = ">=2.0.0"
 pytest-invenio = ">=1.4.1,<1.5.0"
 safety = ">=1.8"
 appnope = { version = "*", optional = true }
+autoflake = "^1.4"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/scripts/test
+++ b/scripts/test
@@ -32,5 +32,6 @@ fi
 safety check -i 39462 && \
 pydocstyle sonar tests docs && \
 isort --check-only --diff "${SCRIPT_PATH}/.." && \
+autoflake  -rc --remove-all-unused-imports --ignore-init-module-imports . && \
 sphinx-build -qnNW docs docs/_build/html && \
 pytest

--- a/sonar/config.py
+++ b/sonar/config.py
@@ -259,17 +259,27 @@ SECURITY_RESET_PASSWORD_TEMPLATE = 'sonar/accounts/reset_password.html'
 SECURITY_REGISTER_USER_TEMPLATE = 'sonar/accounts/signup.html'
 
 RECORDS_UI_ENDPOINTS = {
+    'doc': {
+        'pid_type': 'doc',
+        'route': '/<org_code:view>/documents/<pid_value>',
+        'view_imp': 'sonar.modules.documents.views:detail',
+        'record_class': 'sonar.modules.documents.api:DocumentRecord',
+        'template': 'documents/record.html',
+        'permission_factory_imp': 'sonar.modules.documents.permissions:only_public'
+    },
     'doc_previewer': {
         'pid_type': 'doc',
         'route': '/documents/<pid_value>/preview/<filename>',
         'view_imp': 'invenio_previewer.views:preview',
-        'record_class': 'sonar.modules.documents.api:DocumentRecord'
+        'record_class': 'sonar.modules.documents.api:DocumentRecord',
+        'permission_factory_imp': 'sonar.modules.documents.permissions:only_public'
     },
     'doc_files': {
         'pid_type': 'doc',
         'route': '/documents/<pid_value>/files/<filename>',
         'view_imp': 'invenio_records_files.utils:file_download_ui',
-        'record_class': 'invenio_records_files.api:Record'
+        'record_class': 'invenio_records_files.api:Record',
+        'permission_factory_imp': 'sonar.modules.documents.permissions:only_public'
     },
     'depo_previewer': {
         'pid_type': 'depo',
@@ -295,6 +305,13 @@ RECORDS_UI_ENDPOINTS = {
         'view_imp': 'invenio_records_files.utils:file_download_ui',
         'record_class': 'invenio_records_files.api:Record'
     },
+    'proj': {
+        'pid_type': 'proj',
+        'route': '/<org_code:view>/projects/<pid_value>',
+        'view_imp': 'sonar.resources.projects.views:detail',
+        'record_class': 'sonar.resources.projects.api:Record',
+        'template': 'sonar/projects/detail.html'
+    }
 }
 """Records UI for sonar."""
 

--- a/sonar/ext.py
+++ b/sonar/ext.py
@@ -20,7 +20,7 @@
 from __future__ import absolute_import, print_function
 
 import jinja2
-from flask import current_app
+from flask import current_app, render_template
 from flask_bootstrap import Bootstrap
 from flask_security import user_registered
 from flask_wiki import Wiki
@@ -41,6 +41,7 @@ from sonar.resources.projects.service import \
     RecordService as ProjectRecordService
 
 from . import config_sonar
+from .route_converters import OrganisationCodeConverter
 
 
 def utility_processor():
@@ -77,6 +78,7 @@ class Sonar():
         """Flask application initialization."""
         self.init_config(app)
         self.create_resources()
+        self.init_views(app)
 
         app.extensions['sonar'] = self
 
@@ -104,6 +106,20 @@ class Sonar():
         for k in dir(config_sonar):
             if k.startswith('SONAR_APP_'):
                 app.config.setdefault(k, getattr(config_sonar, k))
+
+    def init_views(self, app):
+        """Initialize the main flask views."""
+        app.url_map.converters['org_code'] = OrganisationCodeConverter
+
+        @app.route('/<org_code:view>')
+        def index(view):
+            """Homepage."""
+            return render_template('sonar/frontpage.html')
+
+        @app.template_filter()
+        def nl2br(string):
+            r"""Replace \n to <br>."""
+            return string.replace('\n', '<br>')
 
     def create_resources(self):
         """Create resources."""

--- a/sonar/modules/documents/cli/oaiharvester.py
+++ b/sonar/modules/documents/cli/oaiharvester.py
@@ -21,10 +21,9 @@ import json
 
 import click
 from click.exceptions import ClickException
-from flask import current_app
 from flask.cli import with_appcontext
 from invenio_db import db
-from invenio_oaiharvester.cli import harvest, oaiharvester
+from invenio_oaiharvester.cli import oaiharvester
 from invenio_oaiharvester.models import OAIHarvestConfig
 
 

--- a/sonar/modules/documents/dojson/rerodoc/model.py
+++ b/sonar/modules/documents/dojson/rerodoc/model.py
@@ -22,7 +22,6 @@ import re
 from dojson import utils
 from flask import current_app
 
-from sonar.modules.documents.api import DocumentRecord
 from sonar.modules.documents.dojson.rerodoc.overdo import Overdo
 from sonar.modules.organisations.api import OrganisationRecord
 from sonar.modules.utils import remove_trailing_punctuation

--- a/sonar/modules/documents/permissions.py
+++ b/sonar/modules/documents/permissions.py
@@ -112,3 +112,12 @@ class DocumentPermission(RecordPermission):
 
         # Same rules as read
         return cls.read(user, record)
+
+def only_public(record, *args, **kwargs):
+    """Allow access only for public tagged documents."""
+
+    def can(self):
+        if record.get('hiddenFromPublic'):
+            return False
+        return True
+    return type('OnlyPublicDocument', (), {'can': can})()

--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -186,7 +186,7 @@ along with this program. If not, see
           <ul class="list-unstyled mb-0">
             {% for project in record.projects %}
             <li class="p-0">
-              <a href="{{ url_for('documents.project_detail', pid_value=project.pid, view=view_code) }}">
+              <a href="{{ url_for('invenio_records_ui.proj', pid_value=project.pid, view=view_code) }}">
                 {{ project.name }}
               </a>
               {%- if project.funding_organisations -%}

--- a/sonar/modules/documents/views.py
+++ b/sonar/modules/documents/views.py
@@ -21,18 +21,14 @@ from __future__ import absolute_import, print_function
 
 import json
 
-from flask import Blueprint, abort, current_app, g, render_template, request
+from flask import Blueprint, current_app, render_template
 from flask_babelex import gettext as _
 from invenio_i18n.ext import current_i18n
-from invenio_pidstore.models import PersistentIdentifier
 from invenio_records_ui.signals import record_viewed
 
-from sonar.modules.documents.api import DocumentRecord
 from sonar.modules.documents.utils import has_external_urls_for_files, \
     populate_files_properties
-from sonar.modules.organisations.api import OrganisationRecord
 from sonar.modules.utils import format_date
-from sonar.proxies import sonar
 
 from .utils import publication_statement_text
 

--- a/sonar/resources/projects/views.py
+++ b/sonar/resources/projects/views.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Projects views."""
+
+from flask import current_app, g, render_template
+from invenio_records_ui.signals import record_viewed
+
+from sonar.proxies import sonar
+
+
+def detail(pid, record, template=None, **kwargs):
+    r"""Project detail view.
+
+    Sends record_viewed signal and renders template.
+
+    :param pid: PID object.
+    :param record: Record object.
+    :param template: Template to render.
+    :param \*\*kwargs: Additional view arguments based on URL rule.
+    :returns: The rendered template.
+    """
+    service = sonar.service('projects')
+    item = service.result_item(service, g.identity,
+                record)
+
+    # Send signal when record is viewed
+    record_viewed.send(
+        current_app._get_current_object(),
+        pid=pid,
+        record=record,
+    )
+
+    return render_template(template,
+                           pid=pid,
+                           record=item.data['metadata'])

--- a/sonar/route_converters.py
+++ b/sonar/route_converters.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Werkzeug Route Converters."""
+
+from flask import current_app, g, request
+from werkzeug.routing import BaseConverter, ValidationError
+
+from .modules.organisations.api import OrganisationRecord
+
+
+class OrganisationCodeConverter(BaseConverter):
+    """Werkzeug Organistaion code converter."""
+
+    # any word
+    regex = r"\w+"
+
+    def to_python(self, value):
+        """Check that the value is a known organisation view code.
+
+        :param value: the URL param value.
+        :returns: the URL param value.
+        """
+        if g.get('organisation'):
+            g.pop('organisation')
+        if value == current_app.config.get('SONAR_APP_DEFAULT_ORGANISATION'):
+            return value
+        organisation = OrganisationRecord.get_record_by_pid(value)
+        if not organisation or not organisation.get('isShared'):
+            raise ValidationError
+        g.organisation = organisation.dumps()
+        return value

--- a/sonar/route_converters.py
+++ b/sonar/route_converters.py
@@ -17,14 +17,14 @@
 
 """Werkzeug Route Converters."""
 
-from flask import current_app, g, request
+from flask import current_app, g
 from werkzeug.routing import BaseConverter, ValidationError
 
 from .modules.organisations.api import OrganisationRecord
 
 
 class OrganisationCodeConverter(BaseConverter):
-    """Werkzeug Organistaion code converter."""
+    """Werkzeug Organisation code converter."""
 
     # any word
     regex = r"\w+"

--- a/sonar/theme/templates/sonar/frontpage.html
+++ b/sonar/theme/templates/sonar/frontpage.html
@@ -26,7 +26,7 @@ along with this program. If not, see
     <div class="row justify-content-center">
       <div class="col-8 col-xs-6 col-lg-3 py-3 py-sm-5 text-center">
         <a
-          href="{{ url_for('documents.index', view=view_code if g.get('organisation', {}).get('isDedicated') else config.SONAR_APP_DEFAULT_ORGANISATION) }}">
+          href="{{ url_for('index', view=view_code if g.get('organisation', {}).get('isDedicated') else config.SONAR_APP_DEFAULT_ORGANISATION) }}">
           {% if g.get('organisation', {}).get('isDedicated') %}
           {% set thumbnail = g.organisation | record_image_url %}
           {% if thumbnail %}

--- a/sonar/theme/templates/sonar/partial/navbar.html
+++ b/sonar/theme/templates/sonar/partial/navbar.html
@@ -18,7 +18,7 @@ along with this program. If not, see
 <nav class="navbar navbar-expand-lg navbar-dark bg-{{ 'header' if page == 'home' else 'organisation' }}">
   <div class="container">
     {% if page != 'home' %}
-    <a class="navbar-brand" href="{{ url_for('documents.index', view=view_code) }}">
+    <a class="navbar-brand" href="{{ url_for('index', view=view_code) }}">
       {% if g.get('organisation', {}).get('isDedicated') %}
       {% set thumbnail = g.organisation | record_image_url %}
       {% if thumbnail %}

--- a/sonar/theme/templates/sonar/partial/organisation.html
+++ b/sonar/theme/templates/sonar/partial/organisation.html
@@ -28,7 +28,7 @@
             </form>
           </div>
           <div class="col text-right">
-            <a href="{{ url_for('documents.index', view=config.SONAR_APP_DEFAULT_ORGANISATION) }}"
+            <a href="{{ url_for('index', view=config.SONAR_APP_DEFAULT_ORGANISATION) }}"
               class="btn btn-outline-primary btn-sm">
               {{ _('Back to SONAR') }}
             </a>

--- a/sonar/theme/views.py
+++ b/sonar/theme/views.py
@@ -100,7 +100,9 @@ def rerodoc_redirection(pid):
         abort(404)
 
     return redirect(
-        url_for('documents.detail', pid_value=pid.get_redirect().pid_value))
+        url_for('invenio_records_ui.doc',
+                view='global',
+                pid_value=pid.get_redirect().pid_value))
 
 
 @blueprint.route('/manage/')

--- a/tests/api/users/test_users_query.py
+++ b/tests/api/users/test_users_query.py
@@ -22,7 +22,7 @@ from invenio_accounts.testutils import login_user_via_session
 
 
 def test_queries(client, superuser, make_user):
-    """."""
+    """Test the query user list filtering."""
     login_user_via_session(client, email=superuser['email'])
 
     headers = [('Content-Type', 'application/json')]

--- a/tests/ui/documents/cli/test_documents_cli_oaiharvester.py
+++ b/tests/ui/documents/cli/test_documents_cli_oaiharvester.py
@@ -18,7 +18,6 @@
 """Test documents CLI commands."""
 
 from click.testing import CliRunner
-from invenio_oaiharvester.models import OAIHarvestConfig
 
 import sonar.modules.documents.cli.oaiharvester as Cli
 

--- a/tests/ui/documents/cli/test_documents_cli_rerodoc.py
+++ b/tests/ui/documents/cli/test_documents_cli_rerodoc.py
@@ -18,7 +18,6 @@
 """Test documents RERODOC cli commands."""
 
 from click.testing import CliRunner
-from mock import patch
 
 import sonar.modules.documents.cli.rerodoc as cli
 

--- a/tests/ui/documents/dojson/rerodoc/test_rerodoc_model.py
+++ b/tests/ui/documents/dojson/rerodoc/test_rerodoc_model.py
@@ -21,7 +21,6 @@ from __future__ import absolute_import, print_function
 
 import pytest
 from dojson.contrib.marc21.utils import create_record
-from utils import mock_response
 
 from sonar.modules.documents.dojson.rerodoc.model import overdo
 

--- a/tests/ui/documents/test_documents_views.py
+++ b/tests/ui/documents/test_documents_views.py
@@ -18,32 +18,27 @@
 """Test documents views."""
 
 import pytest
-from flask import g, url_for
+from flask import g, render_template_string, url_for
 
 import sonar.modules.documents.views as views
-
-
-def test_default_view_code(app):
-    """Test set default view code."""
-    views.default_view_code(None, {'view': 'global'})
 
 
 def test_store_organisation(client, db, organisation):
     """Test store organisation in globals."""
     # Default view, no organisation stored.
-    assert client.get(url_for('documents.index',
+    assert client.get(url_for('index',
                               view='global')).status_code == 200
     assert not g.get('organisation')
 
     # Existing organisation stored, with shared view
-    assert client.get(url_for('documents.index',
+    assert client.get(url_for('index',
                               view='org')).status_code == 200
     assert g.organisation['code'] == 'org'
     assert g.organisation['isShared']
 
     # Non-existing organisation
     g.pop('organisation')
-    assert client.get(url_for('documents.index',
+    assert client.get(url_for('index',
                               view='non-existing')).status_code == 404
     assert not g.get('organisation')
 
@@ -51,31 +46,31 @@ def test_store_organisation(client, db, organisation):
     organisation['isShared'] = False
     organisation.commit()
     db.session.commit()
-    assert client.get(url_for('documents.index',
+    assert client.get(url_for('index',
                               view='org')).status_code == 404
     assert not g.get('organisation')
 
 
 def test_index(client):
     """Test frontpage."""
-    assert isinstance(views.index(), str)
     assert client.get('/').status_code == 200
 
 
 def test_search(app, client):
     """Test search."""
-    assert isinstance(views.search(), str)
-    assert client.get(url_for('documents.search',
+    assert client.get(url_for('documents.search', view='global',
                               resource_type='documents')).status_code == 200
+    assert client.get(url_for('documents.search', view='not-existing',
+                              resource_type='documents')).status_code == 404
 
 
 def test_detail(app, client, document_with_file):
     """Test document detail page."""
     assert client.get(
-        url_for('documents.detail',
+        url_for('invenio_records_ui.doc', view='global',
                 pid_value=document_with_file['pid'])).status_code == 200
 
-    assert client.get(url_for('documents.detail',
+    assert client.get(url_for('invenio_records_ui.doc', view='global',
                               pid_value='not-existing')).status_code == 404
 
 
@@ -130,10 +125,10 @@ def test_create_publication_statement(document):
                       'Impr. Coustaud'
 
 
-def test_nl2br():
+def test_nl2br(app):
     """Test nl2br conversion."""
-    text = 'Multiline text\nMultiline text'
-    assert views.nl2br(text) == 'Multiline text<br>Multiline text'
+    assert render_template_string("{{ 'Multiline text\nMultiline text' | nl2br | safe}}") ==\
+        'Multiline text<br>Multiline text'
 
 
 def test_get_code_from_bibliographic_language(app):
@@ -354,9 +349,10 @@ def test_contribution_text():
 
 def test_project_detail(app, client, project):
     """Test project detail page."""
-    assert client.get(url_for('documents.project_detail',
+    assert client.get(url_for('invenio_records_ui.proj', view='global',
                               pid_value=project.id)).status_code == 200
-
     assert client.get(
-        url_for('documents.project_detail',
+        url_for('invenio_records_ui.proj', view='global',
                 pid_value='not-existing')).status_code == 404
+    assert client.get(url_for('invenio_records_ui.proj', view='not-existing',
+                              pid_value=project.id)).status_code == 404

--- a/tests/ui/test_cli.py
+++ b/tests/ui/test_cli.py
@@ -20,7 +20,6 @@
 from io import BytesIO
 from os.path import isdir
 
-import mock
 from click.testing import CliRunner
 from invenio_search.cli import destroy
 

--- a/tests/ui/test_fetchers.py
+++ b/tests/ui/test_fetchers.py
@@ -17,7 +17,6 @@
 
 """Test SONAR fetchers."""
 
-import pytest
 
 from sonar.modules.documents.api import DocumentRecord
 

--- a/tests/ui/users/test_users_api.py
+++ b/tests/ui/users/test_users_api.py
@@ -17,8 +17,6 @@
 
 """Test API for user records."""
 
-from flask_security import current_user, url_for_security
-from invenio_accounts.testutils import login_user_via_view
 
 from sonar.modules.users.api import UserRecord, UserSearch
 


### PR DESCRIPTION
* Adds document and project detailed view in the invenio-records-ui
  configuration.
* Adds permissions to the detailed, preview and file document views to
  limit the access to the public documents.
* Adds front page route and the global jinja filters to the main
  extension application.
* Adds a new werkzeug converter to limit the view matched routes to the
  existing organisations.
* Use `autoflake` to detect unused import packages.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
