### PR TITLE
collections: hierarchize records

### DIFF
--- a/sonar/ext.py
+++ b/sonar/ext.py
@@ -29,6 +29,7 @@ from invenio_files_rest.signals import file_deleted, file_uploaded
 from invenio_indexer.signals import before_record_index
 from werkzeug.datastructures import MIMEAccept
 
+from sonar.modules.collections.receivers import enrich_collection_data
 from sonar.modules.permissions import has_admin_access, has_submitter_access, \
     has_superuser_access
 from sonar.modules.receivers import file_deleted_listener, \
@@ -102,6 +103,9 @@ class Sonar():
 
         # Add user's full name before record index
         before_record_index.connect(add_full_name, weak=False)
+
+        # Enrich collection's data
+        before_record_index.connect(enrich_collection_data, weak=False)
 
     def init_config(self, app):
         """Initialize configuration."""

--- a/sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json
+++ b/sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json
@@ -46,7 +46,6 @@
           "language"
         ]
       }
-
     },
     "description": {
       "title": "Descriptions",
@@ -80,6 +79,12 @@
           "value",
           "language"
         ]
+      },
+      "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        }
       }
     },
     "organisation": {
@@ -103,6 +108,33 @@
       "form": {
         "expressionProperties": {
           "templateOptions.required": "true"
+        }
+      }
+    },
+    "parent": {
+      "title": "Parent collection",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "pattern": "^https://sonar.ch/api/collections/.*?$",
+          "form": {
+            "remoteTypeahead": {
+              "type": "collections",
+              "field": "name.value.suggest",
+              "label": "label"
+            }
+          }
+        }
+      },
+      "required": [
+        "$ref"
+      ],
+      "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
         }
       }
     },
@@ -169,7 +201,8 @@
   },
   "propertiesOrder": [
     "name",
-    "description"
+    "description",
+    "parent"
   ],
   "required": [
     "name"

--- a/sonar/modules/collections/mappings/v7/collections/collection-v1.0.0.json
+++ b/sonar/modules/collections/mappings/v7/collections/collection-v1.0.0.json
@@ -54,6 +54,28 @@
           }
         }
       },
+      "parent": {
+        "type": "object",
+        "properties": {
+          "pid": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "text"
+              },
+              "language": {
+                "type": "keyword"
+              }
+            }
+          }
+        }
+      },
+      "path": {
+        "type": "text"
+      },
       "_created": {
         "type": "date"
       },

--- a/sonar/modules/collections/permissions.py
+++ b/sonar/modules/collections/permissions.py
@@ -17,6 +17,8 @@
 
 """Record permissions."""
 
+from elasticsearch_dsl import Q
+
 from sonar.modules.documents.api import DocumentSearch
 from sonar.modules.organisations.api import current_organisation
 from sonar.modules.permissions import RecordPermission as BaseRecordPermission
@@ -92,8 +94,12 @@ class RecordPermission(BaseRecordPermission):
         :return: True if action can be done
         :rtype: bool
         """
-        results = DocumentSearch().filter(
-            'term', collections__pid=record['pid']).source(includes=['pid'])
+        results = DocumentSearch().query(
+            Q('nested',
+              path='collections',
+              query=Q('bool', must=Q(
+                  'term',
+                  collections__pid=record['pid'])))).source(includes=['pid'])
 
         # Cannot remove collection associated to a record
         if results.count():

--- a/sonar/modules/collections/receivers.py
+++ b/sonar/modules/collections/receivers.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Signal receivers for collections."""
+
+
+def enrich_collection_data(sender=None,
+                           record=None,
+                           json=None,
+                           index=None,
+                           **kwargs):
+    """Receive a signal before record is indexed, to enrich the data.
+
+    :param sender: Sender of the signal.
+    :param Record record: Record to index.
+    :param dict json: JSON that will be indexed.
+    :param str index: Name of the index in which record will be sent.
+    """
+    if not index.startswith('collections'):
+        return
+
+    def _build_path(parent, path):
+        """Recursive call to build the path from parent node to leaf.
+
+        :param parent: Parent item.
+        :param path: List of PIDs.
+        """
+        if not parent:
+            return
+
+        path.insert(0, parent['pid'])
+        _build_path(parent.get('parent'), path)
+
+    # Make the pass
+    path = [json['pid']]
+    _build_path(json.get('parent'), path)
+    path.insert(0, '')
+    json['path'] = '/'.join(path)

--- a/sonar/modules/collections/schemas.py
+++ b/sonar/modules/collections/schemas.py
@@ -41,6 +41,7 @@ class RecordMetadataSchema(StrictKeysMixin):
     name = fields.List(fields.Dict(), required=True)
     description = fields.List(fields.Dict())
     organisation = fields.Dict()
+    parent = fields.Dict()
     permissions = fields.Dict(dump_only=True)
     label = fields.Method('get_label')
     # When loading, if $schema is not provided, it's retrieved by

--- a/sonar/modules/collections/templates/collections/index.html
+++ b/sonar/modules/collections/templates/collections/index.html
@@ -18,7 +18,7 @@ along with this program. If not, see
 {%- extends config.RECORDS_UI_BASE_TEMPLATE %}
 
 {%- block body %}
-<h1>{{ _('Collections') }}</h1>
+<h1 class="mb-4">{{ _('Collections') }}</h1>
 {% if records | length %}
 <ul class="list-group list-group-flush">
   {% for record in records %}

--- a/sonar/modules/collections/templates/collections/item.html
+++ b/sonar/modules/collections/templates/collections/item.html
@@ -30,9 +30,6 @@ along with this program. If not, see
       {{ collection.description | language_value | markdown_filter | safe }}
     </div>
     {% endif %}
-    <p>
-
-    </p>
     <div class="row">
       <div class="col-sm-6 pt-2">
         <a href="{{ url_for('invenio_records_ui.coll', pid_value=collection.pid, view=view_code) }}">

--- a/sonar/modules/documents/mappings/v7/documents/document-v1.0.0.json
+++ b/sonar/modules/documents/mappings/v7/documents/document-v1.0.0.json
@@ -313,7 +313,7 @@
         }
       },
       "collections": {
-        "type": "object",
+        "type": "nested",
         "properties": {
           "pid": {
             "type": "keyword"

--- a/sonar/modules/documents/query.py
+++ b/sonar/modules/documents/query.py
@@ -90,8 +90,14 @@ def search_factory(self, search, query_parser=None):
 
         # Filter collection
         if request.args.get('collection_view'):
-            search = search.filter(
-                'term', collections__pid=request.args['collection_view'])
+            search = search.query(
+                Q('nested',
+                  path='collections',
+                  query=Q(
+                      'bool',
+                      must=Q(
+                          'term',
+                          collections__pid=request.args['collection_view']))))
     # Admin
     else:
         # Filters records by user's organisation

--- a/sonar/modules/documents/receivers.py
+++ b/sonar/modules/documents/receivers.py
@@ -109,6 +109,27 @@ def enrich_document_data(sender=None,
     # Check if record is open access.
     json['isOpenAccess'] = record.is_open_access()
 
+    # Adds collections for building aggregations.
+    def _get_collections_pids(collection):
+        """Builds the list of collections PIDs from parent to leaf.
+
+        :param dict collection: Collection dictionary.
+        :returns: List of PIDs.
+        :rtype: list
+        """
+        pids = [collection['pid']]
+        if collection.get('parent'):
+            pids = _get_collections_pids(collection['parent']) + pids
+
+        return pids
+
+    for collection in json.get('collections', []):
+        pids = _get_collections_pids(collection)
+        i = 0
+        while i < len(pids):
+            collection[f'collection{i}'] = pids[i]
+            i += 1
+
     # No files are present in record
     if not record.files:
         return

--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -295,7 +295,7 @@ along with this program. If not, see
           <ul class="list-unstyled mb-0">
             {% for collection in record.collections %}
             <li class="p-0">
-              <a href="{{ url_for('documents.search', view=view_code, collection_view=collection.pid) }}">
+              <a href="{{ url_for('documents.search', view=record.organisation[0].pid, collection_view=collection.pid) }}">
                 {{ collection.name | language_value }}
               </a>
             </li>

--- a/sonar/modules/query.py
+++ b/sonar/modules/query.py
@@ -125,3 +125,17 @@ def missing_field_filter(field):
     def inner(values):
         return Q('bool', must_not=[Q('exists', field=field)])
     return inner
+
+
+def collection_filter(field):
+    """Filter for collections."""
+    def inner(values):
+        must = []
+        for value in values:
+            must.append(
+                Q('nested',
+                  path='collections',
+                  query=Q('bool', must=Q('term', **{field: value}))))
+        return Q('bool', must=must)
+
+    return inner

--- a/tests/api/collections/test_collections_documents_facets.py
+++ b/tests/api/collections/test_collections_documents_facets.py
@@ -39,6 +39,34 @@ def test_list(app, db, client, document, collection, superuser):
         '2',
         'doc_count':
         1,
+        'collection1': {
+            'doc_count_error_upper_bound':
+            0,
+            'sum_other_doc_count':
+            0,
+            'buckets': [{
+                'key': '3',
+                'doc_count': 1,
+                'collection2': {
+                    'doc_count_error_upper_bound': 0,
+                    'sum_other_doc_count': 0,
+                    'buckets': []
+                },
+                'name': 'Collection name'
+            }]
+        },
         'name':
-        'Collection name'
+        'Parent collection'
     }]
+
+    # Test with collection filter
+    login_user_via_session(client, email=superuser['email'])
+    res = client.get(url_for('invenio_records_rest.doc_list', collection='2'))
+    assert res.status_code == 200
+    assert res.json['hits']['total']['value'] == 1
+
+    # Test with sub collection filter
+    login_user_via_session(client, email=superuser['email'])
+    res = client.get(url_for('invenio_records_rest.doc_list', collection1='3'))
+    assert res.status_code == 200
+    assert res.json['hits']['total']['value'] == 1

--- a/tests/api/collections/test_collections_suggestions.py
+++ b/tests/api/collections/test_collections_suggestions.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test collections suggestions."""
+
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+
+
+def test_suggestions(client, admin, collection, make_collection):
+    """Test list collections permissions."""
+    make_collection('org')
+
+    login_user_via_session(client, email=admin['email'])
+
+    # 2 results
+    res = client.get(url_for('invenio_records_rest.coll_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total']['value'] == 2
+
+    # Suggestions does not return the collection corresponding to current PID
+    res = client.get(
+        url_for('invenio_records_rest.coll_list',
+                q='name.value.suggest:Collection name',
+                currentPid=collection['pid']))
+    assert res.status_code == 200
+    assert res.json['hits']['total']['value'] == 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -766,11 +766,29 @@ def make_collection(app, db, collection_json):
 @pytest.fixture()
 def collection(app, db, es, admin, organisation, collection_json):
     """Collection fixture."""
+    parent_collection_json = {
+        'name': [{
+            'language': 'eng',
+            'value': 'Parent collection'
+        }]
+    }
+    parent_collection = CollectionRecord.create(parent_collection_json,
+                                                dbcommit=True,
+                                                with_bucket=True)
+    parent_collection.commit()
+    parent_collection.reindex()
+    db.session.commit()
+
     json = copy.deepcopy(collection_json)
     json['organisation'] = {
         '$ref':
         'https://sonar.ch/api/organisations/{pid}'.format(
             pid=organisation['pid'])
+    }
+    json['parent'] = {
+        '$ref':
+        'https://sonar.ch/api/collections/{pid}'.format(
+            pid=parent_collection['pid'])
     }
 
     collection = CollectionRecord.create(json, dbcommit=True, with_bucket=True)


### PR DESCRIPTION
* Adds the possibility to hierarchize collections.
* Displays hierarchized collections in documents aggregations.
* Fixes the link to collections records in document detail view.
* Closes #545.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>