### PR TITLE
resources: apply filters

### DIFF
--- a/sonar/resources/params.py
+++ b/sonar/resources/params.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Results filtering based on request params."""
+
+from invenio_records_resources.services.records.params.base import \
+    ParamInterpreter
+
+
+class FilterParams(ParamInterpreter):
+    """Search filters."""
+
+    def apply(self, identity, search, params):
+        """Apply filters.
+
+        :param identity: Identity representing the logged user.
+        :param search: Elasticsearch object.
+        :param params: Additional params.
+        :returns: Elasticsearch object.
+        """
+        filters = self.config.search_facets_options.get('filters', {})
+        facets_args = params.get('facets', {})
+
+        for k in set(facets_args.keys()) & set(filters.keys()):
+            values = facets_args[k]
+            search = search.filter(filters[k](values))
+
+        return search

--- a/sonar/resources/projects/service.py
+++ b/sonar/resources/projects/service.py
@@ -17,8 +17,6 @@
 
 """Projects service."""
 
-from invenio_records_resources.services import \
-    RecordServiceConfig as BaseRecordServiceConfig
 from invenio_records_resources.services.records.schema import \
     MarshmallowServiceSchema
 from invenio_records_rest.utils import obj_or_import_string
@@ -29,6 +27,7 @@ from sonar.modules.query import and_term_filter
 from sonar.modules.utils import has_custom_resource
 
 from ..service import RecordService as BaseRecordService
+from ..service import RecordServiceConfig as BaseRecordServiceConfig
 from .api import Record, RecordComponent
 from .permissions import RecordPermissionPolicy
 from .results import RecordList

--- a/sonar/resources/service.py
+++ b/sonar/resources/service.py
@@ -19,8 +19,19 @@
 
 from flask_principal import Identity, Need, UserNeed
 from invenio_pidstore.models import PersistentIdentifier, PIDStatus
+from invenio_records_resources.services import \
+    RecordServiceConfig as BaseRecordServiceConfig
 from invenio_records_resources.services.records import \
     RecordService as BaseRecordService
+
+from .params import FilterParams
+
+
+class RecordServiceConfig(BaseRecordServiceConfig):
+    """Service factory configuration."""
+
+    search_params_interpreters_cls = \
+        [FilterParams] + BaseRecordServiceConfig.search_params_interpreters_cls
 
 
 class RecordService(BaseRecordService):

--- a/tests/api/projects/test_projects_filters.py
+++ b/tests/api/projects/test_projects_filters.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test projects filters."""
+
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+
+
+def test_filters(client, superuser, project, make_project):
+    """Test projects filters."""
+    make_project('submitter', 'org')
+
+    login_user_via_session(client, email=superuser['email'])
+
+    # Without filter
+    res = client.get(url_for('projects.projects_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total'] == 2
+    assert len(res.json['aggregations']['user']['buckets']) == 2
+
+    # Existing user filter
+    res = client.get(
+        url_for('projects.projects_list', user='orgadmin'))
+    assert res.status_code == 200
+    assert res.json['hits']['total'] == 1
+    assert len(res.json['aggregations']['user']['buckets']) == 1
+
+    # Non existing organisation filter
+    res = client.get(url_for('projects.projects_list', user='unknown'))
+    assert res.status_code == 200
+    assert res.json['hits']['total'] == 0
+    assert not res.json['aggregations']['user']['buckets']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -634,7 +634,7 @@ def project_json():
 
 
 @pytest.fixture()
-def make_project(db, project_json, make_user):
+def make_project(app, db, project_json, make_user):
     """Factory for creating project."""
 
     def _make_project(role='submitter', organisation=None):
@@ -651,13 +651,15 @@ def make_project(db, project_json, make_user):
 
         project_json.pop('id', None)
 
-        return sonar.service('projects').create(None, project_json)
+        project = sonar.service('projects').create(None, project_json)
+        app.extensions['invenio-search'].flush_and_refresh(index='projects')
+        return project
 
     return _make_project
 
 
 @pytest.fixture()
-def project(app, db, admin, organisation, project_json):
+def project(app, db, es, admin, organisation, project_json):
     """Deposit fixture."""
     json = copy.deepcopy(project_json)
     json['metadata']['user'] = {
@@ -669,7 +671,9 @@ def project(app, db, admin, organisation, project_json):
             pid=organisation['pid'])
     }
 
-    return sonar.service('projects').create(None, json)
+    project = sonar.service('projects').create(None, json)
+    app.extensions['invenio-search'].flush_and_refresh(index='projects')
+    return project
 
 
 @pytest.fixture()


### PR DESCRIPTION
This PR aims to apply filters during the search process, as `invenio_records_resources` just applies `post_filters` at this time...

* Creates a record service configuration to fill the custom `FacetsParam` class.
* Applies filters if some are defined in configuration.
* Closes #554.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>