### PR TITLE
templates: add language value filter

### DIFF
--- a/sonar/ext.py
+++ b/sonar/ext.py
@@ -33,8 +33,8 @@ from sonar.modules.receivers import file_deleted_listener, \
     file_uploaded_listener
 from sonar.modules.users.api import current_user_record
 from sonar.modules.users.signals import add_full_name, user_registered_handler
-from sonar.modules.utils import get_specific_theme, get_switch_aai_providers, \
-    get_view_code
+from sonar.modules.utils import get_language_value, get_specific_theme, \
+    get_switch_aai_providers, get_view_code
 from sonar.resources.projects.resource import \
     RecordResource as ProjectRecordResource
 from sonar.resources.projects.service import \
@@ -120,6 +120,22 @@ class Sonar():
         def nl2br(string):
             r"""Replace \n to <br>."""
             return string.replace('\n', '<br>')
+
+        @app.template_filter()
+        def language_value(values,
+                           locale=None,
+                           value_field='value',
+                           language_field='language'):
+            """Get the value of a field corresponding to the current language.
+
+            :params values: List of values with the language.
+            :params locale: Two digit locale to find.
+            :params value_field: Name of the property containing the value.
+            :params language_field: Name of the property containing the language.
+            :returns: The value corresponding to the current language.
+            """
+            return get_language_value(values, locale, value_field,
+                                      language_field)
 
     def create_resources(self):
         """Create resources."""

--- a/sonar/heg/serializers/schemas/heg.py
+++ b/sonar/heg/serializers/schemas/heg.py
@@ -19,7 +19,7 @@
 
 from marshmallow import Schema, fields, post_dump, pre_dump
 
-from sonar.modules.documents.views import get_bibliographic_code_from_language
+from sonar.modules.utils import get_bibliographic_code_from_language
 
 
 class HEGSchema(Schema):

--- a/sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json
+++ b/sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json
@@ -1,0 +1,5060 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://sonar.ch/schemas/collections/collection-v1.0.0.json",
+  "title": "Collections",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "default": "https://sonar.ch/schemas/collections/collection-v1.0.0.json"
+    },
+    "pid": {
+      "title": "Identifier",
+      "type": "string",
+      "minLength": 1
+    },
+    "hashKey": {
+      "title": "Hash key",
+      "type": "string",
+      "minLength": 1
+    },
+    "name": {
+      "title": "Names",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "title": "Name",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "value": {
+            "title": "Value",
+            "type": "string",
+            "minLength": 1
+          },
+          "language": {
+            "title": "Language",
+            "type": "string",
+            "enum": [
+              "aar",
+              "abk",
+              "ace",
+              "ach",
+              "ada",
+              "ady",
+              "afa",
+              "afh",
+              "afr",
+              "ain",
+              "aka",
+              "akk",
+              "alb",
+              "ale",
+              "alg",
+              "alt",
+              "amh",
+              "ang",
+              "anp",
+              "apa",
+              "ara",
+              "arc",
+              "arg",
+              "arm",
+              "arn",
+              "arp",
+              "art",
+              "arw",
+              "asm",
+              "ast",
+              "ath",
+              "aus",
+              "ava",
+              "ave",
+              "awa",
+              "aym",
+              "aze",
+              "bad",
+              "bai",
+              "bak",
+              "bal",
+              "bam",
+              "ban",
+              "baq",
+              "bas",
+              "bat",
+              "bej",
+              "bel",
+              "bem",
+              "ben",
+              "ber",
+              "bho",
+              "bih",
+              "bik",
+              "bin",
+              "bis",
+              "bla",
+              "bnt",
+              "bos",
+              "bra",
+              "bre",
+              "btk",
+              "bua",
+              "bug",
+              "bul",
+              "bur",
+              "byn",
+              "cad",
+              "cai",
+              "car",
+              "cat",
+              "cau",
+              "ceb",
+              "cel",
+              "cha",
+              "chb",
+              "che",
+              "chg",
+              "chi",
+              "chk",
+              "chm",
+              "chn",
+              "cho",
+              "chp",
+              "chr",
+              "chu",
+              "chv",
+              "chy",
+              "cmc",
+              "cnr",
+              "cop",
+              "cor",
+              "cos",
+              "cpe",
+              "cpf",
+              "cpp",
+              "cre",
+              "crh",
+              "crp",
+              "csb",
+              "cus",
+              "cze",
+              "dak",
+              "dan",
+              "dar",
+              "day",
+              "del",
+              "den",
+              "dgr",
+              "din",
+              "div",
+              "doi",
+              "dra",
+              "dsb",
+              "dua",
+              "dum",
+              "dut",
+              "dyu",
+              "dzo",
+              "efi",
+              "egy",
+              "eka",
+              "elx",
+              "eng",
+              "enm",
+              "epo",
+              "est",
+              "ewe",
+              "ewo",
+              "fan",
+              "fao",
+              "fat",
+              "fij",
+              "fil",
+              "fin",
+              "fiu",
+              "fon",
+              "fre",
+              "frm",
+              "fro",
+              "frr",
+              "frs",
+              "fry",
+              "ful",
+              "fur",
+              "gaa",
+              "gay",
+              "gba",
+              "gem",
+              "geo",
+              "ger",
+              "gez",
+              "gil",
+              "gla",
+              "gle",
+              "glg",
+              "glv",
+              "gmh",
+              "goh",
+              "gon",
+              "gor",
+              "got",
+              "grb",
+              "grc",
+              "gre",
+              "grn",
+              "gsw",
+              "guj",
+              "gwi",
+              "hai",
+              "hat",
+              "hau",
+              "haw",
+              "heb",
+              "her",
+              "hil",
+              "him",
+              "hin",
+              "hit",
+              "hmn",
+              "hmo",
+              "hrv",
+              "hsb",
+              "hun",
+              "hup",
+              "iba",
+              "ibo",
+              "ice",
+              "ido",
+              "iii",
+              "ijo",
+              "iku",
+              "ile",
+              "ilo",
+              "ina",
+              "inc",
+              "ind",
+              "ine",
+              "inh",
+              "ipk",
+              "ira",
+              "iro",
+              "ita",
+              "jav",
+              "jbo",
+              "jpn",
+              "jpr",
+              "jrb",
+              "kaa",
+              "kab",
+              "kac",
+              "kal",
+              "kam",
+              "kan",
+              "kar",
+              "kas",
+              "kau",
+              "kaw",
+              "kaz",
+              "kbd",
+              "kha",
+              "khi",
+              "khm",
+              "kho",
+              "kik",
+              "kin",
+              "kir",
+              "kmb",
+              "kok",
+              "kom",
+              "kon",
+              "kor",
+              "kos",
+              "kpe",
+              "krc",
+              "krl",
+              "kro",
+              "kru",
+              "kua",
+              "kum",
+              "kur",
+              "kut",
+              "lad",
+              "lah",
+              "lam",
+              "lao",
+              "lat",
+              "lav",
+              "lez",
+              "lim",
+              "lin",
+              "lit",
+              "lol",
+              "loz",
+              "ltz",
+              "lua",
+              "lub",
+              "lug",
+              "lui",
+              "lun",
+              "luo",
+              "lus",
+              "mac",
+              "mad",
+              "mag",
+              "mah",
+              "mai",
+              "mak",
+              "mal",
+              "man",
+              "mao",
+              "map",
+              "mar",
+              "mas",
+              "may",
+              "mdf",
+              "mdr",
+              "men",
+              "mga",
+              "mic",
+              "min",
+              "mis",
+              "mkh",
+              "mlg",
+              "mlt",
+              "mnc",
+              "mni",
+              "mno",
+              "moh",
+              "mon",
+              "mos",
+              "mul",
+              "mun",
+              "mus",
+              "mwl",
+              "mwr",
+              "myn",
+              "myv",
+              "nah",
+              "nai",
+              "nap",
+              "nau",
+              "nav",
+              "nbl",
+              "nde",
+              "ndo",
+              "nds",
+              "nep",
+              "new",
+              "nia",
+              "nic",
+              "niu",
+              "nno",
+              "nob",
+              "nog",
+              "non",
+              "nor",
+              "nqo",
+              "nso",
+              "nub",
+              "nwc",
+              "nya",
+              "nym",
+              "nyn",
+              "nyo",
+              "nzi",
+              "oci",
+              "oji",
+              "ori",
+              "orm",
+              "osa",
+              "oss",
+              "ota",
+              "oto",
+              "paa",
+              "pag",
+              "pal",
+              "pam",
+              "pan",
+              "pap",
+              "pau",
+              "peo",
+              "per",
+              "phi",
+              "phn",
+              "pli",
+              "pol",
+              "pon",
+              "por",
+              "pra",
+              "pro",
+              "pus",
+              "que",
+              "raj",
+              "rap",
+              "rar",
+              "roa",
+              "roh",
+              "rom",
+              "rum",
+              "run",
+              "rup",
+              "rus",
+              "sad",
+              "sag",
+              "sah",
+              "sai",
+              "sal",
+              "sam",
+              "san",
+              "sas",
+              "sat",
+              "scn",
+              "sco",
+              "sel",
+              "sem",
+              "sga",
+              "sgn",
+              "shn",
+              "sid",
+              "sin",
+              "sio",
+              "sit",
+              "sla",
+              "slo",
+              "slv",
+              "sma",
+              "sme",
+              "smi",
+              "smj",
+              "smn",
+              "smo",
+              "sms",
+              "sna",
+              "snd",
+              "snk",
+              "sog",
+              "som",
+              "son",
+              "sot",
+              "spa",
+              "srd",
+              "srn",
+              "srp",
+              "srr",
+              "ssa",
+              "ssw",
+              "suk",
+              "sun",
+              "sus",
+              "sux",
+              "swa",
+              "swe",
+              "syc",
+              "syr",
+              "tah",
+              "tai",
+              "tam",
+              "tat",
+              "tel",
+              "tem",
+              "ter",
+              "tet",
+              "tgk",
+              "tgl",
+              "tha",
+              "tib",
+              "tig",
+              "tir",
+              "tiv",
+              "tkl",
+              "tlh",
+              "tli",
+              "tmh",
+              "tog",
+              "ton",
+              "tpi",
+              "tsi",
+              "tsn",
+              "tso",
+              "tuk",
+              "tum",
+              "tup",
+              "tur",
+              "tut",
+              "tvl",
+              "twi",
+              "tyv",
+              "udm",
+              "uga",
+              "uig",
+              "ukr",
+              "umb",
+              "und",
+              "urd",
+              "uzb",
+              "vai",
+              "ven",
+              "vie",
+              "vol",
+              "vot",
+              "wak",
+              "wal",
+              "war",
+              "was",
+              "wel",
+              "wen",
+              "wln",
+              "wol",
+              "xal",
+              "xho",
+              "yao",
+              "yap",
+              "yid",
+              "yor",
+              "ypk",
+              "zap",
+              "zbl",
+              "zen",
+              "zha",
+              "znd",
+              "zul",
+              "zun",
+              "zxx",
+              "zza"
+            ],
+            "form": {
+              "templateOptions": {
+                "sort": true,
+                "wrappers": [
+                  "card"
+                ]
+              },
+              "options": [
+                {
+                  "label": "lang_aar",
+                  "value": "aar"
+                },
+                {
+                  "label": "lang_abk",
+                  "value": "abk"
+                },
+                {
+                  "label": "lang_ace",
+                  "value": "ace"
+                },
+                {
+                  "label": "lang_ach",
+                  "value": "ach"
+                },
+                {
+                  "label": "lang_ada",
+                  "value": "ada"
+                },
+                {
+                  "label": "lang_ady",
+                  "value": "ady"
+                },
+                {
+                  "label": "lang_afa",
+                  "value": "afa"
+                },
+                {
+                  "label": "lang_afh",
+                  "value": "afh"
+                },
+                {
+                  "label": "lang_afr",
+                  "value": "afr"
+                },
+                {
+                  "label": "lang_ain",
+                  "value": "ain"
+                },
+                {
+                  "label": "lang_aka",
+                  "value": "aka"
+                },
+                {
+                  "label": "lang_akk",
+                  "value": "akk"
+                },
+                {
+                  "label": "lang_alb",
+                  "value": "alb"
+                },
+                {
+                  "label": "lang_ale",
+                  "value": "ale"
+                },
+                {
+                  "label": "lang_alg",
+                  "value": "alg"
+                },
+                {
+                  "label": "lang_alt",
+                  "value": "alt"
+                },
+                {
+                  "label": "lang_amh",
+                  "value": "amh"
+                },
+                {
+                  "label": "lang_ang",
+                  "value": "ang"
+                },
+                {
+                  "label": "lang_anp",
+                  "value": "anp"
+                },
+                {
+                  "label": "lang_apa",
+                  "value": "apa"
+                },
+                {
+                  "label": "lang_ara",
+                  "value": "ara"
+                },
+                {
+                  "label": "lang_arc",
+                  "value": "arc"
+                },
+                {
+                  "label": "lang_arg",
+                  "value": "arg"
+                },
+                {
+                  "label": "lang_arm",
+                  "value": "arm"
+                },
+                {
+                  "label": "lang_arn",
+                  "value": "arn"
+                },
+                {
+                  "label": "lang_arp",
+                  "value": "arp"
+                },
+                {
+                  "label": "lang_art",
+                  "value": "art"
+                },
+                {
+                  "label": "lang_arw",
+                  "value": "arw"
+                },
+                {
+                  "label": "lang_asm",
+                  "value": "asm"
+                },
+                {
+                  "label": "lang_ast",
+                  "value": "ast"
+                },
+                {
+                  "label": "lang_ath",
+                  "value": "ath"
+                },
+                {
+                  "label": "lang_aus",
+                  "value": "aus"
+                },
+                {
+                  "label": "lang_ava",
+                  "value": "ava"
+                },
+                {
+                  "label": "lang_ave",
+                  "value": "ave"
+                },
+                {
+                  "label": "lang_awa",
+                  "value": "awa"
+                },
+                {
+                  "label": "lang_aym",
+                  "value": "aym"
+                },
+                {
+                  "label": "lang_aze",
+                  "value": "aze"
+                },
+                {
+                  "label": "lang_bad",
+                  "value": "bad"
+                },
+                {
+                  "label": "lang_bai",
+                  "value": "bai"
+                },
+                {
+                  "label": "lang_bak",
+                  "value": "bak"
+                },
+                {
+                  "label": "lang_bal",
+                  "value": "bal"
+                },
+                {
+                  "label": "lang_bam",
+                  "value": "bam"
+                },
+                {
+                  "label": "lang_ban",
+                  "value": "ban"
+                },
+                {
+                  "label": "lang_baq",
+                  "value": "baq"
+                },
+                {
+                  "label": "lang_bas",
+                  "value": "bas"
+                },
+                {
+                  "label": "lang_bat",
+                  "value": "bat"
+                },
+                {
+                  "label": "lang_bej",
+                  "value": "bej"
+                },
+                {
+                  "label": "lang_bel",
+                  "value": "bel"
+                },
+                {
+                  "label": "lang_bem",
+                  "value": "bem"
+                },
+                {
+                  "label": "lang_ben",
+                  "value": "ben"
+                },
+                {
+                  "label": "lang_ber",
+                  "value": "ber"
+                },
+                {
+                  "label": "lang_bho",
+                  "value": "bho"
+                },
+                {
+                  "label": "lang_bih",
+                  "value": "bih"
+                },
+                {
+                  "label": "lang_bik",
+                  "value": "bik"
+                },
+                {
+                  "label": "lang_bin",
+                  "value": "bin"
+                },
+                {
+                  "label": "lang_bis",
+                  "value": "bis"
+                },
+                {
+                  "label": "lang_bla",
+                  "value": "bla"
+                },
+                {
+                  "label": "lang_bnt",
+                  "value": "bnt"
+                },
+                {
+                  "label": "lang_bos",
+                  "value": "bos"
+                },
+                {
+                  "label": "lang_bra",
+                  "value": "bra"
+                },
+                {
+                  "label": "lang_bre",
+                  "value": "bre"
+                },
+                {
+                  "label": "lang_btk",
+                  "value": "btk"
+                },
+                {
+                  "label": "lang_bua",
+                  "value": "bua"
+                },
+                {
+                  "label": "lang_bug",
+                  "value": "bug"
+                },
+                {
+                  "label": "lang_bul",
+                  "value": "bul"
+                },
+                {
+                  "label": "lang_bur",
+                  "value": "bur"
+                },
+                {
+                  "label": "lang_byn",
+                  "value": "byn"
+                },
+                {
+                  "label": "lang_cad",
+                  "value": "cad"
+                },
+                {
+                  "label": "lang_cai",
+                  "value": "cai"
+                },
+                {
+                  "label": "lang_car",
+                  "value": "car"
+                },
+                {
+                  "label": "lang_cat",
+                  "value": "cat"
+                },
+                {
+                  "label": "lang_cau",
+                  "value": "cau"
+                },
+                {
+                  "label": "lang_ceb",
+                  "value": "ceb"
+                },
+                {
+                  "label": "lang_cel",
+                  "value": "cel"
+                },
+                {
+                  "label": "lang_cha",
+                  "value": "cha"
+                },
+                {
+                  "label": "lang_chb",
+                  "value": "chb"
+                },
+                {
+                  "label": "lang_che",
+                  "value": "che"
+                },
+                {
+                  "label": "lang_chg",
+                  "value": "chg"
+                },
+                {
+                  "label": "lang_chi",
+                  "value": "chi"
+                },
+                {
+                  "label": "lang_chk",
+                  "value": "chk"
+                },
+                {
+                  "label": "lang_chm",
+                  "value": "chm"
+                },
+                {
+                  "label": "lang_chn",
+                  "value": "chn"
+                },
+                {
+                  "label": "lang_cho",
+                  "value": "cho"
+                },
+                {
+                  "label": "lang_chp",
+                  "value": "chp"
+                },
+                {
+                  "label": "lang_chr",
+                  "value": "chr"
+                },
+                {
+                  "label": "lang_chu",
+                  "value": "chu"
+                },
+                {
+                  "label": "lang_chv",
+                  "value": "chv"
+                },
+                {
+                  "label": "lang_chy",
+                  "value": "chy"
+                },
+                {
+                  "label": "lang_cmc",
+                  "value": "cmc"
+                },
+                {
+                  "label": "lang_cnr",
+                  "value": "cnr"
+                },
+                {
+                  "label": "lang_cop",
+                  "value": "cop"
+                },
+                {
+                  "label": "lang_cor",
+                  "value": "cor"
+                },
+                {
+                  "label": "lang_cos",
+                  "value": "cos"
+                },
+                {
+                  "label": "lang_cpe",
+                  "value": "cpe"
+                },
+                {
+                  "label": "lang_cpf",
+                  "value": "cpf"
+                },
+                {
+                  "label": "lang_cpp",
+                  "value": "cpp"
+                },
+                {
+                  "label": "lang_cre",
+                  "value": "cre"
+                },
+                {
+                  "label": "lang_crh",
+                  "value": "crh"
+                },
+                {
+                  "label": "lang_crp",
+                  "value": "crp"
+                },
+                {
+                  "label": "lang_csb",
+                  "value": "csb"
+                },
+                {
+                  "label": "lang_cus",
+                  "value": "cus"
+                },
+                {
+                  "label": "lang_cze",
+                  "value": "cze"
+                },
+                {
+                  "label": "lang_dak",
+                  "value": "dak"
+                },
+                {
+                  "label": "lang_dan",
+                  "value": "dan"
+                },
+                {
+                  "label": "lang_dar",
+                  "value": "dar"
+                },
+                {
+                  "label": "lang_day",
+                  "value": "day"
+                },
+                {
+                  "label": "lang_del",
+                  "value": "del"
+                },
+                {
+                  "label": "lang_den",
+                  "value": "den"
+                },
+                {
+                  "label": "lang_dgr",
+                  "value": "dgr"
+                },
+                {
+                  "label": "lang_din",
+                  "value": "din"
+                },
+                {
+                  "label": "lang_div",
+                  "value": "div"
+                },
+                {
+                  "label": "lang_doi",
+                  "value": "doi"
+                },
+                {
+                  "label": "lang_dra",
+                  "value": "dra"
+                },
+                {
+                  "label": "lang_dsb",
+                  "value": "dsb"
+                },
+                {
+                  "label": "lang_dua",
+                  "value": "dua"
+                },
+                {
+                  "label": "lang_dum",
+                  "value": "dum"
+                },
+                {
+                  "label": "lang_dut",
+                  "value": "dut"
+                },
+                {
+                  "label": "lang_dyu",
+                  "value": "dyu"
+                },
+                {
+                  "label": "lang_dzo",
+                  "value": "dzo"
+                },
+                {
+                  "label": "lang_efi",
+                  "value": "efi"
+                },
+                {
+                  "label": "lang_egy",
+                  "value": "egy"
+                },
+                {
+                  "label": "lang_eka",
+                  "value": "eka"
+                },
+                {
+                  "label": "lang_elx",
+                  "value": "elx"
+                },
+                {
+                  "label": "lang_eng",
+                  "value": "eng",
+                  "preferred": true
+                },
+                {
+                  "label": "lang_enm",
+                  "value": "enm"
+                },
+                {
+                  "label": "lang_epo",
+                  "value": "epo"
+                },
+                {
+                  "label": "lang_est",
+                  "value": "est"
+                },
+                {
+                  "label": "lang_ewe",
+                  "value": "ewe"
+                },
+                {
+                  "label": "lang_ewo",
+                  "value": "ewo"
+                },
+                {
+                  "label": "lang_fan",
+                  "value": "fan"
+                },
+                {
+                  "label": "lang_fao",
+                  "value": "fao"
+                },
+                {
+                  "label": "lang_fat",
+                  "value": "fat"
+                },
+                {
+                  "label": "lang_fij",
+                  "value": "fij"
+                },
+                {
+                  "label": "lang_fil",
+                  "value": "fil"
+                },
+                {
+                  "label": "lang_fin",
+                  "value": "fin"
+                },
+                {
+                  "label": "lang_fiu",
+                  "value": "fiu"
+                },
+                {
+                  "label": "lang_fon",
+                  "value": "fon"
+                },
+                {
+                  "label": "lang_fre",
+                  "value": "fre",
+                  "preferred": true
+                },
+                {
+                  "label": "lang_frm",
+                  "value": "frm"
+                },
+                {
+                  "label": "lang_fro",
+                  "value": "fro"
+                },
+                {
+                  "label": "lang_frr",
+                  "value": "frr"
+                },
+                {
+                  "label": "lang_frs",
+                  "value": "frs"
+                },
+                {
+                  "label": "lang_fry",
+                  "value": "fry"
+                },
+                {
+                  "label": "lang_ful",
+                  "value": "ful"
+                },
+                {
+                  "label": "lang_fur",
+                  "value": "fur"
+                },
+                {
+                  "label": "lang_gaa",
+                  "value": "gaa"
+                },
+                {
+                  "label": "lang_gay",
+                  "value": "gay"
+                },
+                {
+                  "label": "lang_gba",
+                  "value": "gba"
+                },
+                {
+                  "label": "lang_gem",
+                  "value": "gem"
+                },
+                {
+                  "label": "lang_geo",
+                  "value": "geo"
+                },
+                {
+                  "label": "lang_ger",
+                  "value": "ger",
+                  "preferred": true
+                },
+                {
+                  "label": "lang_gez",
+                  "value": "gez"
+                },
+                {
+                  "label": "lang_gil",
+                  "value": "gil"
+                },
+                {
+                  "label": "lang_gla",
+                  "value": "gla"
+                },
+                {
+                  "label": "lang_gle",
+                  "value": "gle"
+                },
+                {
+                  "label": "lang_glg",
+                  "value": "glg"
+                },
+                {
+                  "label": "lang_glv",
+                  "value": "glv"
+                },
+                {
+                  "label": "lang_gmh",
+                  "value": "gmh"
+                },
+                {
+                  "label": "lang_goh",
+                  "value": "goh"
+                },
+                {
+                  "label": "lang_gon",
+                  "value": "gon"
+                },
+                {
+                  "label": "lang_gor",
+                  "value": "gor"
+                },
+                {
+                  "label": "lang_got",
+                  "value": "got"
+                },
+                {
+                  "label": "lang_grb",
+                  "value": "grb"
+                },
+                {
+                  "label": "lang_grc",
+                  "value": "grc"
+                },
+                {
+                  "label": "lang_gre",
+                  "value": "gre"
+                },
+                {
+                  "label": "lang_grn",
+                  "value": "grn"
+                },
+                {
+                  "label": "lang_gsw",
+                  "value": "gsw"
+                },
+                {
+                  "label": "lang_guj",
+                  "value": "guj"
+                },
+                {
+                  "label": "lang_gwi",
+                  "value": "gwi"
+                },
+                {
+                  "label": "lang_hai",
+                  "value": "hai"
+                },
+                {
+                  "label": "lang_hat",
+                  "value": "hat"
+                },
+                {
+                  "label": "lang_hau",
+                  "value": "hau"
+                },
+                {
+                  "label": "lang_haw",
+                  "value": "haw"
+                },
+                {
+                  "label": "lang_heb",
+                  "value": "heb"
+                },
+                {
+                  "label": "lang_her",
+                  "value": "her"
+                },
+                {
+                  "label": "lang_hil",
+                  "value": "hil"
+                },
+                {
+                  "label": "lang_him",
+                  "value": "him"
+                },
+                {
+                  "label": "lang_hin",
+                  "value": "hin"
+                },
+                {
+                  "label": "lang_hit",
+                  "value": "hit"
+                },
+                {
+                  "label": "lang_hmn",
+                  "value": "hmn"
+                },
+                {
+                  "label": "lang_hmo",
+                  "value": "hmo"
+                },
+                {
+                  "label": "lang_hrv",
+                  "value": "hrv"
+                },
+                {
+                  "label": "lang_hsb",
+                  "value": "hsb"
+                },
+                {
+                  "label": "lang_hun",
+                  "value": "hun"
+                },
+                {
+                  "label": "lang_hup",
+                  "value": "hup"
+                },
+                {
+                  "label": "lang_iba",
+                  "value": "iba"
+                },
+                {
+                  "label": "lang_ibo",
+                  "value": "ibo"
+                },
+                {
+                  "label": "lang_ice",
+                  "value": "ice"
+                },
+                {
+                  "label": "lang_ido",
+                  "value": "ido"
+                },
+                {
+                  "label": "lang_iii",
+                  "value": "iii"
+                },
+                {
+                  "label": "lang_ijo",
+                  "value": "ijo"
+                },
+                {
+                  "label": "lang_iku",
+                  "value": "iku"
+                },
+                {
+                  "label": "lang_ile",
+                  "value": "ile"
+                },
+                {
+                  "label": "lang_ilo",
+                  "value": "ilo"
+                },
+                {
+                  "label": "lang_ina",
+                  "value": "ina"
+                },
+                {
+                  "label": "lang_inc",
+                  "value": "inc"
+                },
+                {
+                  "label": "lang_ind",
+                  "value": "ind"
+                },
+                {
+                  "label": "lang_ine",
+                  "value": "ine"
+                },
+                {
+                  "label": "lang_inh",
+                  "value": "inh"
+                },
+                {
+                  "label": "lang_ipk",
+                  "value": "ipk"
+                },
+                {
+                  "label": "lang_ira",
+                  "value": "ira"
+                },
+                {
+                  "label": "lang_iro",
+                  "value": "iro"
+                },
+                {
+                  "label": "lang_ita",
+                  "value": "ita",
+                  "preferred": true
+                },
+                {
+                  "label": "lang_jav",
+                  "value": "jav"
+                },
+                {
+                  "label": "lang_jbo",
+                  "value": "jbo"
+                },
+                {
+                  "label": "lang_jpn",
+                  "value": "jpn"
+                },
+                {
+                  "label": "lang_jpr",
+                  "value": "jpr"
+                },
+                {
+                  "label": "lang_jrb",
+                  "value": "jrb"
+                },
+                {
+                  "label": "lang_kaa",
+                  "value": "kaa"
+                },
+                {
+                  "label": "lang_kab",
+                  "value": "kab"
+                },
+                {
+                  "label": "lang_kac",
+                  "value": "kac"
+                },
+                {
+                  "label": "lang_kal",
+                  "value": "kal"
+                },
+                {
+                  "label": "lang_kam",
+                  "value": "kam"
+                },
+                {
+                  "label": "lang_kan",
+                  "value": "kan"
+                },
+                {
+                  "label": "lang_kar",
+                  "value": "kar"
+                },
+                {
+                  "label": "lang_kas",
+                  "value": "kas"
+                },
+                {
+                  "label": "lang_kau",
+                  "value": "kau"
+                },
+                {
+                  "label": "lang_kaw",
+                  "value": "kaw"
+                },
+                {
+                  "label": "lang_kaz",
+                  "value": "kaz"
+                },
+                {
+                  "label": "lang_kbd",
+                  "value": "kbd"
+                },
+                {
+                  "label": "lang_kha",
+                  "value": "kha"
+                },
+                {
+                  "label": "lang_khi",
+                  "value": "khi"
+                },
+                {
+                  "label": "lang_khm",
+                  "value": "khm"
+                },
+                {
+                  "label": "lang_kho",
+                  "value": "kho"
+                },
+                {
+                  "label": "lang_kik",
+                  "value": "kik"
+                },
+                {
+                  "label": "lang_kin",
+                  "value": "kin"
+                },
+                {
+                  "label": "lang_kir",
+                  "value": "kir"
+                },
+                {
+                  "label": "lang_kmb",
+                  "value": "kmb"
+                },
+                {
+                  "label": "lang_kok",
+                  "value": "kok"
+                },
+                {
+                  "label": "lang_kom",
+                  "value": "kom"
+                },
+                {
+                  "label": "lang_kon",
+                  "value": "kon"
+                },
+                {
+                  "label": "lang_kor",
+                  "value": "kor"
+                },
+                {
+                  "label": "lang_kos",
+                  "value": "kos"
+                },
+                {
+                  "label": "lang_kpe",
+                  "value": "kpe"
+                },
+                {
+                  "label": "lang_krc",
+                  "value": "krc"
+                },
+                {
+                  "label": "lang_krl",
+                  "value": "krl"
+                },
+                {
+                  "label": "lang_kro",
+                  "value": "kro"
+                },
+                {
+                  "label": "lang_kru",
+                  "value": "kru"
+                },
+                {
+                  "label": "lang_kua",
+                  "value": "kua"
+                },
+                {
+                  "label": "lang_kum",
+                  "value": "kum"
+                },
+                {
+                  "label": "lang_kur",
+                  "value": "kur"
+                },
+                {
+                  "label": "lang_kut",
+                  "value": "kut"
+                },
+                {
+                  "label": "lang_lad",
+                  "value": "lad"
+                },
+                {
+                  "label": "lang_lah",
+                  "value": "lah"
+                },
+                {
+                  "label": "lang_lam",
+                  "value": "lam"
+                },
+                {
+                  "label": "lang_lao",
+                  "value": "lao"
+                },
+                {
+                  "label": "lang_lat",
+                  "value": "lat"
+                },
+                {
+                  "label": "lang_lav",
+                  "value": "lav"
+                },
+                {
+                  "label": "lang_lez",
+                  "value": "lez"
+                },
+                {
+                  "label": "lang_lim",
+                  "value": "lim"
+                },
+                {
+                  "label": "lang_lin",
+                  "value": "lin"
+                },
+                {
+                  "label": "lang_lit",
+                  "value": "lit"
+                },
+                {
+                  "label": "lang_lol",
+                  "value": "lol"
+                },
+                {
+                  "label": "lang_loz",
+                  "value": "loz"
+                },
+                {
+                  "label": "lang_ltz",
+                  "value": "ltz"
+                },
+                {
+                  "label": "lang_lua",
+                  "value": "lua"
+                },
+                {
+                  "label": "lang_lub",
+                  "value": "lub"
+                },
+                {
+                  "label": "lang_lug",
+                  "value": "lug"
+                },
+                {
+                  "label": "lang_lui",
+                  "value": "lui"
+                },
+                {
+                  "label": "lang_lun",
+                  "value": "lun"
+                },
+                {
+                  "label": "lang_luo",
+                  "value": "luo"
+                },
+                {
+                  "label": "lang_lus",
+                  "value": "lus"
+                },
+                {
+                  "label": "lang_mac",
+                  "value": "mac"
+                },
+                {
+                  "label": "lang_mad",
+                  "value": "mad"
+                },
+                {
+                  "label": "lang_mag",
+                  "value": "mag"
+                },
+                {
+                  "label": "lang_mah",
+                  "value": "mah"
+                },
+                {
+                  "label": "lang_mai",
+                  "value": "mai"
+                },
+                {
+                  "label": "lang_mak",
+                  "value": "mak"
+                },
+                {
+                  "label": "lang_mal",
+                  "value": "mal"
+                },
+                {
+                  "label": "lang_man",
+                  "value": "man"
+                },
+                {
+                  "label": "lang_mao",
+                  "value": "mao"
+                },
+                {
+                  "label": "lang_map",
+                  "value": "map"
+                },
+                {
+                  "label": "lang_mar",
+                  "value": "mar"
+                },
+                {
+                  "label": "lang_mas",
+                  "value": "mas"
+                },
+                {
+                  "label": "lang_may",
+                  "value": "may"
+                },
+                {
+                  "label": "lang_mdf",
+                  "value": "mdf"
+                },
+                {
+                  "label": "lang_mdr",
+                  "value": "mdr"
+                },
+                {
+                  "label": "lang_men",
+                  "value": "men"
+                },
+                {
+                  "label": "lang_mga",
+                  "value": "mga"
+                },
+                {
+                  "label": "lang_mic",
+                  "value": "mic"
+                },
+                {
+                  "label": "lang_min",
+                  "value": "min"
+                },
+                {
+                  "label": "lang_mis",
+                  "value": "mis"
+                },
+                {
+                  "label": "lang_mkh",
+                  "value": "mkh"
+                },
+                {
+                  "label": "lang_mlg",
+                  "value": "mlg"
+                },
+                {
+                  "label": "lang_mlt",
+                  "value": "mlt"
+                },
+                {
+                  "label": "lang_mnc",
+                  "value": "mnc"
+                },
+                {
+                  "label": "lang_mni",
+                  "value": "mni"
+                },
+                {
+                  "label": "lang_mno",
+                  "value": "mno"
+                },
+                {
+                  "label": "lang_moh",
+                  "value": "moh"
+                },
+                {
+                  "label": "lang_mon",
+                  "value": "mon"
+                },
+                {
+                  "label": "lang_mos",
+                  "value": "mos"
+                },
+                {
+                  "label": "lang_mul",
+                  "value": "mul"
+                },
+                {
+                  "label": "lang_mun",
+                  "value": "mun"
+                },
+                {
+                  "label": "lang_mus",
+                  "value": "mus"
+                },
+                {
+                  "label": "lang_mwl",
+                  "value": "mwl"
+                },
+                {
+                  "label": "lang_mwr",
+                  "value": "mwr"
+                },
+                {
+                  "label": "lang_myn",
+                  "value": "myn"
+                },
+                {
+                  "label": "lang_myv",
+                  "value": "myv"
+                },
+                {
+                  "label": "lang_nah",
+                  "value": "nah"
+                },
+                {
+                  "label": "lang_nai",
+                  "value": "nai"
+                },
+                {
+                  "label": "lang_nap",
+                  "value": "nap"
+                },
+                {
+                  "label": "lang_nau",
+                  "value": "nau"
+                },
+                {
+                  "label": "lang_nav",
+                  "value": "nav"
+                },
+                {
+                  "label": "lang_nbl",
+                  "value": "nbl"
+                },
+                {
+                  "label": "lang_nde",
+                  "value": "nde"
+                },
+                {
+                  "label": "lang_ndo",
+                  "value": "ndo"
+                },
+                {
+                  "label": "lang_nds",
+                  "value": "nds"
+                },
+                {
+                  "label": "lang_nep",
+                  "value": "nep"
+                },
+                {
+                  "label": "lang_new",
+                  "value": "new"
+                },
+                {
+                  "label": "lang_nia",
+                  "value": "nia"
+                },
+                {
+                  "label": "lang_nic",
+                  "value": "nic"
+                },
+                {
+                  "label": "lang_niu",
+                  "value": "niu"
+                },
+                {
+                  "label": "lang_nno",
+                  "value": "nno"
+                },
+                {
+                  "label": "lang_nob",
+                  "value": "nob"
+                },
+                {
+                  "label": "lang_nog",
+                  "value": "nog"
+                },
+                {
+                  "label": "lang_non",
+                  "value": "non"
+                },
+                {
+                  "label": "lang_nor",
+                  "value": "nor"
+                },
+                {
+                  "label": "lang_nqo",
+                  "value": "nqo"
+                },
+                {
+                  "label": "lang_nso",
+                  "value": "nso"
+                },
+                {
+                  "label": "lang_nub",
+                  "value": "nub"
+                },
+                {
+                  "label": "lang_nwc",
+                  "value": "nwc"
+                },
+                {
+                  "label": "lang_nya",
+                  "value": "nya"
+                },
+                {
+                  "label": "lang_nym",
+                  "value": "nym"
+                },
+                {
+                  "label": "lang_nyn",
+                  "value": "nyn"
+                },
+                {
+                  "label": "lang_nyo",
+                  "value": "nyo"
+                },
+                {
+                  "label": "lang_nzi",
+                  "value": "nzi"
+                },
+                {
+                  "label": "lang_oci",
+                  "value": "oci"
+                },
+                {
+                  "label": "lang_oji",
+                  "value": "oji"
+                },
+                {
+                  "label": "lang_ori",
+                  "value": "ori"
+                },
+                {
+                  "label": "lang_orm",
+                  "value": "orm"
+                },
+                {
+                  "label": "lang_osa",
+                  "value": "osa"
+                },
+                {
+                  "label": "lang_oss",
+                  "value": "oss"
+                },
+                {
+                  "label": "lang_ota",
+                  "value": "ota"
+                },
+                {
+                  "label": "lang_oto",
+                  "value": "oto"
+                },
+                {
+                  "label": "lang_paa",
+                  "value": "paa"
+                },
+                {
+                  "label": "lang_pag",
+                  "value": "pag"
+                },
+                {
+                  "label": "lang_pal",
+                  "value": "pal"
+                },
+                {
+                  "label": "lang_pam",
+                  "value": "pam"
+                },
+                {
+                  "label": "lang_pan",
+                  "value": "pan"
+                },
+                {
+                  "label": "lang_pap",
+                  "value": "pap"
+                },
+                {
+                  "label": "lang_pau",
+                  "value": "pau"
+                },
+                {
+                  "label": "lang_peo",
+                  "value": "peo"
+                },
+                {
+                  "label": "lang_per",
+                  "value": "per"
+                },
+                {
+                  "label": "lang_phi",
+                  "value": "phi"
+                },
+                {
+                  "label": "lang_phn",
+                  "value": "phn"
+                },
+                {
+                  "label": "lang_pli",
+                  "value": "pli"
+                },
+                {
+                  "label": "lang_pol",
+                  "value": "pol"
+                },
+                {
+                  "label": "lang_pon",
+                  "value": "pon"
+                },
+                {
+                  "label": "lang_por",
+                  "value": "por"
+                },
+                {
+                  "label": "lang_pra",
+                  "value": "pra"
+                },
+                {
+                  "label": "lang_pro",
+                  "value": "pro"
+                },
+                {
+                  "label": "lang_pus",
+                  "value": "pus"
+                },
+                {
+                  "label": "lang_que",
+                  "value": "que"
+                },
+                {
+                  "label": "lang_raj",
+                  "value": "raj"
+                },
+                {
+                  "label": "lang_rap",
+                  "value": "rap"
+                },
+                {
+                  "label": "lang_rar",
+                  "value": "rar"
+                },
+                {
+                  "label": "lang_roa",
+                  "value": "roa"
+                },
+                {
+                  "label": "lang_roh",
+                  "value": "roh"
+                },
+                {
+                  "label": "lang_rom",
+                  "value": "rom"
+                },
+                {
+                  "label": "lang_rum",
+                  "value": "rum"
+                },
+                {
+                  "label": "lang_run",
+                  "value": "run"
+                },
+                {
+                  "label": "lang_rup",
+                  "value": "rup"
+                },
+                {
+                  "label": "lang_rus",
+                  "value": "rus"
+                },
+                {
+                  "label": "lang_sad",
+                  "value": "sad"
+                },
+                {
+                  "label": "lang_sag",
+                  "value": "sag"
+                },
+                {
+                  "label": "lang_sah",
+                  "value": "sah"
+                },
+                {
+                  "label": "lang_sai",
+                  "value": "sai"
+                },
+                {
+                  "label": "lang_sal",
+                  "value": "sal"
+                },
+                {
+                  "label": "lang_sam",
+                  "value": "sam"
+                },
+                {
+                  "label": "lang_san",
+                  "value": "san"
+                },
+                {
+                  "label": "lang_sas",
+                  "value": "sas"
+                },
+                {
+                  "label": "lang_sat",
+                  "value": "sat"
+                },
+                {
+                  "label": "lang_scn",
+                  "value": "scn"
+                },
+                {
+                  "label": "lang_sco",
+                  "value": "sco"
+                },
+                {
+                  "label": "lang_sel",
+                  "value": "sel"
+                },
+                {
+                  "label": "lang_sem",
+                  "value": "sem"
+                },
+                {
+                  "label": "lang_sga",
+                  "value": "sga"
+                },
+                {
+                  "label": "lang_sgn",
+                  "value": "sgn"
+                },
+                {
+                  "label": "lang_shn",
+                  "value": "shn"
+                },
+                {
+                  "label": "lang_sid",
+                  "value": "sid"
+                },
+                {
+                  "label": "lang_sin",
+                  "value": "sin"
+                },
+                {
+                  "label": "lang_sio",
+                  "value": "sio"
+                },
+                {
+                  "label": "lang_sit",
+                  "value": "sit"
+                },
+                {
+                  "label": "lang_sla",
+                  "value": "sla"
+                },
+                {
+                  "label": "lang_slo",
+                  "value": "slo"
+                },
+                {
+                  "label": "lang_slv",
+                  "value": "slv"
+                },
+                {
+                  "label": "lang_sma",
+                  "value": "sma"
+                },
+                {
+                  "label": "lang_sme",
+                  "value": "sme"
+                },
+                {
+                  "label": "lang_smi",
+                  "value": "smi"
+                },
+                {
+                  "label": "lang_smj",
+                  "value": "smj"
+                },
+                {
+                  "label": "lang_smn",
+                  "value": "smn"
+                },
+                {
+                  "label": "lang_smo",
+                  "value": "smo"
+                },
+                {
+                  "label": "lang_sms",
+                  "value": "sms"
+                },
+                {
+                  "label": "lang_sna",
+                  "value": "sna"
+                },
+                {
+                  "label": "lang_snd",
+                  "value": "snd"
+                },
+                {
+                  "label": "lang_snk",
+                  "value": "snk"
+                },
+                {
+                  "label": "lang_sog",
+                  "value": "sog"
+                },
+                {
+                  "label": "lang_som",
+                  "value": "som"
+                },
+                {
+                  "label": "lang_son",
+                  "value": "son"
+                },
+                {
+                  "label": "lang_sot",
+                  "value": "sot"
+                },
+                {
+                  "label": "lang_spa",
+                  "value": "spa"
+                },
+                {
+                  "label": "lang_srd",
+                  "value": "srd"
+                },
+                {
+                  "label": "lang_srn",
+                  "value": "srn"
+                },
+                {
+                  "label": "lang_srp",
+                  "value": "srp"
+                },
+                {
+                  "label": "lang_srr",
+                  "value": "srr"
+                },
+                {
+                  "label": "lang_ssa",
+                  "value": "ssa"
+                },
+                {
+                  "label": "lang_ssw",
+                  "value": "ssw"
+                },
+                {
+                  "label": "lang_suk",
+                  "value": "suk"
+                },
+                {
+                  "label": "lang_sun",
+                  "value": "sun"
+                },
+                {
+                  "label": "lang_sus",
+                  "value": "sus"
+                },
+                {
+                  "label": "lang_sux",
+                  "value": "sux"
+                },
+                {
+                  "label": "lang_swa",
+                  "value": "swa"
+                },
+                {
+                  "label": "lang_swe",
+                  "value": "swe"
+                },
+                {
+                  "label": "lang_syc",
+                  "value": "syc"
+                },
+                {
+                  "label": "lang_syr",
+                  "value": "syr"
+                },
+                {
+                  "label": "lang_tah",
+                  "value": "tah"
+                },
+                {
+                  "label": "lang_tai",
+                  "value": "tai"
+                },
+                {
+                  "label": "lang_tam",
+                  "value": "tam"
+                },
+                {
+                  "label": "lang_tat",
+                  "value": "tat"
+                },
+                {
+                  "label": "lang_tel",
+                  "value": "tel"
+                },
+                {
+                  "label": "lang_tem",
+                  "value": "tem"
+                },
+                {
+                  "label": "lang_ter",
+                  "value": "ter"
+                },
+                {
+                  "label": "lang_tet",
+                  "value": "tet"
+                },
+                {
+                  "label": "lang_tgk",
+                  "value": "tgk"
+                },
+                {
+                  "label": "lang_tgl",
+                  "value": "tgl"
+                },
+                {
+                  "label": "lang_tha",
+                  "value": "tha"
+                },
+                {
+                  "label": "lang_tib",
+                  "value": "tib"
+                },
+                {
+                  "label": "lang_tig",
+                  "value": "tig"
+                },
+                {
+                  "label": "lang_tir",
+                  "value": "tir"
+                },
+                {
+                  "label": "lang_tiv",
+                  "value": "tiv"
+                },
+                {
+                  "label": "lang_tkl",
+                  "value": "tkl"
+                },
+                {
+                  "label": "lang_tlh",
+                  "value": "tlh"
+                },
+                {
+                  "label": "lang_tli",
+                  "value": "tli"
+                },
+                {
+                  "label": "lang_tmh",
+                  "value": "tmh"
+                },
+                {
+                  "label": "lang_tog",
+                  "value": "tog"
+                },
+                {
+                  "label": "lang_ton",
+                  "value": "ton"
+                },
+                {
+                  "label": "lang_tpi",
+                  "value": "tpi"
+                },
+                {
+                  "label": "lang_tsi",
+                  "value": "tsi"
+                },
+                {
+                  "label": "lang_tsn",
+                  "value": "tsn"
+                },
+                {
+                  "label": "lang_tso",
+                  "value": "tso"
+                },
+                {
+                  "label": "lang_tuk",
+                  "value": "tuk"
+                },
+                {
+                  "label": "lang_tum",
+                  "value": "tum"
+                },
+                {
+                  "label": "lang_tup",
+                  "value": "tup"
+                },
+                {
+                  "label": "lang_tur",
+                  "value": "tur"
+                },
+                {
+                  "label": "lang_tut",
+                  "value": "tut"
+                },
+                {
+                  "label": "lang_tvl",
+                  "value": "tvl"
+                },
+                {
+                  "label": "lang_twi",
+                  "value": "twi"
+                },
+                {
+                  "label": "lang_tyv",
+                  "value": "tyv"
+                },
+                {
+                  "label": "lang_udm",
+                  "value": "udm"
+                },
+                {
+                  "label": "lang_uga",
+                  "value": "uga"
+                },
+                {
+                  "label": "lang_uig",
+                  "value": "uig"
+                },
+                {
+                  "label": "lang_ukr",
+                  "value": "ukr"
+                },
+                {
+                  "label": "lang_umb",
+                  "value": "umb"
+                },
+                {
+                  "label": "lang_und",
+                  "value": "und"
+                },
+                {
+                  "label": "lang_urd",
+                  "value": "urd"
+                },
+                {
+                  "label": "lang_uzb",
+                  "value": "uzb"
+                },
+                {
+                  "label": "lang_vai",
+                  "value": "vai"
+                },
+                {
+                  "label": "lang_ven",
+                  "value": "ven"
+                },
+                {
+                  "label": "lang_vie",
+                  "value": "vie"
+                },
+                {
+                  "label": "lang_vol",
+                  "value": "vol"
+                },
+                {
+                  "label": "lang_vot",
+                  "value": "vot"
+                },
+                {
+                  "label": "lang_wak",
+                  "value": "wak"
+                },
+                {
+                  "label": "lang_wal",
+                  "value": "wal"
+                },
+                {
+                  "label": "lang_war",
+                  "value": "war"
+                },
+                {
+                  "label": "lang_was",
+                  "value": "was"
+                },
+                {
+                  "label": "lang_wel",
+                  "value": "wel"
+                },
+                {
+                  "label": "lang_wen",
+                  "value": "wen"
+                },
+                {
+                  "label": "lang_wln",
+                  "value": "wln"
+                },
+                {
+                  "label": "lang_wol",
+                  "value": "wol"
+                },
+                {
+                  "label": "lang_xal",
+                  "value": "xal"
+                },
+                {
+                  "label": "lang_xho",
+                  "value": "xho"
+                },
+                {
+                  "label": "lang_yao",
+                  "value": "yao"
+                },
+                {
+                  "label": "lang_yap",
+                  "value": "yap"
+                },
+                {
+                  "label": "lang_yid",
+                  "value": "yid"
+                },
+                {
+                  "label": "lang_yor",
+                  "value": "yor"
+                },
+                {
+                  "label": "lang_ypk",
+                  "value": "ypk"
+                },
+                {
+                  "label": "lang_zap",
+                  "value": "zap"
+                },
+                {
+                  "label": "lang_zbl",
+                  "value": "zbl"
+                },
+                {
+                  "label": "lang_zen",
+                  "value": "zen"
+                },
+                {
+                  "label": "lang_zha",
+                  "value": "zha"
+                },
+                {
+                  "label": "lang_znd",
+                  "value": "znd"
+                },
+                {
+                  "label": "lang_zul",
+                  "value": "zul"
+                },
+                {
+                  "label": "lang_zun",
+                  "value": "zun"
+                },
+                {
+                  "label": "lang_zxx",
+                  "value": "zxx"
+                },
+                {
+                  "label": "lang_zza",
+                  "value": "zza"
+                }
+              ]
+            }
+          }
+        },
+        "propertiesOrder": [
+          "language",
+          "value"
+        ],
+        "required": [
+          "value",
+          "language"
+        ]
+      }
+    },
+    "description": {
+      "title": "Descriptions",
+      "type": "array",
+      "minItems": 0,
+      "items": {
+        "title": "Description",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "value": {
+            "title": "Value",
+            "type": "string",
+            "minLength": 1,
+            "form": {
+              "type": "textarea",
+              "templateOptions": {
+                "rows": 5
+              }
+            }
+          },
+          "language": {
+            "title": "Language",
+            "type": "string",
+            "enum": [
+              "aar",
+              "abk",
+              "ace",
+              "ach",
+              "ada",
+              "ady",
+              "afa",
+              "afh",
+              "afr",
+              "ain",
+              "aka",
+              "akk",
+              "alb",
+              "ale",
+              "alg",
+              "alt",
+              "amh",
+              "ang",
+              "anp",
+              "apa",
+              "ara",
+              "arc",
+              "arg",
+              "arm",
+              "arn",
+              "arp",
+              "art",
+              "arw",
+              "asm",
+              "ast",
+              "ath",
+              "aus",
+              "ava",
+              "ave",
+              "awa",
+              "aym",
+              "aze",
+              "bad",
+              "bai",
+              "bak",
+              "bal",
+              "bam",
+              "ban",
+              "baq",
+              "bas",
+              "bat",
+              "bej",
+              "bel",
+              "bem",
+              "ben",
+              "ber",
+              "bho",
+              "bih",
+              "bik",
+              "bin",
+              "bis",
+              "bla",
+              "bnt",
+              "bos",
+              "bra",
+              "bre",
+              "btk",
+              "bua",
+              "bug",
+              "bul",
+              "bur",
+              "byn",
+              "cad",
+              "cai",
+              "car",
+              "cat",
+              "cau",
+              "ceb",
+              "cel",
+              "cha",
+              "chb",
+              "che",
+              "chg",
+              "chi",
+              "chk",
+              "chm",
+              "chn",
+              "cho",
+              "chp",
+              "chr",
+              "chu",
+              "chv",
+              "chy",
+              "cmc",
+              "cnr",
+              "cop",
+              "cor",
+              "cos",
+              "cpe",
+              "cpf",
+              "cpp",
+              "cre",
+              "crh",
+              "crp",
+              "csb",
+              "cus",
+              "cze",
+              "dak",
+              "dan",
+              "dar",
+              "day",
+              "del",
+              "den",
+              "dgr",
+              "din",
+              "div",
+              "doi",
+              "dra",
+              "dsb",
+              "dua",
+              "dum",
+              "dut",
+              "dyu",
+              "dzo",
+              "efi",
+              "egy",
+              "eka",
+              "elx",
+              "eng",
+              "enm",
+              "epo",
+              "est",
+              "ewe",
+              "ewo",
+              "fan",
+              "fao",
+              "fat",
+              "fij",
+              "fil",
+              "fin",
+              "fiu",
+              "fon",
+              "fre",
+              "frm",
+              "fro",
+              "frr",
+              "frs",
+              "fry",
+              "ful",
+              "fur",
+              "gaa",
+              "gay",
+              "gba",
+              "gem",
+              "geo",
+              "ger",
+              "gez",
+              "gil",
+              "gla",
+              "gle",
+              "glg",
+              "glv",
+              "gmh",
+              "goh",
+              "gon",
+              "gor",
+              "got",
+              "grb",
+              "grc",
+              "gre",
+              "grn",
+              "gsw",
+              "guj",
+              "gwi",
+              "hai",
+              "hat",
+              "hau",
+              "haw",
+              "heb",
+              "her",
+              "hil",
+              "him",
+              "hin",
+              "hit",
+              "hmn",
+              "hmo",
+              "hrv",
+              "hsb",
+              "hun",
+              "hup",
+              "iba",
+              "ibo",
+              "ice",
+              "ido",
+              "iii",
+              "ijo",
+              "iku",
+              "ile",
+              "ilo",
+              "ina",
+              "inc",
+              "ind",
+              "ine",
+              "inh",
+              "ipk",
+              "ira",
+              "iro",
+              "ita",
+              "jav",
+              "jbo",
+              "jpn",
+              "jpr",
+              "jrb",
+              "kaa",
+              "kab",
+              "kac",
+              "kal",
+              "kam",
+              "kan",
+              "kar",
+              "kas",
+              "kau",
+              "kaw",
+              "kaz",
+              "kbd",
+              "kha",
+              "khi",
+              "khm",
+              "kho",
+              "kik",
+              "kin",
+              "kir",
+              "kmb",
+              "kok",
+              "kom",
+              "kon",
+              "kor",
+              "kos",
+              "kpe",
+              "krc",
+              "krl",
+              "kro",
+              "kru",
+              "kua",
+              "kum",
+              "kur",
+              "kut",
+              "lad",
+              "lah",
+              "lam",
+              "lao",
+              "lat",
+              "lav",
+              "lez",
+              "lim",
+              "lin",
+              "lit",
+              "lol",
+              "loz",
+              "ltz",
+              "lua",
+              "lub",
+              "lug",
+              "lui",
+              "lun",
+              "luo",
+              "lus",
+              "mac",
+              "mad",
+              "mag",
+              "mah",
+              "mai",
+              "mak",
+              "mal",
+              "man",
+              "mao",
+              "map",
+              "mar",
+              "mas",
+              "may",
+              "mdf",
+              "mdr",
+              "men",
+              "mga",
+              "mic",
+              "min",
+              "mis",
+              "mkh",
+              "mlg",
+              "mlt",
+              "mnc",
+              "mni",
+              "mno",
+              "moh",
+              "mon",
+              "mos",
+              "mul",
+              "mun",
+              "mus",
+              "mwl",
+              "mwr",
+              "myn",
+              "myv",
+              "nah",
+              "nai",
+              "nap",
+              "nau",
+              "nav",
+              "nbl",
+              "nde",
+              "ndo",
+              "nds",
+              "nep",
+              "new",
+              "nia",
+              "nic",
+              "niu",
+              "nno",
+              "nob",
+              "nog",
+              "non",
+              "nor",
+              "nqo",
+              "nso",
+              "nub",
+              "nwc",
+              "nya",
+              "nym",
+              "nyn",
+              "nyo",
+              "nzi",
+              "oci",
+              "oji",
+              "ori",
+              "orm",
+              "osa",
+              "oss",
+              "ota",
+              "oto",
+              "paa",
+              "pag",
+              "pal",
+              "pam",
+              "pan",
+              "pap",
+              "pau",
+              "peo",
+              "per",
+              "phi",
+              "phn",
+              "pli",
+              "pol",
+              "pon",
+              "por",
+              "pra",
+              "pro",
+              "pus",
+              "que",
+              "raj",
+              "rap",
+              "rar",
+              "roa",
+              "roh",
+              "rom",
+              "rum",
+              "run",
+              "rup",
+              "rus",
+              "sad",
+              "sag",
+              "sah",
+              "sai",
+              "sal",
+              "sam",
+              "san",
+              "sas",
+              "sat",
+              "scn",
+              "sco",
+              "sel",
+              "sem",
+              "sga",
+              "sgn",
+              "shn",
+              "sid",
+              "sin",
+              "sio",
+              "sit",
+              "sla",
+              "slo",
+              "slv",
+              "sma",
+              "sme",
+              "smi",
+              "smj",
+              "smn",
+              "smo",
+              "sms",
+              "sna",
+              "snd",
+              "snk",
+              "sog",
+              "som",
+              "son",
+              "sot",
+              "spa",
+              "srd",
+              "srn",
+              "srp",
+              "srr",
+              "ssa",
+              "ssw",
+              "suk",
+              "sun",
+              "sus",
+              "sux",
+              "swa",
+              "swe",
+              "syc",
+              "syr",
+              "tah",
+              "tai",
+              "tam",
+              "tat",
+              "tel",
+              "tem",
+              "ter",
+              "tet",
+              "tgk",
+              "tgl",
+              "tha",
+              "tib",
+              "tig",
+              "tir",
+              "tiv",
+              "tkl",
+              "tlh",
+              "tli",
+              "tmh",
+              "tog",
+              "ton",
+              "tpi",
+              "tsi",
+              "tsn",
+              "tso",
+              "tuk",
+              "tum",
+              "tup",
+              "tur",
+              "tut",
+              "tvl",
+              "twi",
+              "tyv",
+              "udm",
+              "uga",
+              "uig",
+              "ukr",
+              "umb",
+              "und",
+              "urd",
+              "uzb",
+              "vai",
+              "ven",
+              "vie",
+              "vol",
+              "vot",
+              "wak",
+              "wal",
+              "war",
+              "was",
+              "wel",
+              "wen",
+              "wln",
+              "wol",
+              "xal",
+              "xho",
+              "yao",
+              "yap",
+              "yid",
+              "yor",
+              "ypk",
+              "zap",
+              "zbl",
+              "zen",
+              "zha",
+              "znd",
+              "zul",
+              "zun",
+              "zxx",
+              "zza"
+            ],
+            "form": {
+              "templateOptions": {
+                "sort": true,
+                "wrappers": [
+                  "card"
+                ]
+              },
+              "options": [
+                {
+                  "label": "lang_aar",
+                  "value": "aar"
+                },
+                {
+                  "label": "lang_abk",
+                  "value": "abk"
+                },
+                {
+                  "label": "lang_ace",
+                  "value": "ace"
+                },
+                {
+                  "label": "lang_ach",
+                  "value": "ach"
+                },
+                {
+                  "label": "lang_ada",
+                  "value": "ada"
+                },
+                {
+                  "label": "lang_ady",
+                  "value": "ady"
+                },
+                {
+                  "label": "lang_afa",
+                  "value": "afa"
+                },
+                {
+                  "label": "lang_afh",
+                  "value": "afh"
+                },
+                {
+                  "label": "lang_afr",
+                  "value": "afr"
+                },
+                {
+                  "label": "lang_ain",
+                  "value": "ain"
+                },
+                {
+                  "label": "lang_aka",
+                  "value": "aka"
+                },
+                {
+                  "label": "lang_akk",
+                  "value": "akk"
+                },
+                {
+                  "label": "lang_alb",
+                  "value": "alb"
+                },
+                {
+                  "label": "lang_ale",
+                  "value": "ale"
+                },
+                {
+                  "label": "lang_alg",
+                  "value": "alg"
+                },
+                {
+                  "label": "lang_alt",
+                  "value": "alt"
+                },
+                {
+                  "label": "lang_amh",
+                  "value": "amh"
+                },
+                {
+                  "label": "lang_ang",
+                  "value": "ang"
+                },
+                {
+                  "label": "lang_anp",
+                  "value": "anp"
+                },
+                {
+                  "label": "lang_apa",
+                  "value": "apa"
+                },
+                {
+                  "label": "lang_ara",
+                  "value": "ara"
+                },
+                {
+                  "label": "lang_arc",
+                  "value": "arc"
+                },
+                {
+                  "label": "lang_arg",
+                  "value": "arg"
+                },
+                {
+                  "label": "lang_arm",
+                  "value": "arm"
+                },
+                {
+                  "label": "lang_arn",
+                  "value": "arn"
+                },
+                {
+                  "label": "lang_arp",
+                  "value": "arp"
+                },
+                {
+                  "label": "lang_art",
+                  "value": "art"
+                },
+                {
+                  "label": "lang_arw",
+                  "value": "arw"
+                },
+                {
+                  "label": "lang_asm",
+                  "value": "asm"
+                },
+                {
+                  "label": "lang_ast",
+                  "value": "ast"
+                },
+                {
+                  "label": "lang_ath",
+                  "value": "ath"
+                },
+                {
+                  "label": "lang_aus",
+                  "value": "aus"
+                },
+                {
+                  "label": "lang_ava",
+                  "value": "ava"
+                },
+                {
+                  "label": "lang_ave",
+                  "value": "ave"
+                },
+                {
+                  "label": "lang_awa",
+                  "value": "awa"
+                },
+                {
+                  "label": "lang_aym",
+                  "value": "aym"
+                },
+                {
+                  "label": "lang_aze",
+                  "value": "aze"
+                },
+                {
+                  "label": "lang_bad",
+                  "value": "bad"
+                },
+                {
+                  "label": "lang_bai",
+                  "value": "bai"
+                },
+                {
+                  "label": "lang_bak",
+                  "value": "bak"
+                },
+                {
+                  "label": "lang_bal",
+                  "value": "bal"
+                },
+                {
+                  "label": "lang_bam",
+                  "value": "bam"
+                },
+                {
+                  "label": "lang_ban",
+                  "value": "ban"
+                },
+                {
+                  "label": "lang_baq",
+                  "value": "baq"
+                },
+                {
+                  "label": "lang_bas",
+                  "value": "bas"
+                },
+                {
+                  "label": "lang_bat",
+                  "value": "bat"
+                },
+                {
+                  "label": "lang_bej",
+                  "value": "bej"
+                },
+                {
+                  "label": "lang_bel",
+                  "value": "bel"
+                },
+                {
+                  "label": "lang_bem",
+                  "value": "bem"
+                },
+                {
+                  "label": "lang_ben",
+                  "value": "ben"
+                },
+                {
+                  "label": "lang_ber",
+                  "value": "ber"
+                },
+                {
+                  "label": "lang_bho",
+                  "value": "bho"
+                },
+                {
+                  "label": "lang_bih",
+                  "value": "bih"
+                },
+                {
+                  "label": "lang_bik",
+                  "value": "bik"
+                },
+                {
+                  "label": "lang_bin",
+                  "value": "bin"
+                },
+                {
+                  "label": "lang_bis",
+                  "value": "bis"
+                },
+                {
+                  "label": "lang_bla",
+                  "value": "bla"
+                },
+                {
+                  "label": "lang_bnt",
+                  "value": "bnt"
+                },
+                {
+                  "label": "lang_bos",
+                  "value": "bos"
+                },
+                {
+                  "label": "lang_bra",
+                  "value": "bra"
+                },
+                {
+                  "label": "lang_bre",
+                  "value": "bre"
+                },
+                {
+                  "label": "lang_btk",
+                  "value": "btk"
+                },
+                {
+                  "label": "lang_bua",
+                  "value": "bua"
+                },
+                {
+                  "label": "lang_bug",
+                  "value": "bug"
+                },
+                {
+                  "label": "lang_bul",
+                  "value": "bul"
+                },
+                {
+                  "label": "lang_bur",
+                  "value": "bur"
+                },
+                {
+                  "label": "lang_byn",
+                  "value": "byn"
+                },
+                {
+                  "label": "lang_cad",
+                  "value": "cad"
+                },
+                {
+                  "label": "lang_cai",
+                  "value": "cai"
+                },
+                {
+                  "label": "lang_car",
+                  "value": "car"
+                },
+                {
+                  "label": "lang_cat",
+                  "value": "cat"
+                },
+                {
+                  "label": "lang_cau",
+                  "value": "cau"
+                },
+                {
+                  "label": "lang_ceb",
+                  "value": "ceb"
+                },
+                {
+                  "label": "lang_cel",
+                  "value": "cel"
+                },
+                {
+                  "label": "lang_cha",
+                  "value": "cha"
+                },
+                {
+                  "label": "lang_chb",
+                  "value": "chb"
+                },
+                {
+                  "label": "lang_che",
+                  "value": "che"
+                },
+                {
+                  "label": "lang_chg",
+                  "value": "chg"
+                },
+                {
+                  "label": "lang_chi",
+                  "value": "chi"
+                },
+                {
+                  "label": "lang_chk",
+                  "value": "chk"
+                },
+                {
+                  "label": "lang_chm",
+                  "value": "chm"
+                },
+                {
+                  "label": "lang_chn",
+                  "value": "chn"
+                },
+                {
+                  "label": "lang_cho",
+                  "value": "cho"
+                },
+                {
+                  "label": "lang_chp",
+                  "value": "chp"
+                },
+                {
+                  "label": "lang_chr",
+                  "value": "chr"
+                },
+                {
+                  "label": "lang_chu",
+                  "value": "chu"
+                },
+                {
+                  "label": "lang_chv",
+                  "value": "chv"
+                },
+                {
+                  "label": "lang_chy",
+                  "value": "chy"
+                },
+                {
+                  "label": "lang_cmc",
+                  "value": "cmc"
+                },
+                {
+                  "label": "lang_cnr",
+                  "value": "cnr"
+                },
+                {
+                  "label": "lang_cop",
+                  "value": "cop"
+                },
+                {
+                  "label": "lang_cor",
+                  "value": "cor"
+                },
+                {
+                  "label": "lang_cos",
+                  "value": "cos"
+                },
+                {
+                  "label": "lang_cpe",
+                  "value": "cpe"
+                },
+                {
+                  "label": "lang_cpf",
+                  "value": "cpf"
+                },
+                {
+                  "label": "lang_cpp",
+                  "value": "cpp"
+                },
+                {
+                  "label": "lang_cre",
+                  "value": "cre"
+                },
+                {
+                  "label": "lang_crh",
+                  "value": "crh"
+                },
+                {
+                  "label": "lang_crp",
+                  "value": "crp"
+                },
+                {
+                  "label": "lang_csb",
+                  "value": "csb"
+                },
+                {
+                  "label": "lang_cus",
+                  "value": "cus"
+                },
+                {
+                  "label": "lang_cze",
+                  "value": "cze"
+                },
+                {
+                  "label": "lang_dak",
+                  "value": "dak"
+                },
+                {
+                  "label": "lang_dan",
+                  "value": "dan"
+                },
+                {
+                  "label": "lang_dar",
+                  "value": "dar"
+                },
+                {
+                  "label": "lang_day",
+                  "value": "day"
+                },
+                {
+                  "label": "lang_del",
+                  "value": "del"
+                },
+                {
+                  "label": "lang_den",
+                  "value": "den"
+                },
+                {
+                  "label": "lang_dgr",
+                  "value": "dgr"
+                },
+                {
+                  "label": "lang_din",
+                  "value": "din"
+                },
+                {
+                  "label": "lang_div",
+                  "value": "div"
+                },
+                {
+                  "label": "lang_doi",
+                  "value": "doi"
+                },
+                {
+                  "label": "lang_dra",
+                  "value": "dra"
+                },
+                {
+                  "label": "lang_dsb",
+                  "value": "dsb"
+                },
+                {
+                  "label": "lang_dua",
+                  "value": "dua"
+                },
+                {
+                  "label": "lang_dum",
+                  "value": "dum"
+                },
+                {
+                  "label": "lang_dut",
+                  "value": "dut"
+                },
+                {
+                  "label": "lang_dyu",
+                  "value": "dyu"
+                },
+                {
+                  "label": "lang_dzo",
+                  "value": "dzo"
+                },
+                {
+                  "label": "lang_efi",
+                  "value": "efi"
+                },
+                {
+                  "label": "lang_egy",
+                  "value": "egy"
+                },
+                {
+                  "label": "lang_eka",
+                  "value": "eka"
+                },
+                {
+                  "label": "lang_elx",
+                  "value": "elx"
+                },
+                {
+                  "label": "lang_eng",
+                  "value": "eng",
+                  "preferred": true
+                },
+                {
+                  "label": "lang_enm",
+                  "value": "enm"
+                },
+                {
+                  "label": "lang_epo",
+                  "value": "epo"
+                },
+                {
+                  "label": "lang_est",
+                  "value": "est"
+                },
+                {
+                  "label": "lang_ewe",
+                  "value": "ewe"
+                },
+                {
+                  "label": "lang_ewo",
+                  "value": "ewo"
+                },
+                {
+                  "label": "lang_fan",
+                  "value": "fan"
+                },
+                {
+                  "label": "lang_fao",
+                  "value": "fao"
+                },
+                {
+                  "label": "lang_fat",
+                  "value": "fat"
+                },
+                {
+                  "label": "lang_fij",
+                  "value": "fij"
+                },
+                {
+                  "label": "lang_fil",
+                  "value": "fil"
+                },
+                {
+                  "label": "lang_fin",
+                  "value": "fin"
+                },
+                {
+                  "label": "lang_fiu",
+                  "value": "fiu"
+                },
+                {
+                  "label": "lang_fon",
+                  "value": "fon"
+                },
+                {
+                  "label": "lang_fre",
+                  "value": "fre",
+                  "preferred": true
+                },
+                {
+                  "label": "lang_frm",
+                  "value": "frm"
+                },
+                {
+                  "label": "lang_fro",
+                  "value": "fro"
+                },
+                {
+                  "label": "lang_frr",
+                  "value": "frr"
+                },
+                {
+                  "label": "lang_frs",
+                  "value": "frs"
+                },
+                {
+                  "label": "lang_fry",
+                  "value": "fry"
+                },
+                {
+                  "label": "lang_ful",
+                  "value": "ful"
+                },
+                {
+                  "label": "lang_fur",
+                  "value": "fur"
+                },
+                {
+                  "label": "lang_gaa",
+                  "value": "gaa"
+                },
+                {
+                  "label": "lang_gay",
+                  "value": "gay"
+                },
+                {
+                  "label": "lang_gba",
+                  "value": "gba"
+                },
+                {
+                  "label": "lang_gem",
+                  "value": "gem"
+                },
+                {
+                  "label": "lang_geo",
+                  "value": "geo"
+                },
+                {
+                  "label": "lang_ger",
+                  "value": "ger",
+                  "preferred": true
+                },
+                {
+                  "label": "lang_gez",
+                  "value": "gez"
+                },
+                {
+                  "label": "lang_gil",
+                  "value": "gil"
+                },
+                {
+                  "label": "lang_gla",
+                  "value": "gla"
+                },
+                {
+                  "label": "lang_gle",
+                  "value": "gle"
+                },
+                {
+                  "label": "lang_glg",
+                  "value": "glg"
+                },
+                {
+                  "label": "lang_glv",
+                  "value": "glv"
+                },
+                {
+                  "label": "lang_gmh",
+                  "value": "gmh"
+                },
+                {
+                  "label": "lang_goh",
+                  "value": "goh"
+                },
+                {
+                  "label": "lang_gon",
+                  "value": "gon"
+                },
+                {
+                  "label": "lang_gor",
+                  "value": "gor"
+                },
+                {
+                  "label": "lang_got",
+                  "value": "got"
+                },
+                {
+                  "label": "lang_grb",
+                  "value": "grb"
+                },
+                {
+                  "label": "lang_grc",
+                  "value": "grc"
+                },
+                {
+                  "label": "lang_gre",
+                  "value": "gre"
+                },
+                {
+                  "label": "lang_grn",
+                  "value": "grn"
+                },
+                {
+                  "label": "lang_gsw",
+                  "value": "gsw"
+                },
+                {
+                  "label": "lang_guj",
+                  "value": "guj"
+                },
+                {
+                  "label": "lang_gwi",
+                  "value": "gwi"
+                },
+                {
+                  "label": "lang_hai",
+                  "value": "hai"
+                },
+                {
+                  "label": "lang_hat",
+                  "value": "hat"
+                },
+                {
+                  "label": "lang_hau",
+                  "value": "hau"
+                },
+                {
+                  "label": "lang_haw",
+                  "value": "haw"
+                },
+                {
+                  "label": "lang_heb",
+                  "value": "heb"
+                },
+                {
+                  "label": "lang_her",
+                  "value": "her"
+                },
+                {
+                  "label": "lang_hil",
+                  "value": "hil"
+                },
+                {
+                  "label": "lang_him",
+                  "value": "him"
+                },
+                {
+                  "label": "lang_hin",
+                  "value": "hin"
+                },
+                {
+                  "label": "lang_hit",
+                  "value": "hit"
+                },
+                {
+                  "label": "lang_hmn",
+                  "value": "hmn"
+                },
+                {
+                  "label": "lang_hmo",
+                  "value": "hmo"
+                },
+                {
+                  "label": "lang_hrv",
+                  "value": "hrv"
+                },
+                {
+                  "label": "lang_hsb",
+                  "value": "hsb"
+                },
+                {
+                  "label": "lang_hun",
+                  "value": "hun"
+                },
+                {
+                  "label": "lang_hup",
+                  "value": "hup"
+                },
+                {
+                  "label": "lang_iba",
+                  "value": "iba"
+                },
+                {
+                  "label": "lang_ibo",
+                  "value": "ibo"
+                },
+                {
+                  "label": "lang_ice",
+                  "value": "ice"
+                },
+                {
+                  "label": "lang_ido",
+                  "value": "ido"
+                },
+                {
+                  "label": "lang_iii",
+                  "value": "iii"
+                },
+                {
+                  "label": "lang_ijo",
+                  "value": "ijo"
+                },
+                {
+                  "label": "lang_iku",
+                  "value": "iku"
+                },
+                {
+                  "label": "lang_ile",
+                  "value": "ile"
+                },
+                {
+                  "label": "lang_ilo",
+                  "value": "ilo"
+                },
+                {
+                  "label": "lang_ina",
+                  "value": "ina"
+                },
+                {
+                  "label": "lang_inc",
+                  "value": "inc"
+                },
+                {
+                  "label": "lang_ind",
+                  "value": "ind"
+                },
+                {
+                  "label": "lang_ine",
+                  "value": "ine"
+                },
+                {
+                  "label": "lang_inh",
+                  "value": "inh"
+                },
+                {
+                  "label": "lang_ipk",
+                  "value": "ipk"
+                },
+                {
+                  "label": "lang_ira",
+                  "value": "ira"
+                },
+                {
+                  "label": "lang_iro",
+                  "value": "iro"
+                },
+                {
+                  "label": "lang_ita",
+                  "value": "ita",
+                  "preferred": true
+                },
+                {
+                  "label": "lang_jav",
+                  "value": "jav"
+                },
+                {
+                  "label": "lang_jbo",
+                  "value": "jbo"
+                },
+                {
+                  "label": "lang_jpn",
+                  "value": "jpn"
+                },
+                {
+                  "label": "lang_jpr",
+                  "value": "jpr"
+                },
+                {
+                  "label": "lang_jrb",
+                  "value": "jrb"
+                },
+                {
+                  "label": "lang_kaa",
+                  "value": "kaa"
+                },
+                {
+                  "label": "lang_kab",
+                  "value": "kab"
+                },
+                {
+                  "label": "lang_kac",
+                  "value": "kac"
+                },
+                {
+                  "label": "lang_kal",
+                  "value": "kal"
+                },
+                {
+                  "label": "lang_kam",
+                  "value": "kam"
+                },
+                {
+                  "label": "lang_kan",
+                  "value": "kan"
+                },
+                {
+                  "label": "lang_kar",
+                  "value": "kar"
+                },
+                {
+                  "label": "lang_kas",
+                  "value": "kas"
+                },
+                {
+                  "label": "lang_kau",
+                  "value": "kau"
+                },
+                {
+                  "label": "lang_kaw",
+                  "value": "kaw"
+                },
+                {
+                  "label": "lang_kaz",
+                  "value": "kaz"
+                },
+                {
+                  "label": "lang_kbd",
+                  "value": "kbd"
+                },
+                {
+                  "label": "lang_kha",
+                  "value": "kha"
+                },
+                {
+                  "label": "lang_khi",
+                  "value": "khi"
+                },
+                {
+                  "label": "lang_khm",
+                  "value": "khm"
+                },
+                {
+                  "label": "lang_kho",
+                  "value": "kho"
+                },
+                {
+                  "label": "lang_kik",
+                  "value": "kik"
+                },
+                {
+                  "label": "lang_kin",
+                  "value": "kin"
+                },
+                {
+                  "label": "lang_kir",
+                  "value": "kir"
+                },
+                {
+                  "label": "lang_kmb",
+                  "value": "kmb"
+                },
+                {
+                  "label": "lang_kok",
+                  "value": "kok"
+                },
+                {
+                  "label": "lang_kom",
+                  "value": "kom"
+                },
+                {
+                  "label": "lang_kon",
+                  "value": "kon"
+                },
+                {
+                  "label": "lang_kor",
+                  "value": "kor"
+                },
+                {
+                  "label": "lang_kos",
+                  "value": "kos"
+                },
+                {
+                  "label": "lang_kpe",
+                  "value": "kpe"
+                },
+                {
+                  "label": "lang_krc",
+                  "value": "krc"
+                },
+                {
+                  "label": "lang_krl",
+                  "value": "krl"
+                },
+                {
+                  "label": "lang_kro",
+                  "value": "kro"
+                },
+                {
+                  "label": "lang_kru",
+                  "value": "kru"
+                },
+                {
+                  "label": "lang_kua",
+                  "value": "kua"
+                },
+                {
+                  "label": "lang_kum",
+                  "value": "kum"
+                },
+                {
+                  "label": "lang_kur",
+                  "value": "kur"
+                },
+                {
+                  "label": "lang_kut",
+                  "value": "kut"
+                },
+                {
+                  "label": "lang_lad",
+                  "value": "lad"
+                },
+                {
+                  "label": "lang_lah",
+                  "value": "lah"
+                },
+                {
+                  "label": "lang_lam",
+                  "value": "lam"
+                },
+                {
+                  "label": "lang_lao",
+                  "value": "lao"
+                },
+                {
+                  "label": "lang_lat",
+                  "value": "lat"
+                },
+                {
+                  "label": "lang_lav",
+                  "value": "lav"
+                },
+                {
+                  "label": "lang_lez",
+                  "value": "lez"
+                },
+                {
+                  "label": "lang_lim",
+                  "value": "lim"
+                },
+                {
+                  "label": "lang_lin",
+                  "value": "lin"
+                },
+                {
+                  "label": "lang_lit",
+                  "value": "lit"
+                },
+                {
+                  "label": "lang_lol",
+                  "value": "lol"
+                },
+                {
+                  "label": "lang_loz",
+                  "value": "loz"
+                },
+                {
+                  "label": "lang_ltz",
+                  "value": "ltz"
+                },
+                {
+                  "label": "lang_lua",
+                  "value": "lua"
+                },
+                {
+                  "label": "lang_lub",
+                  "value": "lub"
+                },
+                {
+                  "label": "lang_lug",
+                  "value": "lug"
+                },
+                {
+                  "label": "lang_lui",
+                  "value": "lui"
+                },
+                {
+                  "label": "lang_lun",
+                  "value": "lun"
+                },
+                {
+                  "label": "lang_luo",
+                  "value": "luo"
+                },
+                {
+                  "label": "lang_lus",
+                  "value": "lus"
+                },
+                {
+                  "label": "lang_mac",
+                  "value": "mac"
+                },
+                {
+                  "label": "lang_mad",
+                  "value": "mad"
+                },
+                {
+                  "label": "lang_mag",
+                  "value": "mag"
+                },
+                {
+                  "label": "lang_mah",
+                  "value": "mah"
+                },
+                {
+                  "label": "lang_mai",
+                  "value": "mai"
+                },
+                {
+                  "label": "lang_mak",
+                  "value": "mak"
+                },
+                {
+                  "label": "lang_mal",
+                  "value": "mal"
+                },
+                {
+                  "label": "lang_man",
+                  "value": "man"
+                },
+                {
+                  "label": "lang_mao",
+                  "value": "mao"
+                },
+                {
+                  "label": "lang_map",
+                  "value": "map"
+                },
+                {
+                  "label": "lang_mar",
+                  "value": "mar"
+                },
+                {
+                  "label": "lang_mas",
+                  "value": "mas"
+                },
+                {
+                  "label": "lang_may",
+                  "value": "may"
+                },
+                {
+                  "label": "lang_mdf",
+                  "value": "mdf"
+                },
+                {
+                  "label": "lang_mdr",
+                  "value": "mdr"
+                },
+                {
+                  "label": "lang_men",
+                  "value": "men"
+                },
+                {
+                  "label": "lang_mga",
+                  "value": "mga"
+                },
+                {
+                  "label": "lang_mic",
+                  "value": "mic"
+                },
+                {
+                  "label": "lang_min",
+                  "value": "min"
+                },
+                {
+                  "label": "lang_mis",
+                  "value": "mis"
+                },
+                {
+                  "label": "lang_mkh",
+                  "value": "mkh"
+                },
+                {
+                  "label": "lang_mlg",
+                  "value": "mlg"
+                },
+                {
+                  "label": "lang_mlt",
+                  "value": "mlt"
+                },
+                {
+                  "label": "lang_mnc",
+                  "value": "mnc"
+                },
+                {
+                  "label": "lang_mni",
+                  "value": "mni"
+                },
+                {
+                  "label": "lang_mno",
+                  "value": "mno"
+                },
+                {
+                  "label": "lang_moh",
+                  "value": "moh"
+                },
+                {
+                  "label": "lang_mon",
+                  "value": "mon"
+                },
+                {
+                  "label": "lang_mos",
+                  "value": "mos"
+                },
+                {
+                  "label": "lang_mul",
+                  "value": "mul"
+                },
+                {
+                  "label": "lang_mun",
+                  "value": "mun"
+                },
+                {
+                  "label": "lang_mus",
+                  "value": "mus"
+                },
+                {
+                  "label": "lang_mwl",
+                  "value": "mwl"
+                },
+                {
+                  "label": "lang_mwr",
+                  "value": "mwr"
+                },
+                {
+                  "label": "lang_myn",
+                  "value": "myn"
+                },
+                {
+                  "label": "lang_myv",
+                  "value": "myv"
+                },
+                {
+                  "label": "lang_nah",
+                  "value": "nah"
+                },
+                {
+                  "label": "lang_nai",
+                  "value": "nai"
+                },
+                {
+                  "label": "lang_nap",
+                  "value": "nap"
+                },
+                {
+                  "label": "lang_nau",
+                  "value": "nau"
+                },
+                {
+                  "label": "lang_nav",
+                  "value": "nav"
+                },
+                {
+                  "label": "lang_nbl",
+                  "value": "nbl"
+                },
+                {
+                  "label": "lang_nde",
+                  "value": "nde"
+                },
+                {
+                  "label": "lang_ndo",
+                  "value": "ndo"
+                },
+                {
+                  "label": "lang_nds",
+                  "value": "nds"
+                },
+                {
+                  "label": "lang_nep",
+                  "value": "nep"
+                },
+                {
+                  "label": "lang_new",
+                  "value": "new"
+                },
+                {
+                  "label": "lang_nia",
+                  "value": "nia"
+                },
+                {
+                  "label": "lang_nic",
+                  "value": "nic"
+                },
+                {
+                  "label": "lang_niu",
+                  "value": "niu"
+                },
+                {
+                  "label": "lang_nno",
+                  "value": "nno"
+                },
+                {
+                  "label": "lang_nob",
+                  "value": "nob"
+                },
+                {
+                  "label": "lang_nog",
+                  "value": "nog"
+                },
+                {
+                  "label": "lang_non",
+                  "value": "non"
+                },
+                {
+                  "label": "lang_nor",
+                  "value": "nor"
+                },
+                {
+                  "label": "lang_nqo",
+                  "value": "nqo"
+                },
+                {
+                  "label": "lang_nso",
+                  "value": "nso"
+                },
+                {
+                  "label": "lang_nub",
+                  "value": "nub"
+                },
+                {
+                  "label": "lang_nwc",
+                  "value": "nwc"
+                },
+                {
+                  "label": "lang_nya",
+                  "value": "nya"
+                },
+                {
+                  "label": "lang_nym",
+                  "value": "nym"
+                },
+                {
+                  "label": "lang_nyn",
+                  "value": "nyn"
+                },
+                {
+                  "label": "lang_nyo",
+                  "value": "nyo"
+                },
+                {
+                  "label": "lang_nzi",
+                  "value": "nzi"
+                },
+                {
+                  "label": "lang_oci",
+                  "value": "oci"
+                },
+                {
+                  "label": "lang_oji",
+                  "value": "oji"
+                },
+                {
+                  "label": "lang_ori",
+                  "value": "ori"
+                },
+                {
+                  "label": "lang_orm",
+                  "value": "orm"
+                },
+                {
+                  "label": "lang_osa",
+                  "value": "osa"
+                },
+                {
+                  "label": "lang_oss",
+                  "value": "oss"
+                },
+                {
+                  "label": "lang_ota",
+                  "value": "ota"
+                },
+                {
+                  "label": "lang_oto",
+                  "value": "oto"
+                },
+                {
+                  "label": "lang_paa",
+                  "value": "paa"
+                },
+                {
+                  "label": "lang_pag",
+                  "value": "pag"
+                },
+                {
+                  "label": "lang_pal",
+                  "value": "pal"
+                },
+                {
+                  "label": "lang_pam",
+                  "value": "pam"
+                },
+                {
+                  "label": "lang_pan",
+                  "value": "pan"
+                },
+                {
+                  "label": "lang_pap",
+                  "value": "pap"
+                },
+                {
+                  "label": "lang_pau",
+                  "value": "pau"
+                },
+                {
+                  "label": "lang_peo",
+                  "value": "peo"
+                },
+                {
+                  "label": "lang_per",
+                  "value": "per"
+                },
+                {
+                  "label": "lang_phi",
+                  "value": "phi"
+                },
+                {
+                  "label": "lang_phn",
+                  "value": "phn"
+                },
+                {
+                  "label": "lang_pli",
+                  "value": "pli"
+                },
+                {
+                  "label": "lang_pol",
+                  "value": "pol"
+                },
+                {
+                  "label": "lang_pon",
+                  "value": "pon"
+                },
+                {
+                  "label": "lang_por",
+                  "value": "por"
+                },
+                {
+                  "label": "lang_pra",
+                  "value": "pra"
+                },
+                {
+                  "label": "lang_pro",
+                  "value": "pro"
+                },
+                {
+                  "label": "lang_pus",
+                  "value": "pus"
+                },
+                {
+                  "label": "lang_que",
+                  "value": "que"
+                },
+                {
+                  "label": "lang_raj",
+                  "value": "raj"
+                },
+                {
+                  "label": "lang_rap",
+                  "value": "rap"
+                },
+                {
+                  "label": "lang_rar",
+                  "value": "rar"
+                },
+                {
+                  "label": "lang_roa",
+                  "value": "roa"
+                },
+                {
+                  "label": "lang_roh",
+                  "value": "roh"
+                },
+                {
+                  "label": "lang_rom",
+                  "value": "rom"
+                },
+                {
+                  "label": "lang_rum",
+                  "value": "rum"
+                },
+                {
+                  "label": "lang_run",
+                  "value": "run"
+                },
+                {
+                  "label": "lang_rup",
+                  "value": "rup"
+                },
+                {
+                  "label": "lang_rus",
+                  "value": "rus"
+                },
+                {
+                  "label": "lang_sad",
+                  "value": "sad"
+                },
+                {
+                  "label": "lang_sag",
+                  "value": "sag"
+                },
+                {
+                  "label": "lang_sah",
+                  "value": "sah"
+                },
+                {
+                  "label": "lang_sai",
+                  "value": "sai"
+                },
+                {
+                  "label": "lang_sal",
+                  "value": "sal"
+                },
+                {
+                  "label": "lang_sam",
+                  "value": "sam"
+                },
+                {
+                  "label": "lang_san",
+                  "value": "san"
+                },
+                {
+                  "label": "lang_sas",
+                  "value": "sas"
+                },
+                {
+                  "label": "lang_sat",
+                  "value": "sat"
+                },
+                {
+                  "label": "lang_scn",
+                  "value": "scn"
+                },
+                {
+                  "label": "lang_sco",
+                  "value": "sco"
+                },
+                {
+                  "label": "lang_sel",
+                  "value": "sel"
+                },
+                {
+                  "label": "lang_sem",
+                  "value": "sem"
+                },
+                {
+                  "label": "lang_sga",
+                  "value": "sga"
+                },
+                {
+                  "label": "lang_sgn",
+                  "value": "sgn"
+                },
+                {
+                  "label": "lang_shn",
+                  "value": "shn"
+                },
+                {
+                  "label": "lang_sid",
+                  "value": "sid"
+                },
+                {
+                  "label": "lang_sin",
+                  "value": "sin"
+                },
+                {
+                  "label": "lang_sio",
+                  "value": "sio"
+                },
+                {
+                  "label": "lang_sit",
+                  "value": "sit"
+                },
+                {
+                  "label": "lang_sla",
+                  "value": "sla"
+                },
+                {
+                  "label": "lang_slo",
+                  "value": "slo"
+                },
+                {
+                  "label": "lang_slv",
+                  "value": "slv"
+                },
+                {
+                  "label": "lang_sma",
+                  "value": "sma"
+                },
+                {
+                  "label": "lang_sme",
+                  "value": "sme"
+                },
+                {
+                  "label": "lang_smi",
+                  "value": "smi"
+                },
+                {
+                  "label": "lang_smj",
+                  "value": "smj"
+                },
+                {
+                  "label": "lang_smn",
+                  "value": "smn"
+                },
+                {
+                  "label": "lang_smo",
+                  "value": "smo"
+                },
+                {
+                  "label": "lang_sms",
+                  "value": "sms"
+                },
+                {
+                  "label": "lang_sna",
+                  "value": "sna"
+                },
+                {
+                  "label": "lang_snd",
+                  "value": "snd"
+                },
+                {
+                  "label": "lang_snk",
+                  "value": "snk"
+                },
+                {
+                  "label": "lang_sog",
+                  "value": "sog"
+                },
+                {
+                  "label": "lang_som",
+                  "value": "som"
+                },
+                {
+                  "label": "lang_son",
+                  "value": "son"
+                },
+                {
+                  "label": "lang_sot",
+                  "value": "sot"
+                },
+                {
+                  "label": "lang_spa",
+                  "value": "spa"
+                },
+                {
+                  "label": "lang_srd",
+                  "value": "srd"
+                },
+                {
+                  "label": "lang_srn",
+                  "value": "srn"
+                },
+                {
+                  "label": "lang_srp",
+                  "value": "srp"
+                },
+                {
+                  "label": "lang_srr",
+                  "value": "srr"
+                },
+                {
+                  "label": "lang_ssa",
+                  "value": "ssa"
+                },
+                {
+                  "label": "lang_ssw",
+                  "value": "ssw"
+                },
+                {
+                  "label": "lang_suk",
+                  "value": "suk"
+                },
+                {
+                  "label": "lang_sun",
+                  "value": "sun"
+                },
+                {
+                  "label": "lang_sus",
+                  "value": "sus"
+                },
+                {
+                  "label": "lang_sux",
+                  "value": "sux"
+                },
+                {
+                  "label": "lang_swa",
+                  "value": "swa"
+                },
+                {
+                  "label": "lang_swe",
+                  "value": "swe"
+                },
+                {
+                  "label": "lang_syc",
+                  "value": "syc"
+                },
+                {
+                  "label": "lang_syr",
+                  "value": "syr"
+                },
+                {
+                  "label": "lang_tah",
+                  "value": "tah"
+                },
+                {
+                  "label": "lang_tai",
+                  "value": "tai"
+                },
+                {
+                  "label": "lang_tam",
+                  "value": "tam"
+                },
+                {
+                  "label": "lang_tat",
+                  "value": "tat"
+                },
+                {
+                  "label": "lang_tel",
+                  "value": "tel"
+                },
+                {
+                  "label": "lang_tem",
+                  "value": "tem"
+                },
+                {
+                  "label": "lang_ter",
+                  "value": "ter"
+                },
+                {
+                  "label": "lang_tet",
+                  "value": "tet"
+                },
+                {
+                  "label": "lang_tgk",
+                  "value": "tgk"
+                },
+                {
+                  "label": "lang_tgl",
+                  "value": "tgl"
+                },
+                {
+                  "label": "lang_tha",
+                  "value": "tha"
+                },
+                {
+                  "label": "lang_tib",
+                  "value": "tib"
+                },
+                {
+                  "label": "lang_tig",
+                  "value": "tig"
+                },
+                {
+                  "label": "lang_tir",
+                  "value": "tir"
+                },
+                {
+                  "label": "lang_tiv",
+                  "value": "tiv"
+                },
+                {
+                  "label": "lang_tkl",
+                  "value": "tkl"
+                },
+                {
+                  "label": "lang_tlh",
+                  "value": "tlh"
+                },
+                {
+                  "label": "lang_tli",
+                  "value": "tli"
+                },
+                {
+                  "label": "lang_tmh",
+                  "value": "tmh"
+                },
+                {
+                  "label": "lang_tog",
+                  "value": "tog"
+                },
+                {
+                  "label": "lang_ton",
+                  "value": "ton"
+                },
+                {
+                  "label": "lang_tpi",
+                  "value": "tpi"
+                },
+                {
+                  "label": "lang_tsi",
+                  "value": "tsi"
+                },
+                {
+                  "label": "lang_tsn",
+                  "value": "tsn"
+                },
+                {
+                  "label": "lang_tso",
+                  "value": "tso"
+                },
+                {
+                  "label": "lang_tuk",
+                  "value": "tuk"
+                },
+                {
+                  "label": "lang_tum",
+                  "value": "tum"
+                },
+                {
+                  "label": "lang_tup",
+                  "value": "tup"
+                },
+                {
+                  "label": "lang_tur",
+                  "value": "tur"
+                },
+                {
+                  "label": "lang_tut",
+                  "value": "tut"
+                },
+                {
+                  "label": "lang_tvl",
+                  "value": "tvl"
+                },
+                {
+                  "label": "lang_twi",
+                  "value": "twi"
+                },
+                {
+                  "label": "lang_tyv",
+                  "value": "tyv"
+                },
+                {
+                  "label": "lang_udm",
+                  "value": "udm"
+                },
+                {
+                  "label": "lang_uga",
+                  "value": "uga"
+                },
+                {
+                  "label": "lang_uig",
+                  "value": "uig"
+                },
+                {
+                  "label": "lang_ukr",
+                  "value": "ukr"
+                },
+                {
+                  "label": "lang_umb",
+                  "value": "umb"
+                },
+                {
+                  "label": "lang_und",
+                  "value": "und"
+                },
+                {
+                  "label": "lang_urd",
+                  "value": "urd"
+                },
+                {
+                  "label": "lang_uzb",
+                  "value": "uzb"
+                },
+                {
+                  "label": "lang_vai",
+                  "value": "vai"
+                },
+                {
+                  "label": "lang_ven",
+                  "value": "ven"
+                },
+                {
+                  "label": "lang_vie",
+                  "value": "vie"
+                },
+                {
+                  "label": "lang_vol",
+                  "value": "vol"
+                },
+                {
+                  "label": "lang_vot",
+                  "value": "vot"
+                },
+                {
+                  "label": "lang_wak",
+                  "value": "wak"
+                },
+                {
+                  "label": "lang_wal",
+                  "value": "wal"
+                },
+                {
+                  "label": "lang_war",
+                  "value": "war"
+                },
+                {
+                  "label": "lang_was",
+                  "value": "was"
+                },
+                {
+                  "label": "lang_wel",
+                  "value": "wel"
+                },
+                {
+                  "label": "lang_wen",
+                  "value": "wen"
+                },
+                {
+                  "label": "lang_wln",
+                  "value": "wln"
+                },
+                {
+                  "label": "lang_wol",
+                  "value": "wol"
+                },
+                {
+                  "label": "lang_xal",
+                  "value": "xal"
+                },
+                {
+                  "label": "lang_xho",
+                  "value": "xho"
+                },
+                {
+                  "label": "lang_yao",
+                  "value": "yao"
+                },
+                {
+                  "label": "lang_yap",
+                  "value": "yap"
+                },
+                {
+                  "label": "lang_yid",
+                  "value": "yid"
+                },
+                {
+                  "label": "lang_yor",
+                  "value": "yor"
+                },
+                {
+                  "label": "lang_ypk",
+                  "value": "ypk"
+                },
+                {
+                  "label": "lang_zap",
+                  "value": "zap"
+                },
+                {
+                  "label": "lang_zbl",
+                  "value": "zbl"
+                },
+                {
+                  "label": "lang_zen",
+                  "value": "zen"
+                },
+                {
+                  "label": "lang_zha",
+                  "value": "zha"
+                },
+                {
+                  "label": "lang_znd",
+                  "value": "znd"
+                },
+                {
+                  "label": "lang_zul",
+                  "value": "zul"
+                },
+                {
+                  "label": "lang_zun",
+                  "value": "zun"
+                },
+                {
+                  "label": "lang_zxx",
+                  "value": "zxx"
+                },
+                {
+                  "label": "lang_zza",
+                  "value": "zza"
+                }
+              ]
+            }
+          }
+        },
+        "propertiesOrder": [
+          "language",
+          "value"
+        ],
+        "required": [
+          "value",
+          "language"
+        ]
+      }
+    },
+    "organisation": {
+      "title": "Organisation",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "title": "Organisation",
+          "type": "string",
+          "pattern": "^https://sonar.ch/api/organisations/.*?$",
+          "form": {
+            "remoteOptions": {
+              "type": "organisations"
+            }
+          }
+        }
+      },
+      "required": [
+        "$ref"
+      ],
+      "form": {
+        "expressionProperties": {
+          "templateOptions.required": "true"
+        }
+      }
+    },
+    "_bucket": {
+      "title": "Bucket UUID",
+      "type": "string",
+      "minLength": 1
+    },
+    "_files": {
+      "title": "Files",
+      "description": "List of files attached to the record.",
+      "type": "array",
+      "items": {
+        "title": "File item",
+        "description": "Describes the information of a single file in the record.",
+        "additionalProperties": false,
+        "type": "object",
+        "properties": {
+          "bucket": {
+            "title": "Bucket UUID",
+            "type": "string",
+            "minLength": 1
+          },
+          "file_id": {
+            "title": "File UUID",
+            "type": "string",
+            "minLength": 1
+          },
+          "version_id": {
+            "title": "Version UUID",
+            "type": "string",
+            "minLength": 1
+          },
+          "key": {
+            "title": "Key",
+            "type": "string",
+            "minLength": 1
+          },
+          "mimetype": {
+            "title": "Mimetype",
+            "type": "string",
+            "minLength": 1
+          },
+          "checksum": {
+            "title": "Checksum",
+            "description": "MD5 checksum of the file.",
+            "type": "string",
+            "minLength": 1
+          },
+          "size": {
+            "title": "Size",
+            "description": "Size of the file in bytes.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "bucket",
+          "file_id",
+          "version_id",
+          "key"
+        ]
+      }
+    }
+  },
+  "propertiesOrder": [
+    "name",
+    "description"
+  ],
+  "required": [
+    "name"
+  ]
+}

--- a/sonar/modules/documents/views.py
+++ b/sonar/modules/documents/views.py
@@ -28,7 +28,8 @@ from invenio_records_ui.signals import record_viewed
 
 from sonar.modules.documents.utils import has_external_urls_for_files, \
     populate_files_properties
-from sonar.modules.utils import format_date
+from sonar.modules.utils import format_date, \
+    get_bibliographic_code_from_language
 
 from .utils import publication_statement_text
 
@@ -284,23 +285,6 @@ def get_language_from_bibliographic_code(language_code):
             language_code=language_code))
 
     return languages_map[language_code]
-
-
-def get_bibliographic_code_from_language(language_code):
-    """Return bibliographic language code from language.
-
-    For example, get_bibliographic_code_from_language("de") will
-    return "ger"
-
-    :param language_code: Bibliographic language
-    :return str
-    """
-    for key, lang in current_app.config.get('SONAR_APP_LANGUAGES_MAP').items():
-        if lang == language_code:
-            return key
-
-    raise Exception('Language code not found for "{language_code}"'.format(
-        language_code=language_code))
 
 
 def get_preferred_languages(force_language=None):

--- a/sonar/modules/utils.py
+++ b/sonar/modules/utils.py
@@ -237,3 +237,44 @@ def has_custom_resource(resource_type):
 
     return current_app.config.get('SONAR_APP_ORGANISATION_CONFIG').get(
         current_organisation['code'], {}).get(resource_type)
+
+
+def get_language_value(values,
+                       locale=None,
+                       value_field='value',
+                       language_field='language'):
+    """Return the value corresponding to the locale.
+
+    :params values: List of values with the language.
+    :params locale: Two digit locale to find.
+    :params value_field: Name of the property containing the value.
+    :params language_field: Name of the property containing the language.
+    :returns: The value associated with the language.
+    """
+    if not values:
+        return None
+
+    locale = locale or get_current_language()
+    locale = get_bibliographic_code_from_language(locale)
+
+    for value in values:
+        if value[language_field] == locale:
+            return value[value_field]
+
+    return values[0][value_field]
+
+
+def get_bibliographic_code_from_language(language_code):
+    """Return bibliographic language code from language.
+
+    For example, get_bibliographic_code_from_language("de") will
+    return "ger".
+
+    :param language_code: Bibliographic language.
+    :returns: The bibliographic code corresponding to language.
+    """
+    for key, lang in current_app.config.get('SONAR_APP_LANGUAGES_MAP').items():
+        if lang == language_code:
+            return key
+
+    raise Exception(f'Language code not found for "{language_code}"')

--- a/tests/ui/documents/test_documents_views.py
+++ b/tests/ui/documents/test_documents_views.py
@@ -26,28 +26,24 @@ import sonar.modules.documents.views as views
 def test_store_organisation(client, db, organisation):
     """Test store organisation in globals."""
     # Default view, no organisation stored.
-    assert client.get(url_for('index',
-                              view='global')).status_code == 200
+    assert client.get(url_for('index', view='global')).status_code == 200
     assert not g.get('organisation')
 
     # Existing organisation stored, with shared view
-    assert client.get(url_for('index',
-                              view='org')).status_code == 200
+    assert client.get(url_for('index', view='org')).status_code == 200
     assert g.organisation['code'] == 'org'
     assert g.organisation['isShared']
 
     # Non-existing organisation
     g.pop('organisation')
-    assert client.get(url_for('index',
-                              view='non-existing')).status_code == 404
+    assert client.get(url_for('index', view='non-existing')).status_code == 404
     assert not g.get('organisation')
 
     # Existing organisation without shared view
     organisation['isShared'] = False
     organisation.commit()
     db.session.commit()
-    assert client.get(url_for('index',
-                              view='org')).status_code == 404
+    assert client.get(url_for('index', view='org')).status_code == 404
     assert not g.get('organisation')
 
 
@@ -58,20 +54,26 @@ def test_index(client):
 
 def test_search(app, client):
     """Test search."""
-    assert client.get(url_for('documents.search', view='global',
-                              resource_type='documents')).status_code == 200
-    assert client.get(url_for('documents.search', view='not-existing',
-                              resource_type='documents')).status_code == 404
+    assert client.get(
+        url_for('documents.search', view='global',
+                resource_type='documents')).status_code == 200
+    assert client.get(
+        url_for('documents.search',
+                view='not-existing',
+                resource_type='documents')).status_code == 404
 
 
 def test_detail(app, client, document_with_file):
     """Test document detail page."""
     assert client.get(
-        url_for('invenio_records_ui.doc', view='global',
+        url_for('invenio_records_ui.doc',
+                view='global',
                 pid_value=document_with_file['pid'])).status_code == 200
 
-    assert client.get(url_for('invenio_records_ui.doc', view='global',
-                              pid_value='not-existing')).status_code == 404
+    assert client.get(
+        url_for('invenio_records_ui.doc',
+                view='global',
+                pid_value='not-existing')).status_code == 404
 
 
 def test_title_format(document):
@@ -138,15 +140,6 @@ def test_get_code_from_bibliographic_language(app):
     with pytest.raises(Exception) as e:
         views.get_language_from_bibliographic_code('zzz')
     assert str(e.value) == 'Language code not found for "zzz"'
-
-
-def test_get_bibliographic_code_from_language(app):
-    """Test bibliographic language code to alpha 2 code conversion."""
-    with pytest.raises(Exception) as e:
-        views.get_bibliographic_code_from_language("zz")
-    assert str(e.value) == 'Language code not found for "zz"'
-
-    assert views.get_bibliographic_code_from_language('de') == 'ger'
 
 
 def test_get_preferred_languages(app):
@@ -349,10 +342,27 @@ def test_contribution_text():
 
 def test_project_detail(app, client, project):
     """Test project detail page."""
-    assert client.get(url_for('invenio_records_ui.proj', view='global',
-                              pid_value=project.id)).status_code == 200
     assert client.get(
         url_for('invenio_records_ui.proj', view='global',
+                pid_value=project.id)).status_code == 200
+    assert client.get(
+        url_for('invenio_records_ui.proj',
+                view='global',
                 pid_value='not-existing')).status_code == 404
-    assert client.get(url_for('invenio_records_ui.proj', view='not-existing',
-                              pid_value=project.id)).status_code == 404
+    assert client.get(
+        url_for('invenio_records_ui.proj',
+                view='not-existing',
+                pid_value=project.id)).status_code == 404
+
+
+def test_language_value(app):
+    """Test language value."""
+    values = [{
+        'language': 'eng',
+        'value': 'Value ENG'
+    }, {
+        'language': 'fre',
+        'value': 'Value FRE'
+    }]
+    assert render_template_string('{{ values | language_value }}',
+                                  values=values) == 'Value ENG'

--- a/tests/ui/test_utils.py
+++ b/tests/ui/test_utils.py
@@ -187,3 +187,35 @@ def test_has_custom_resource(client, make_user, monkeypatch):
     monkeypatch.setattr('sonar.modules.organisations.api.current_organisation',
                         {})
     assert not has_custom_resource('projects')
+
+
+def test_get_bibliographic_code_from_language(app):
+    """Test bibliographic language code to alpha 2 code conversion."""
+    with pytest.raises(Exception) as e:
+        get_bibliographic_code_from_language("zz")
+    assert str(e.value) == 'Language code not found for "zz"'
+
+    assert get_bibliographic_code_from_language('de') == 'ger'
+
+
+def test_get_language_value(app):
+    """Test language value."""
+    # No value passed
+    assert get_language_value(None) == None
+    assert get_language_value([]) == None
+
+    # No locale
+    values = [{
+        'language': 'eng',
+        'value': 'Value ENG'
+    }, {
+        'language': 'fre',
+        'value': 'Value FRE'
+    }]
+    assert get_language_value(values) == 'Value ENG'
+
+    # Existing locale
+    assert get_language_value(values, 'fr') == 'Value FRE'
+
+    # Non existing locale
+    assert get_language_value(values, 'de') == 'Value ENG'


### PR DESCRIPTION
* Adds a filter to get the value corresponding to a language in a list property.
* Moves `get_bibliographic_code_from_language` into utils functions.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>