### PR TITLE
documents: flag record as `harvested`

### DIFF
--- a/sonar/modules/documents/marshmallow/json.py
+++ b/sonar/modules/documents/marshmallow/json.py
@@ -101,6 +101,7 @@ class DocumentMetadataSchemaV1(StrictKeysMixin):
     oa_status = SanitizedUnicode()
     hiddenFromPublic = fields.Boolean()
     sections = fields.List(fields.Str())
+    harvested = fields.Boolean()
     _bucket = SanitizedUnicode()
     _files = Nested(FileSchemaV1, many=True)
     _oai = fields.Dict()

--- a/sonar/modules/documents/tasks.py
+++ b/sonar/modules/documents/tasks.py
@@ -46,6 +46,9 @@ def import_records(records_to_import):
             record = DocumentRecord.get_record_by_identifier(
                 data.get('identifiedBy', []))
 
+            # Set record as harvested
+            data['harvested'] = True
+
             if not record:
                 record = DocumentRecord.create(data,
                                                dbcommit=False,

--- a/tests/ui/documents/test_documents_tasks.py
+++ b/tests/ui/documents/test_documents_tasks.py
@@ -39,6 +39,7 @@ def test_import_records(mock_record_by_identifier, app, document_json,
     ids = import_records([document_json])
     record = DocumentRecord.get_record(ids[0])
     assert record
+    assert record['harvested']
 
     # Update
     mock_record_by_identifier.return_value = record


### PR DESCRIPTION
* Flags record as `harvested` when it is imported from an external source.
* Closes #556.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>