### PR TITLE
documents: hide `hiddenFromPublic` from editor

### DIFF
--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -1758,10 +1758,7 @@
     },
     "hiddenFromPublic": {
       "title": "Hidden to public",
-      "type": "boolean",
-      "form": {
-        "hide": true
-      }
+      "type": "boolean"
     }
   },
   "propertiesOrder": [
@@ -1788,8 +1785,7 @@
     "additionalMaterials",
     "contentNote",
     "otherMaterialCharacteristics",
-    "usageAndAccessPolicy",
-    "hiddenFromPublic"
+    "usageAndAccessPolicy"
   ],
   "required": [
     "$schema",


### PR DESCRIPTION
* Hides the property `hiddenFromPublic` from the document editor.
* Closes #537.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>