### PR TITLE
documents: fix controlled affiliations

### DIFF
--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -1379,17 +1379,13 @@
               "title": "Controlled affiliation",
               "type": "string",
               "minLength": 1
-            },
-            "form": {
-              "hideExpression": "field.parent.model.agent.type !== 'bf:Person'"
             }
           }
         },
         "propertiesOrder": [
           "agent",
           "role",
-          "affiliation",
-          "controlledAffiliation"
+          "affiliation"
         ],
         "required": [
           "agent",

--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -342,9 +342,9 @@ along with this program. If not, see
 {%- endblock %}
 
 {% block javascript %}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.6.0/umd/popper.min.js"
-  integrity="sha512-BmM0/BQlqh02wuK5Gz9yrbe7VyIVwOzD1o40yi1IsTjriX/NGF37NyXHfmFzIlMmoSIBXgqDiG1VNU6kB5dBbA=="
-  crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.16.1/umd/popper.min.js"
+  integrity="sha512-ubuT8Z88WxezgSqf3RLuNi5lmjstiJcyezx34yIU2gAHonIi27Na7atqzUZCOoY4CExaoFumzOsFQ2Ch+I/HCw=="
+  crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
   integrity="sha256-4+XzXVhsDmqanXGHaHvgh1gMQKX40OUvDEBTu8JcmNs=" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>


### PR DESCRIPTION
* Removes the field from the document editor.
* Fixes the display of the tooltip in document detail view.
* Forces to clear cache for JSON schemas, to have the right schema content.
* Closes #541.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>