### PR TITLE
translations: update catalog

### DIFF
--- a/sonar/translations/de/LC_MESSAGES/messages.po
+++ b/sonar/translations/de/LC_MESSAGES/messages.po
@@ -10,20 +10,19 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
 "Report-Msgid-Bugs-To: nicolas.prongue@rero.ch\n"
-"POT-Creation-Date: 2021-06-01 15:56+0200\n"
-"PO-Revision-Date: 2021-06-06 13:32+0000\n"
+"POT-Creation-Date: 2021-06-14 13:34+0200\n"
+"PO-Revision-Date: 2021-06-11 07:32+0000\n"
 "Last-Translator: Nicolas Prongué <n.prongue@outlook.com>\n"
-"Language-Team: German <https://hosted.weblate.org/projects/rero_plus/sonar/"
-"de/>\n"
 "Language: de\n"
+"Language-Team: German "
+"<https://hosted.weblate.org/projects/rero_plus/sonar/de/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.7-dev\n"
 "Generated-By: Babel 2.9.1\n"
 
-#: sonar/theme/views.py:65
+#: sonar/theme/views.py:67
 #, python-format
 msgid "%(icon)s Profile"
 msgstr "%(icon)s Mein Konto"
@@ -36,13 +35,13 @@ msgstr ""
 msgid "About SONAR"
 msgstr "Über SONAR"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:681
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:697
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:795
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:811
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:663
 msgid "Abstract"
 msgstr "Zusammenfassung"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:678
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:792
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:659
 msgid "Abstracts"
 msgstr "Abstracts"
@@ -60,10 +59,11 @@ msgid "Accompanying material of the resource, i.e. maps."
 msgstr "Begleitmaterial der Ressource, z.B. Landkarten."
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:844
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1651
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1663
 msgid "Acquisition terms"
 msgstr "Bezugsbedingung"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:77
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:210
 msgid "Action"
 msgstr "Aktion"
@@ -76,7 +76,11 @@ msgstr ""
 msgid "Actor involved"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:933
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:704
+msgid "Add a new collection"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1044
 msgid "Add a new project"
 msgstr "Neues Projekt hinzufügen"
 
@@ -89,14 +93,13 @@ msgstr "Zusätzliche Materialien"
 msgid "Administration"
 msgstr "Administration"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:834
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1009
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1367
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:948
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1383
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:203
 msgid "Affiliation"
 msgstr "Zugehörigkeit"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1180
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1196
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:159
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:250
 msgid "Agent"
@@ -132,9 +135,13 @@ msgid ""
 "underscores."
 msgstr "Mindestens drei Buchstaben, nur Kleinbuchstaben und Unterstriche erlaubt."
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1484
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1496
 msgid "Author or editor"
 msgstr "Autor oder Herausgeber"
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:612
+msgid "Authors / Editors"
+msgstr ""
 
 #: sonar/modules/documents/templates/documents/record.html:44
 #: sonar/theme/templates/sonar/projects/detail.html:15
@@ -145,7 +152,7 @@ msgstr "Zurück"
 msgid "Back to SONAR"
 msgstr "Zurück an SONAR"
 
-#: sonar/config.py:584
+#: sonar/config.py:608
 msgid "Best match"
 msgstr "Bestmöglicher Treffer"
 
@@ -161,12 +168,12 @@ msgstr "Kurzbeschreibung des Auftrags"
 msgid "Brief description of the report"
 msgstr "Kurzbeschreibung des Berichts"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1788
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:30
 msgid "Bronze"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4993
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5008
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:110
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:125
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:20
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:34
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:15
@@ -184,35 +191,35 @@ msgstr "Bucket UUID wird zum Speichern der Dateien benutzt"
 msgid "CAS or DAS"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:27
+#: sonar/common/jsonschemas/license-v1.0.0.json:28
 msgid "CC BY"
 msgstr "CC BY"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:31
+#: sonar/common/jsonschemas/license-v1.0.0.json:32
 msgid "CC BY-NC"
 msgstr "CC BY-NC"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:35
+#: sonar/common/jsonschemas/license-v1.0.0.json:36
 msgid "CC BY-NC-ND"
 msgstr "CC BY-NC-ND"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:39
+#: sonar/common/jsonschemas/license-v1.0.0.json:40
 msgid "CC BY-NC-SA"
 msgstr "CC BY-NC-SA"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:43
+#: sonar/common/jsonschemas/license-v1.0.0.json:44
 msgid "CC BY-ND"
 msgstr "CC BY-ND"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:47
+#: sonar/common/jsonschemas/license-v1.0.0.json:48
 msgid "CC BY-SA"
 msgstr "CC BY-SA"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:23
+#: sonar/common/jsonschemas/license-v1.0.0.json:24
 msgid "CC0"
 msgstr "CC0"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5033
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:150
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:59
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:58
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:266
@@ -224,16 +231,16 @@ msgid "City"
 msgstr "Stadt"
 
 #: sonar/common/jsonschemas/classification-v1.0.0.json:2
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1015
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1031
 #: sonar/modules/documents/templates/documents/record.html:262
 msgid "Classification"
 msgstr "Klassifikation"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1066
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1082
 msgid "Classification portion"
 msgstr "Notation"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1011
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1027
 msgid "Classifications"
 msgstr "Klassifikationen"
 
@@ -245,7 +252,7 @@ msgstr ""
 msgid "Click here to reset your password"
 msgstr "Hier klicken, um Ihr Passwort zurückzusetzen"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1792
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:34
 msgid "Closed"
 msgstr "Geschlossen"
 
@@ -253,18 +260,27 @@ msgstr "Geschlossen"
 msgid "Code"
 msgstr "Code"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:999
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:680
 msgid "Collection"
 msgstr "Sammlung"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:4
+#: sonar/modules/collections/templates/collections/index.html:21
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:676
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:995
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:999
+#: sonar/modules/documents/templates/documents/record.html:288
 msgid "Collections"
 msgstr "Sammlungen"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:106
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:245
 msgid "Comment"
 msgstr "Kommentar"
+
+#: sonar/common/jsonschemas/validation-v1.0.0.json:107
+msgid "Comment associated with the current action."
+msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:513
 msgid "Company"
@@ -282,37 +298,41 @@ msgstr "E-Mail-Adresse bestätigen"
 msgid "Contact"
 msgstr "Kontakt"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1094
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:540
+msgid "Contained in (journal, book, proceedings)"
+msgstr ""
+
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1110
 msgid "Content note"
 msgstr "Anmerkung zum Inhalt"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1090
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1106
 msgid "Content notes"
 msgstr "Anmerkungen zum Inhalt"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1175
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1480
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1191
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1492
 msgid "Contribution"
 msgstr "Beitrag"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1171
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1187
 msgid "Contributions"
 msgstr "Beiträge"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:814
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:928
 msgid "Contributor"
 msgstr "Mitwirkende"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:808
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:922
 msgid "Contributors"
 msgstr "Mitwirkenden"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1379
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1395
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:212
 msgid "Controlled affiliation"
 msgstr "Institutszugehörigkeit (überprüft)"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1375
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1391
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:208
 msgid "Controlled affiliations"
 msgstr "Institutszugehörigkeiten (überprüft)"
@@ -322,27 +342,36 @@ msgstr "Institutszugehörigkeiten (überprüft)"
 msgid "Creativity, transformations and innovations in education"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:78
+msgid "Current action done in the validation process."
+msgstr ""
+
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:173
 msgid "Current cataloguing step."
 msgstr "Aktueller Katalogisierungsschritt."
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1799
+#: sonar/common/jsonschemas/validation-v1.0.0.json:65
+msgid "Current status of the record in the validation process."
+msgstr ""
+
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1774
 msgid "Custom field 1"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1819
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1794
 msgid "Custom field 2"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1839
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1814
 msgid "Custom field 3"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:42
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:240
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:777
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:891
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:496
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1123
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1295
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1139
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1311
 msgid "Date"
 msgstr "Datum"
 
@@ -354,14 +383,18 @@ msgstr "Datum im Format JJJJ-MM-TT, z.B. 1970-01-31"
 msgid "Date of approval by the Team Leader"
 msgstr "Datum der Genehmigung durch den Teamleiter"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1271
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1287
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:34
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1279
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1295
 msgid "Date of death"
 msgstr "Todesdatum"
+
+#: sonar/common/jsonschemas/validation-v1.0.0.json:43
+msgid "Date when the log is created."
+msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:640
 msgid "Dean of a school"
@@ -372,8 +405,8 @@ msgstr ""
 msgid "Dear %(email)s"
 msgstr "Sehr geehrte(r) %(email)s"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:762
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1108
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:876
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1124
 msgid "Degree"
 msgstr "Akademischer Abschluss"
 
@@ -389,20 +422,22 @@ msgstr "Ablehnung der Ablage"
 msgid "Deposit to validate"
 msgstr "Ablage zu genehmigen"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5003
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:120
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:30
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:236
 msgid "Describes the information of a single file in the record."
 msgstr "Beschreibt die Information einer einzelnen Datei der Ressource."
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2497
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:941
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:56
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:740
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1052
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:38
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:55
 msgid "Description"
 msgstr "Beschreibung"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2493
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:52
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:736
 msgid "Descriptions"
 msgstr ""
 
@@ -418,8 +453,8 @@ msgstr ""
 msgid "Director, head of establishment"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:757
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1103
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:871
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1119
 msgid "Dissertation"
 msgstr "These"
 
@@ -435,12 +470,12 @@ msgstr ""
 msgid "Doctorate supported by the HEP-VS"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:558
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1117
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:556
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1124
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:3
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:958
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1411
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1445
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1423
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1457
 msgid "Document"
 msgstr "Dokument"
 
@@ -448,7 +483,7 @@ msgstr "Dokument"
 msgid "Document ID"
 msgstr "Dokument-ID"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1118
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1125
 msgid "Document created on basis of this deposit."
 msgstr "Dokument erstellt auf Grundlage dieser Ablage."
 
@@ -486,10 +521,6 @@ msgstr "E-Mail"
 msgid "Edition"
 msgstr "Ausgabe"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:596
-msgid "Editors"
-msgstr "Herausgeber"
-
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:211
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:273
 msgid "Education, childhood and the learning Society 21"
@@ -518,7 +549,7 @@ msgid "Emotions, learning, and well-being at school"
 msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:80
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:959
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1075
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:79
 msgid "End date"
 msgstr "Enddatum"
@@ -546,8 +577,15 @@ msgstr ""
 "Geben Sie bitte unten Ihre E-Mail-Adresse ein, und wir werden Ihnen einen"
 " Link senden, um Ihr Passwort zurückzusetzen."
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:886
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1020
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:569
+msgid "Example: 1"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:586
+msgid "Example: 10"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1000
 msgid "Example: 1111-2222-3333-4444"
 msgstr "Beispiel: 1111-2222-3333-4444"
 
@@ -556,13 +594,11 @@ msgstr "Beispiel: 1111-2222-3333-4444"
 msgid "Example: 2019 or 2019-01-01"
 msgstr "Beispiel: 2019 oder 2019-01-01"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:782
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1127
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:896
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1143
 msgid "Example: 2019 or 2019-05-05"
 msgstr "Beispiel: 2019 oder 2019-05-05"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:953
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:960
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:153
 msgid "Example: 2019-05-05"
 msgstr "Beispiel: 2019-05-05"
@@ -573,6 +609,8 @@ msgstr "Beispiel: 2020"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:75
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:88
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1070
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1082
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:74
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:87
 msgid "Example: 2020-12-01"
@@ -586,17 +624,17 @@ msgstr "Beispiel: Muster"
 msgid "Example: John"
 msgstr "Beispiel: Hans"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1488
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1500
 msgid "Example: Muller, Hans"
 msgstr "Beispiel: Muster, Hans"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:638
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:655
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:977
 msgid "Example: Published version"
 msgstr "Beispiel: Veröffentlichte Version"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:591
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1441
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:602
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1453
 msgid "Examples: 135, 5-27, …"
 msgstr "Beispiele: 135, 5-27, …"
 
@@ -604,7 +642,11 @@ msgstr "Beispiele: 135, 5-27, …"
 msgid "Except within organisation"
 msgstr "Ausgenommen innerhalb der Institution"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:913
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:685
+msgid "Existing collection"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1024
 msgid "Existing project"
 msgstr "Bestehendes Projekt"
 
@@ -632,20 +674,20 @@ msgstr "Externe Partner"
 msgid "External partners are involved"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5013
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:130
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:39
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:35
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:246
 msgid "File UUID"
 msgstr "Datei-UUID"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5002
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:119
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:29
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:235
 msgid "File item"
 msgstr "Datei-Item"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4998
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:115
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:25
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:21
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:231
@@ -696,7 +738,7 @@ msgstr "Format, d.h. Masse in cm."
 msgid "Formats"
 msgstr "Formate"
 
-#: sonar/config.py:72
+#: sonar/config.py:74
 msgid "French"
 msgstr "Französisch"
 
@@ -717,12 +759,10 @@ msgstr ""
 msgid "Funding number"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1048
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:245
 msgid "Funding organisation"
 msgstr "Förderorganisation"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1045
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:241
 #: sonar/theme/templates/sonar/projects/detail.html:64
 msgid "Funding organisations"
@@ -736,20 +776,20 @@ msgstr ""
 msgid "Funding was granted for the project"
 msgstr ""
 
-#: sonar/config.py:72
+#: sonar/config.py:74
 msgid "German"
 msgstr "Deutsch"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1780
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:22
 msgid "Gold"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:772
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1118
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:886
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1134
 msgid "Granting institution"
 msgstr "Verleihende Institution"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1776
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:18
 msgid "Green"
 msgstr ""
 
@@ -777,7 +817,7 @@ msgstr "HTML markup zugelassen."
 msgid "Harvested"
 msgstr "Gesammelt"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:18
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:18
 msgid "Hash key"
 msgstr ""
 
@@ -785,8 +825,8 @@ msgstr ""
 msgid "Help & Documentation"
 msgstr "Hilfe & Dokumentation"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:559
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1451
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:557
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1463
 msgid ""
 "Host document, for example a journal for an article, or a book for a book"
 " chapter."
@@ -798,7 +838,7 @@ msgstr ""
 msgid "How are research results used in training?"
 msgstr "Wie werden Forschungsergebnisse in der Ausbildung genutzt?"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1784
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:26
 msgid "Hybrid"
 msgstr ""
 
@@ -807,24 +847,22 @@ msgid "IR hosting service"
 msgstr "IR Hosting-Service"
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:867
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1674
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1686
 msgid "ISBN/ISSN status should be selected in the list below."
 msgstr "Der ISBN/ISSN-Status muss in der Liste ausgewählt werden."
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1220
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1236
 msgid "Identified by"
 msgstr "Identifikator"
 
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:2
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:3
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:9
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:13
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:13
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:15
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:360
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:966
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1058
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:693
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1500
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1512
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:13
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:13
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:9
@@ -835,7 +873,7 @@ msgstr "Identifikator"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:357
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:689
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1496
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1508
 #: sonar/modules/documents/templates/documents/record.html:237
 msgid "Identifiers"
 msgstr "Identifikatoren"
@@ -853,10 +891,6 @@ msgstr "Wenn dieses Feld ausgefüllt ist, leitet die Datei zum angegebenen URL."
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:316
 msgid "In progress"
 msgstr ""
-
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:597
-msgid "In the format \\"
-msgstr "Im Format \"Vorname, Nachname\""
 
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:118
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:165
@@ -884,12 +918,10 @@ msgstr "Interne Forschungsmitarbeitenden"
 msgid "Invenio"
 msgstr "Invenio"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:974
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:154
 msgid "Investigator"
 msgstr "Gesuchstellende"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:971
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:150
 #: sonar/theme/templates/sonar/projects/detail.html:35
 msgid "Investigators"
@@ -903,21 +935,21 @@ msgstr "Ist eine dedizierte Organisation"
 msgid "Is shared"
 msgstr "Wird im gemeinsamen Portal gezeigt"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1429
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1441
 msgid "Issue"
 msgstr "Lieferung"
 
-#: sonar/config.py:73
+#: sonar/config.py:75
 msgid "Italian"
 msgstr "Italienisch"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:767
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1113
-#: sonar/modules/documents/views.py:234
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:881
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1129
+#: sonar/modules/documents/views.py:240
 msgid "Jury note"
 msgstr "Anmerkung des Entscheidungsgremiums"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5023
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:140
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:49
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:47
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:256
@@ -928,7 +960,12 @@ msgstr "Schlüssel"
 msgid "Key (filename) of the file."
 msgstr "Schlüssel (Dateiname) der Datei."
 
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:835
+msgid "Keyword"
+msgstr ""
+
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:391
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:832
 msgid "Keywords"
 msgstr ""
 
@@ -936,7 +973,7 @@ msgstr ""
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:69
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:503
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:903
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1154
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1170
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:94
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:141
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:188
@@ -950,8 +987,6 @@ msgid "Labels"
 msgstr ""
 
 #: sonar/common/jsonschemas/language-v1.0.0.json:2
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:37
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2513
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:354
 #: sonar/modules/documents/templates/documents/record.html:221
 msgid "Language"
@@ -974,7 +1009,7 @@ msgstr "Letztes Update nach OAI-PMH (Zeitstempel formatiert nach ISO8601)"
 msgid "Last name"
 msgstr "Nachname"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:829
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:943
 msgid "Last name, first name, ex: Doe, John"
 msgstr "Familienname, Vorname, z.B.: Muster,Hans"
 
@@ -983,9 +1018,13 @@ msgid "Lecturer/professor"
 msgstr ""
 
 #: sonar/common/jsonschemas/license-v1.0.0.json:2
-#: sonar/modules/documents/templates/documents/record.html:288
+#: sonar/modules/documents/templates/documents/record.html:306
 msgid "License"
 msgstr "Lizenz"
+
+#: sonar/common/jsonschemas/license-v1.0.0.json:52
+msgid "License undefined"
+msgstr ""
 
 #: sonar/theme/templates/sonar/projects/detail.html:79
 msgid "Linked documents"
@@ -1003,17 +1042,22 @@ msgstr ""
 "der Organisation zugänglich sind. Hinweis: der bibliografische Datensatz "
 "(Metadaten) ist immer öffentlich. Geben Sie eine Regel pro Zeile ein."
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4999
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:116
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:26
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:22
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:232
 msgid "List of files attached to the record."
 msgstr "Liste der mit der Ressource verbundenen Dateien."
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:21
+msgid "List of logs."
+msgstr ""
+
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:878
 msgid "Locality (Valais)"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:25
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:188
 msgid "Log"
 msgstr "Log"
@@ -1048,11 +1092,12 @@ msgstr ""
 msgid "Logout"
 msgstr "Abmelden"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:20
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:184
 msgid "Logs"
 msgstr "Logs"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5034
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:151
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:60
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:59
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:267
@@ -1071,11 +1116,11 @@ msgstr "Hauptteam"
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:291
 msgid "Main title"
-msgstr "Haupttitel"
+msgstr "Titel"
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:287
 msgid "Main titles"
-msgstr "Haupttitel"
+msgstr "Titel"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:836
 msgid "Mandate"
@@ -1093,38 +1138,38 @@ msgstr ""
 msgid "Mediator"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5028
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:145
 msgid "Mimetype"
 msgstr ""
 
-#: sonar/config.py:578
+#: sonar/config.py:602
 msgid "Most recent"
 msgstr "Neueste(r)"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:356
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:535
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:898
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:27
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:828
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:936
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:979
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1053
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:27
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:711
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:942
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1047
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:33
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:50
 msgid "Name"
 msgstr "Name"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:23
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:23
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:707
 msgid "Names"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:55
-msgid "Not OA / Rights reserved"
-msgstr "Nicht OA / Rechte vorbehalten"
+#: sonar/modules/collections/templates/collections/index.html:32
+msgid "No collection found"
+msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:650
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:828
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1635
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1647
 msgid "Note"
 msgstr "Anmerkung"
 
@@ -1141,8 +1186,8 @@ msgid "Notes"
 msgstr "Anmerkungen"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:741
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:577
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1303
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:579
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1319
 msgid "Number"
 msgstr "Heft"
 
@@ -1162,8 +1207,7 @@ msgstr "OAI-PMH Sets."
 msgid "OAI-PMH specific information."
 msgstr "OAI-PMH-spezifische Information."
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:880
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1014
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:994
 msgid "ORCID"
 msgstr "ORCID"
 
@@ -1172,18 +1216,17 @@ msgstr "ORCID"
 msgid "Object type"
 msgstr "Objekttyp"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1760
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:2
 msgid "Open access status"
 msgstr "Open Access Status"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:93
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4969
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4973
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:86
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:90
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:222
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:5
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:84
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:287
-#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:291
 msgid "Organisation"
 msgstr "Organisation"
 
@@ -1224,26 +1267,22 @@ msgstr ""
 "Sonstige Materialeigenschaften, z.B. Abbildungen, schwarz-weiss, oder "
 "farbig."
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:51
-msgid "Other OA / license undefined"
-msgstr "Andere Art von OA / Lizenz unbestimmt"
-
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:882
 msgid "Other canton (Switzerland)"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:624
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:641
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:953
 #: sonar/modules/documents/templates/documents/record.html:208
 msgid "Other electronic version"
 msgstr "Andere elektronische Version"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:621
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:638
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:949
 msgid "Other electronic versions"
 msgstr "Andere elektronische Versionen"
 
-#: sonar/modules/documents/templates/documents/record.html:311
+#: sonar/modules/documents/templates/documents/record.html:329
 msgid "Other files"
 msgstr "Andere Dateien"
 
@@ -1256,8 +1295,8 @@ msgstr ""
 msgid "PID type"
 msgstr "PID-Typ"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:585
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1437
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:596
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1449
 msgid "Pages"
 msgstr "Seiten"
 
@@ -1265,8 +1304,7 @@ msgstr "Seiten"
 msgid "Parents"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:540
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1407
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1419
 msgid "Part of (host document)"
 msgstr "Enthalten in (Übergeordnetes Dokument)"
 
@@ -1278,7 +1316,7 @@ msgstr ""
 msgid "Period"
 msgstr "Zeitraum"
 
-#: sonar/modules/documents/templates/documents/record.html:301
+#: sonar/modules/documents/templates/documents/record.html:319
 msgid "Permalink"
 msgstr "Permalink"
 
@@ -1295,7 +1333,7 @@ msgstr "Telefonnummer"
 msgid "Phone number with the international prefix, without spaces."
 msgstr "Telefonnummer mit Landesvorwahl, ohne Leerzeichen."
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1287
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1303
 msgid "Place"
 msgstr "Ort"
 
@@ -1306,6 +1344,15 @@ msgstr ""
 #: sonar/templates/security/email/welcome.html:5
 msgid "Please confirm your e-mail by clicking here"
 msgstr "Bitte bestätigen Sie Ihre Email-Adresse, indem Sie hier klicken"
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:573
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:590
+msgid "Please enter a valid number."
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:606
+msgid "Please enter a valid pages range, example: 135, 5-27."
+msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:85
 msgid "Position"
@@ -1336,13 +1383,13 @@ msgstr ""
 msgid "Practitioner-trainer"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1210
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1226
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:164
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:255
 msgid "Preferred name"
 msgstr "Bevorzugter Name"
 
-#: sonar/modules/documents/templates/documents/record.html:329
+#: sonar/modules/documents/templates/documents/record.html:347
 #: sonar/theme/templates/sonar/preview/base.html:23
 msgid "Preview"
 msgstr "Vorschau"
@@ -1362,11 +1409,11 @@ msgstr ""
 
 #: sonar/theme/templates/sonar/partial/dropdown_user.html:21
 #: sonar/theme/templates/sonar/partial/dropdown_user.html:24
-#: sonar/theme/views.py:66
+#: sonar/theme/views.py:68
 msgid "Profile"
 msgstr "Profil"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:916
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1027
 msgid "Project"
 msgstr "Projekt"
 
@@ -1406,12 +1453,12 @@ msgstr "Öffentlicher Zugang ab"
 msgid "Public foundation"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:633
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:650
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:973
 msgid "Public note"
 msgstr "Öffentliche Anmerkung"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1456
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1468
 msgid "Publication"
 msgstr "Veröffentlichung"
 
@@ -1424,12 +1471,12 @@ msgid "Published in"
 msgstr "Veröffentlicht in"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:332
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:606
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:623
 msgid "Publisher"
 msgstr "Verlag"
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:836
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1643
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1655
 msgid "Qualifier"
 msgstr "Erläuterung"
 
@@ -1437,15 +1484,19 @@ msgstr "Erläuterung"
 msgid "Realization framework"
 msgstr "Realisierungsrahmen"
 
+#: sonar/modules/validation/api.py:216
+msgid "Record validation"
+msgstr ""
+
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:4
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:908
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1732
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1019
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1744
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:4
 msgid "Research project"
 msgstr "Forschungsprojekt"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:901
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1728
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1015
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1740
 #: sonar/modules/documents/templates/documents/record.html:183
 msgid "Research projects"
 msgstr "Forschungsprojekte"
@@ -1461,15 +1512,18 @@ msgstr "Passwort zurücksetzen"
 msgid "Responsibility"
 msgstr "Verantwortlichkeit"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:839
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:984
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1330
+#: sonar/common/jsonschemas/license-v1.0.0.json:56
+msgid "Rights reserved"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:953
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1346
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:99
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:181
 msgid "Role"
 msgstr "Rolle"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1326
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1342
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:177
 msgid "Roles"
 msgstr "Rollen"
@@ -1492,6 +1546,10 @@ msgstr "Logo von SONAR"
 msgid "Schema"
 msgstr "Schema"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:3
+msgid "Schema representing a validation workflow."
+msgstr ""
+
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:9
 msgid "Schema to validate document against."
 msgstr "Schema zur Validierung von bibliographischen Aufnahmen."
@@ -1506,6 +1564,10 @@ msgstr ""
 #: sonar/theme/templates/sonar/partial/organisation.html:21
 msgid "Search"
 msgstr "Suche"
+
+#: sonar/modules/collections/templates/collections/item.html:48
+msgid "Search in collection"
+msgstr ""
 
 #: sonar/theme/templates/sonar/frontpage.html:57
 msgid "Search publications, authors, projects..."
@@ -1564,14 +1626,14 @@ msgstr "Registrieren mit %(type)s"
 msgid "Sign-up with SWITCHaai"
 msgstr "Registrieren mit SWITCHaai"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5039
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:156
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:65
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:64
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:272
 msgid "Size"
 msgstr "Grösse"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5040
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:157
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:66
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:65
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:273
@@ -1586,8 +1648,8 @@ msgstr ""
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:510
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:849
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:926
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1245
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1656
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1261
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1668
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:117
 msgid "Source"
 msgstr "Quelle"
@@ -1600,13 +1662,9 @@ msgstr "Quellcode bei"
 msgid "Special education teacher"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:659
-msgid "Specific collections"
-msgstr "Besondere Sammlungen"
-
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:67
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:952
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1461
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1063
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1473
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:66
 msgid "Start date"
 msgstr "Startdatum"
@@ -1632,7 +1690,7 @@ msgid "State of Valais, parastatal institution"
 msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:474
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1466
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1478
 msgid "Statement"
 msgstr "Angabe"
 
@@ -1640,10 +1698,11 @@ msgstr "Angabe"
 msgid "Statements"
 msgstr "Angaben"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:64
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:39
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:136
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:860
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1667
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1679
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:39
 msgid "Status"
 msgstr "Status"
@@ -1672,14 +1731,11 @@ msgstr ""
 msgid "Student in training"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:721
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:898
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:915
 msgid "Subject"
 msgstr "Thema"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:718
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:737
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:894
 msgid "Subjects"
 msgstr "Themen"
@@ -1701,7 +1757,7 @@ msgstr "Super-Administration"
 msgid "Suspended"
 msgstr ""
 
-#: sonar/config.py:94 sonar/config.py:98
+#: sonar/config.py:96 sonar/config.py:100
 msgid "Swiss Open Access Repository"
 msgstr "Swiss Open Access Repository"
 
@@ -1738,7 +1794,7 @@ msgstr ""
 "Personen, die mit öffentlichen Schweizer Forschungseinrichtungen "
 "verbunden sind."
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:660
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:677
 msgid ""
 "The names of the organisation's specific/patrimonial collections to which"
 " this document belongs"
@@ -1769,7 +1825,7 @@ msgstr ""
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:304
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:264
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:627
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1450
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1462
 msgid "Title"
 msgstr "Titel"
 
@@ -1812,11 +1868,11 @@ msgstr ""
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:449
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:478
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:698
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1022
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1052
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1185
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1225
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1505
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1038
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1068
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1201
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1241
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1517
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:97
 msgid "Type"
 msgstr "Typ"
@@ -1829,7 +1885,7 @@ msgstr ""
 msgid "Type of the file"
 msgstr "Dateityp"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:643
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:660
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:963
 msgid "URL"
 msgstr "URL"
@@ -1846,10 +1902,12 @@ msgstr "UUID des ObjectVersion-Objekts."
 msgid "UUID of the bucket the tile is assigned to."
 msgstr "UUID des Buckets, dem die Kachel zugewiesen ist."
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1146
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1162
 msgid "Usage and access policy"
 msgstr "Nutzungs- und Zugangs-Richtlinien"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:90
+#: sonar/common/jsonschemas/validation-v1.0.0.json:96
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:116
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:121
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:120
@@ -1857,15 +1915,25 @@ msgstr "Nutzungs- und Zugangs-Richtlinien"
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:198
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:202
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:5
-#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:311
-#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:316
+#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:310
+#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:315
 msgid "User"
 msgstr "Benutzer"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:91
+msgid "User which created the record."
+msgstr ""
+
+#: sonar/common/jsonschemas/validation-v1.0.0.json:2
+msgid "Validation"
+msgstr ""
+
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:39
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:32
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2502
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:32
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:61
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:505
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:716
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:745
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:296
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:320
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:405
@@ -1874,8 +1942,8 @@ msgstr "Benutzer"
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:668
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:823
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:911
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1256
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1630
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1272
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1642
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:99
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:146
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:193
@@ -1883,7 +1951,11 @@ msgstr "Benutzer"
 msgid "Value"
 msgstr "Wert"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5018
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:851
+msgid "Values"
+msgstr ""
+
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:135
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:44
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:41
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:251
@@ -1894,8 +1966,8 @@ msgstr "Version-UUID"
 msgid "Vice-rector HE"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:569
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1421
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:562
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1433
 msgid "Volume"
 msgstr "Band"
 
@@ -1903,7 +1975,7 @@ msgstr "Band"
 msgid "Welcome to SONAR"
 msgstr "Willkommen bei SONAR"
 
-#: sonar/config.py:125
+#: sonar/config.py:127
 msgid "Welcome to SONAR, the Swiss Open Access Repository!"
 msgstr "Willkommen bei SONAR, dem Swiss Open Access Repository!"
 
@@ -1912,8 +1984,8 @@ msgid ""
 "What are the benefits and quality improvements in the research in this "
 "project?"
 msgstr ""
-"Was sind die Vorteile und Qualitätsverbesserungen der Forschung in diesem "
-"Projekt?"
+"Was sind die Vorteile und Qualitätsverbesserungen der Forschung in diesem"
+" Projekt?"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:770
 msgid "What are the benefits of research in training?"
@@ -1924,8 +1996,8 @@ msgid ""
 "What is the impact of research on public action or on internal or "
 "external governance?"
 msgstr ""
-"Welche Auswirkungen hat die Forschung auf das öffentliche Handeln oder auf "
-"die interne oder externe Steuerung?"
+"Welche Auswirkungen hat die Forschung auf das öffentliche Handeln oder "
+"auf die interne oder externe Steuerung?"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:782
 msgid "What is the impact of the research on the professional environment?"
@@ -1939,8 +2011,7 @@ msgstr ""
 msgid "Why?"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:564
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1416
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1428
 msgid "Year"
 msgstr "Jahr"
 
@@ -1962,78 +2033,78 @@ msgstr "Akteur"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:417
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:728
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1535
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1547
 msgid "bf:AudioIssueNumber"
 msgstr "Verlagsreferenz (Audiodokumente)"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1049
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1065
 msgid "bf:ClassificationDdc"
 msgstr "Dewey-Dezimalklassifikation (DDC)"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1019
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1035
 msgid "bf:ClassificationUdc"
 msgstr "Universelle Dezimalklassifikation (UDK)"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:402
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:732
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1539
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1551
 msgid "bf:Doi"
 msgstr "DOI"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:421
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:736
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1543
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1555
 msgid "bf:Ean"
 msgstr "EAN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:425
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:740
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1547
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1559
 msgid "bf:Gtin14Number"
 msgstr "GTIN-14"
 
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:17
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:429
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:744
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1234
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1551
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1250
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1563
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:106
 msgid "bf:Identifier"
 msgstr "Identifikator"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:433
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:748
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1555
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1567
 msgid "bf:Isan"
 msgstr "ISAN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:412
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:752
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1559
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1571
 msgid "bf:Isbn"
 msgstr "ISBN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:437
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:756
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1563
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1575
 msgid "bf:Ismn"
 msgstr "ISMN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:441
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:760
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1567
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1579
 msgid "bf:Isrc"
 msgstr "ISRC"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:445
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:764
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1571
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1583
 msgid "bf:Issn"
 msgstr "ISSN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:449
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:768
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1575
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1587
 msgid "bf:IssnL"
 msgstr "ISSN-L"
 
@@ -2044,8 +2115,8 @@ msgstr "Sprache"
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:21
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:453
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:772
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1238
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1579
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1254
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1591
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:110
 msgid "bf:Local"
 msgstr "Lokaler Identifikator"
@@ -2056,37 +2127,37 @@ msgstr "Herstellung"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:457
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:776
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1583
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1595
 msgid "bf:MatrixNumber"
 msgstr "Matrix-Nummer (Tone)"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1203
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1219
 msgid "bf:Meeting"
 msgstr "Konferenz"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:461
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:780
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1587
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1599
 msgid "bf:MusicDistributorNumber"
 msgstr "Vertriebsnummer (Musik)"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:465
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:784
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1591
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1603
 msgid "bf:MusicPlate"
 msgstr "Druckplattennummer (Partituren)"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:469
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:788
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1595
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1607
 msgid "bf:MusicPublisherNumber"
 msgstr "Verlagsnummer (Musik)"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1199
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1215
 msgid "bf:Organization"
 msgstr "Körperschaft"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1195
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1211
 msgid "bf:Person"
 msgstr "Person"
 
@@ -2100,41 +2171,41 @@ msgstr "Veröffentlichung"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:473
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:792
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1599
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1611
 msgid "bf:PublisherNumber"
 msgstr "Verlagsnummer"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:493
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:812
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1619
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1631
 msgid "bf:ReportNumber"
 msgstr "Berichtsnummer"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:497
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:816
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1623
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1635
 msgid "bf:Strn"
 msgstr "STRN"
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:280
 msgid "bf:Title"
-msgstr "Titel"
+msgstr "Haupttitel"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:477
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:796
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1603
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1615
 msgid "bf:Upc"
 msgstr "UPC"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:481
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:800
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1607
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1619
 msgid "bf:Urn"
 msgstr "URN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:485
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:804
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1611
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1623
 msgid "bf:VideoRecordingNumber"
 msgstr "Videoaufzeichnungsnummer"
 
@@ -2498,41 +2569,40 @@ msgstr "Open Access"
 msgid "coar:c_f1cf"
 msgstr "Unterliegt Embargo"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1002
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:195
 msgid "coinvestigator"
 msgstr "Mitgesuchstellende"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:857
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1351
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:971
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1367
 msgid "contribution_role_cre"
 msgstr "Verfasser / Schöpfer"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:861
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1359
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:975
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1375
 msgid "contribution_role_ctb"
 msgstr "Mitwirkende"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:869
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1343
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:983
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1359
 msgid "contribution_role_dgs"
 msgstr "Akademischer Betreuer"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:865
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1355
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:979
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1371
 msgid "contribution_role_edt"
 msgstr "Herausgeber"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:873
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1347
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:987
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1363
 msgid "contribution_role_prt"
 msgstr "Drucker"
 
-#: sonar/modules/documents/views.py:266
+#: sonar/modules/documents/views.py:272
 msgid "contribution_role_{role}"
 msgstr "contribution_role_{role}"
 
-#: sonar/config.py:549
+#: sonar/config.py:573
 msgid "contributor"
 msgstr "Mitwirkende"
 
@@ -2816,7 +2886,6 @@ msgstr ""
 msgid "innerSearcher"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:998
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:191
 msgid "investigator"
 msgstr "Gesuchstellende"
@@ -2825,2913 +2894,1948 @@ msgstr "Gesuchstellende"
 msgid "keywords"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:500
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:535
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3011
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:694
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1010
+msgid "label"
+msgstr ""
+
+#: sonar/common/jsonschemas/language-v1.0.0.json:497
 msgid "lang_aar"
 msgstr "Afar"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:504
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:539
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3015
+#: sonar/common/jsonschemas/language-v1.0.0.json:501
 msgid "lang_abk"
 msgstr "Abchasisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:508
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:543
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3019
+#: sonar/common/jsonschemas/language-v1.0.0.json:505
 msgid "lang_ace"
 msgstr "Achinesisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:512
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:547
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3023
+#: sonar/common/jsonschemas/language-v1.0.0.json:509
 msgid "lang_ach"
 msgstr "Acholi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:516
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:551
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3027
+#: sonar/common/jsonschemas/language-v1.0.0.json:513
 msgid "lang_ada"
 msgstr "Dangme"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:520
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:555
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3031
+#: sonar/common/jsonschemas/language-v1.0.0.json:517
 msgid "lang_ady"
 msgstr "Adygeisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:524
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:559
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3035
+#: sonar/common/jsonschemas/language-v1.0.0.json:521
 msgid "lang_afa"
 msgstr "Afroasiatische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:528
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:563
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3039
+#: sonar/common/jsonschemas/language-v1.0.0.json:525
 msgid "lang_afh"
 msgstr "Afrihili"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:532
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:567
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3043
+#: sonar/common/jsonschemas/language-v1.0.0.json:529
 msgid "lang_afr"
 msgstr "Afrikaans"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:536
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:571
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3047
+#: sonar/common/jsonschemas/language-v1.0.0.json:533
 msgid "lang_ain"
 msgstr "Ainu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:540
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:575
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3051
+#: sonar/common/jsonschemas/language-v1.0.0.json:537
 msgid "lang_aka"
 msgstr "Akan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:544
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:579
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3055
+#: sonar/common/jsonschemas/language-v1.0.0.json:541
 msgid "lang_akk"
 msgstr "Akkadisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:548
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:583
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3059
+#: sonar/common/jsonschemas/language-v1.0.0.json:545
 msgid "lang_alb"
 msgstr "Albanisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:552
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:587
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3063
+#: sonar/common/jsonschemas/language-v1.0.0.json:549
 msgid "lang_ale"
 msgstr "Aleutisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:556
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:591
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3067
+#: sonar/common/jsonschemas/language-v1.0.0.json:553
 msgid "lang_alg"
 msgstr "Algonkin Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:560
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:595
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3071
+#: sonar/common/jsonschemas/language-v1.0.0.json:557
 msgid "lang_alt"
 msgstr "Südaltaisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:564
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:599
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3075
+#: sonar/common/jsonschemas/language-v1.0.0.json:561
 msgid "lang_amh"
 msgstr "Amharisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:568
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:603
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3079
+#: sonar/common/jsonschemas/language-v1.0.0.json:565
 msgid "lang_ang"
 msgstr "Altenglisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:572
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:607
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3083
+#: sonar/common/jsonschemas/language-v1.0.0.json:569
 msgid "lang_anp"
 msgstr "Angika"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:576
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:611
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3087
+#: sonar/common/jsonschemas/language-v1.0.0.json:573
 msgid "lang_apa"
 msgstr "Apache Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:580
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:615
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3091
+#: sonar/common/jsonschemas/language-v1.0.0.json:577
 msgid "lang_ara"
 msgstr "Arabisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:584
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:619
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3095
+#: sonar/common/jsonschemas/language-v1.0.0.json:581
 msgid "lang_arc"
 msgstr "Reichsaramäisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:588
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:623
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3099
+#: sonar/common/jsonschemas/language-v1.0.0.json:585
 msgid "lang_arg"
 msgstr "Aragonesisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:592
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:627
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3103
+#: sonar/common/jsonschemas/language-v1.0.0.json:589
 msgid "lang_arm"
 msgstr "Armenisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:596
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:631
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3107
+#: sonar/common/jsonschemas/language-v1.0.0.json:593
 msgid "lang_arn"
 msgstr "Mapudungun"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:600
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:635
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3111
+#: sonar/common/jsonschemas/language-v1.0.0.json:597
 msgid "lang_arp"
 msgstr "Arapaho"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:604
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:639
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3115
+#: sonar/common/jsonschemas/language-v1.0.0.json:601
 msgid "lang_art"
 msgstr "Konstruierte Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:608
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:643
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3119
+#: sonar/common/jsonschemas/language-v1.0.0.json:605
 msgid "lang_arw"
 msgstr "Arawak"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:612
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:647
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3123
+#: sonar/common/jsonschemas/language-v1.0.0.json:609
 msgid "lang_asm"
 msgstr "Assamesisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:616
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:651
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3127
+#: sonar/common/jsonschemas/language-v1.0.0.json:613
 msgid "lang_ast"
 msgstr "Asturisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:620
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:655
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3131
+#: sonar/common/jsonschemas/language-v1.0.0.json:617
 msgid "lang_ath"
 msgstr "Athapaskische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:624
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:659
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3135
+#: sonar/common/jsonschemas/language-v1.0.0.json:621
 msgid "lang_aus"
 msgstr "Australische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:628
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:663
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3139
+#: sonar/common/jsonschemas/language-v1.0.0.json:625
 msgid "lang_ava"
 msgstr "Awarisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:632
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:667
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3143
+#: sonar/common/jsonschemas/language-v1.0.0.json:629
 msgid "lang_ave"
 msgstr "Avestisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:636
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:671
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3147
+#: sonar/common/jsonschemas/language-v1.0.0.json:633
 msgid "lang_awa"
 msgstr "Awadhi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:640
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:675
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3151
+#: sonar/common/jsonschemas/language-v1.0.0.json:637
 msgid "lang_aym"
 msgstr "Aymara"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:644
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:679
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3155
+#: sonar/common/jsonschemas/language-v1.0.0.json:641
 msgid "lang_aze"
 msgstr "Aserbaidschanisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:648
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:683
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3159
+#: sonar/common/jsonschemas/language-v1.0.0.json:645
 msgid "lang_bad"
 msgstr "Banda Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:652
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:687
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3163
+#: sonar/common/jsonschemas/language-v1.0.0.json:649
 msgid "lang_bai"
 msgstr "Bamileke Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:656
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:691
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3167
+#: sonar/common/jsonschemas/language-v1.0.0.json:653
 msgid "lang_bak"
 msgstr "Baschkirisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:660
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:695
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3171
+#: sonar/common/jsonschemas/language-v1.0.0.json:657
 msgid "lang_bal"
 msgstr "Belutschisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:664
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:699
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3175
+#: sonar/common/jsonschemas/language-v1.0.0.json:661
 msgid "lang_bam"
 msgstr "Bambara"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:668
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:703
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3179
+#: sonar/common/jsonschemas/language-v1.0.0.json:665
 msgid "lang_ban"
 msgstr "Balinesisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:672
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:707
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3183
+#: sonar/common/jsonschemas/language-v1.0.0.json:669
 msgid "lang_baq"
 msgstr "Baskisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:676
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:711
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3187
+#: sonar/common/jsonschemas/language-v1.0.0.json:673
 msgid "lang_bas"
 msgstr "Basaa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:680
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:715
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3191
+#: sonar/common/jsonschemas/language-v1.0.0.json:677
 msgid "lang_bat"
 msgstr "Baltische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:684
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:719
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3195
+#: sonar/common/jsonschemas/language-v1.0.0.json:681
 msgid "lang_bej"
 msgstr "Bedscha"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:688
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:723
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3199
+#: sonar/common/jsonschemas/language-v1.0.0.json:685
 msgid "lang_bel"
 msgstr "Weissrussisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:692
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:727
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3203
+#: sonar/common/jsonschemas/language-v1.0.0.json:689
 msgid "lang_bem"
 msgstr "Bemba"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:696
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:731
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3207
+#: sonar/common/jsonschemas/language-v1.0.0.json:693
 msgid "lang_ben"
 msgstr "Bengalisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:700
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:735
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3211
+#: sonar/common/jsonschemas/language-v1.0.0.json:697
 msgid "lang_ber"
 msgstr "Berbersprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:704
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:739
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3215
+#: sonar/common/jsonschemas/language-v1.0.0.json:701
 msgid "lang_bho"
 msgstr "Bhojpuri"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:708
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:743
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3219
+#: sonar/common/jsonschemas/language-v1.0.0.json:705
 msgid "lang_bih"
 msgstr "Bihari"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:712
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:747
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3223
+#: sonar/common/jsonschemas/language-v1.0.0.json:709
 msgid "lang_bik"
 msgstr "Bikolano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:716
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:751
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3227
+#: sonar/common/jsonschemas/language-v1.0.0.json:713
 msgid "lang_bin"
 msgstr "Edo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:720
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:755
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3231
+#: sonar/common/jsonschemas/language-v1.0.0.json:717
 msgid "lang_bis"
 msgstr "Bislama"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:724
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:759
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3235
+#: sonar/common/jsonschemas/language-v1.0.0.json:721
 msgid "lang_bla"
 msgstr "Blackfoot"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:728
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:763
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3239
+#: sonar/common/jsonschemas/language-v1.0.0.json:725
 msgid "lang_bnt"
 msgstr "Bantusprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:732
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:767
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3243
+#: sonar/common/jsonschemas/language-v1.0.0.json:729
 msgid "lang_bos"
 msgstr "Bosnisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:736
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:771
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3247
+#: sonar/common/jsonschemas/language-v1.0.0.json:733
 msgid "lang_bra"
 msgstr "Braj-Bhakha"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:740
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:775
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3251
+#: sonar/common/jsonschemas/language-v1.0.0.json:737
 msgid "lang_bre"
 msgstr "Bretonisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:744
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:779
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3255
+#: sonar/common/jsonschemas/language-v1.0.0.json:741
 msgid "lang_btk"
 msgstr "Bataksprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:748
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:783
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3259
+#: sonar/common/jsonschemas/language-v1.0.0.json:745
 msgid "lang_bua"
 msgstr "Burjatisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:752
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:787
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3263
+#: sonar/common/jsonschemas/language-v1.0.0.json:749
 msgid "lang_bug"
 msgstr "Buginesisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:756
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:791
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3267
+#: sonar/common/jsonschemas/language-v1.0.0.json:753
 msgid "lang_bul"
 msgstr "Bulgarisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:760
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:795
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3271
+#: sonar/common/jsonschemas/language-v1.0.0.json:757
 msgid "lang_bur"
 msgstr "Birmanisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:764
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:799
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3275
+#: sonar/common/jsonschemas/language-v1.0.0.json:761
 msgid "lang_byn"
 msgstr "Blin"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:768
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:803
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3279
+#: sonar/common/jsonschemas/language-v1.0.0.json:765
 msgid "lang_cad"
 msgstr "Caddo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:772
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:807
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3283
+#: sonar/common/jsonschemas/language-v1.0.0.json:769
 msgid "lang_cai"
 msgstr "Mesoamerikanische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:776
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:811
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3287
+#: sonar/common/jsonschemas/language-v1.0.0.json:773
 msgid "lang_car"
 msgstr "Karib"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:780
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:815
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3291
+#: sonar/common/jsonschemas/language-v1.0.0.json:777
 msgid "lang_cat"
 msgstr "Katalanisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:784
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:819
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3295
+#: sonar/common/jsonschemas/language-v1.0.0.json:781
 msgid "lang_cau"
 msgstr "Kaukasisch (anderes)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:788
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:823
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3299
+#: sonar/common/jsonschemas/language-v1.0.0.json:785
 msgid "lang_ceb"
 msgstr "Cebuano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:792
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:827
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3303
+#: sonar/common/jsonschemas/language-v1.0.0.json:789
 msgid "lang_cel"
 msgstr "Keltische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:796
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:831
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3307
+#: sonar/common/jsonschemas/language-v1.0.0.json:793
 msgid "lang_cha"
 msgstr "Chamorro"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:800
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:835
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3311
+#: sonar/common/jsonschemas/language-v1.0.0.json:797
 msgid "lang_chb"
 msgstr "Chibcha"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:804
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:839
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3315
+#: sonar/common/jsonschemas/language-v1.0.0.json:801
 msgid "lang_che"
 msgstr "Tschechisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:808
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:843
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3319
+#: sonar/common/jsonschemas/language-v1.0.0.json:805
 msgid "lang_chg"
 msgstr "Tschagataisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:812
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:847
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3323
+#: sonar/common/jsonschemas/language-v1.0.0.json:809
 msgid "lang_chi"
 msgstr "Chinesisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:816
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:851
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3327
+#: sonar/common/jsonschemas/language-v1.0.0.json:813
 msgid "lang_chk"
 msgstr "Chuukesisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:820
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:855
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3331
+#: sonar/common/jsonschemas/language-v1.0.0.json:817
 msgid "lang_chm"
 msgstr "Mari"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:824
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:859
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3335
+#: sonar/common/jsonschemas/language-v1.0.0.json:821
 msgid "lang_chn"
 msgstr "Chinook Wawa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:828
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:863
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3339
+#: sonar/common/jsonschemas/language-v1.0.0.json:825
 msgid "lang_cho"
 msgstr "Choctaw"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:832
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:867
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3343
+#: sonar/common/jsonschemas/language-v1.0.0.json:829
 msgid "lang_chp"
 msgstr "Chipewyan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:836
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:871
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3347
+#: sonar/common/jsonschemas/language-v1.0.0.json:833
 msgid "lang_chr"
 msgstr "Cherokee"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:840
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:875
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3351
+#: sonar/common/jsonschemas/language-v1.0.0.json:837
 msgid "lang_chu"
 msgstr "Kirchenslawisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:844
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:879
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3355
+#: sonar/common/jsonschemas/language-v1.0.0.json:841
 msgid "lang_chv"
 msgstr "Tschuwaschisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:848
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:883
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3359
+#: sonar/common/jsonschemas/language-v1.0.0.json:845
 msgid "lang_chy"
 msgstr "Cheyenne"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:852
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:887
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3363
+#: sonar/common/jsonschemas/language-v1.0.0.json:849
 msgid "lang_cmc"
 msgstr "Chamische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:856
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:891
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3367
+#: sonar/common/jsonschemas/language-v1.0.0.json:853
 msgid "lang_cnr"
 msgstr "Montenegrinisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:860
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:895
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3371
+#: sonar/common/jsonschemas/language-v1.0.0.json:857
 msgid "lang_cop"
 msgstr "Koptisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:864
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:899
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3375
+#: sonar/common/jsonschemas/language-v1.0.0.json:861
 msgid "lang_cor"
 msgstr "Kornisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:868
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:903
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3379
+#: sonar/common/jsonschemas/language-v1.0.0.json:865
 msgid "lang_cos"
 msgstr "Korsisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:872
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:907
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3383
+#: sonar/common/jsonschemas/language-v1.0.0.json:869
 msgid "lang_cpe"
 msgstr "Englisch-basierte Kreols und Pidgins"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:876
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:911
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3387
+#: sonar/common/jsonschemas/language-v1.0.0.json:873
 msgid "lang_cpf"
 msgstr "Französisch-basierte Kreols und Pidgins"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:880
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:915
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3391
+#: sonar/common/jsonschemas/language-v1.0.0.json:877
 msgid "lang_cpp"
 msgstr "Portugiesisch-basierte Kreols und Pidgins"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:884
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:919
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3395
+#: sonar/common/jsonschemas/language-v1.0.0.json:881
 msgid "lang_cre"
 msgstr "Cree"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:888
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:923
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3399
+#: sonar/common/jsonschemas/language-v1.0.0.json:885
 msgid "lang_crh"
 msgstr "Krimtatarisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:892
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:927
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3403
+#: sonar/common/jsonschemas/language-v1.0.0.json:889
 msgid "lang_crp"
 msgstr "Kreol- und Pidginsprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:896
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:931
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3407
+#: sonar/common/jsonschemas/language-v1.0.0.json:893
 msgid "lang_csb"
 msgstr "Kaschubisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:900
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:935
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3411
+#: sonar/common/jsonschemas/language-v1.0.0.json:897
 msgid "lang_cus"
 msgstr "Kuschitische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:904
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:939
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3415
+#: sonar/common/jsonschemas/language-v1.0.0.json:901
 msgid "lang_cze"
 msgstr "Tschechisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:908
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:943
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3419
+#: sonar/common/jsonschemas/language-v1.0.0.json:905
 msgid "lang_dak"
 msgstr "Dakota"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:912
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:947
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3423
+#: sonar/common/jsonschemas/language-v1.0.0.json:909
 msgid "lang_dan"
 msgstr "Dänisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:916
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:951
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3427
+#: sonar/common/jsonschemas/language-v1.0.0.json:913
 msgid "lang_dar"
 msgstr "Darginisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:920
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:955
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3431
+#: sonar/common/jsonschemas/language-v1.0.0.json:917
 msgid "lang_day"
 msgstr "Land-Dayak-Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:924
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:959
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3435
+#: sonar/common/jsonschemas/language-v1.0.0.json:921
 msgid "lang_del"
 msgstr "Delawarisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:928
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:963
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3439
+#: sonar/common/jsonschemas/language-v1.0.0.json:925
 msgid "lang_den"
 msgstr "Slavey"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:932
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:967
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3443
+#: sonar/common/jsonschemas/language-v1.0.0.json:929
 msgid "lang_dgr"
 msgstr "Dogrib"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:936
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:971
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3447
+#: sonar/common/jsonschemas/language-v1.0.0.json:933
 msgid "lang_din"
 msgstr "Dinka"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:940
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:975
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3451
+#: sonar/common/jsonschemas/language-v1.0.0.json:937
 msgid "lang_div"
 msgstr "Dhivehi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:944
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:979
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3455
+#: sonar/common/jsonschemas/language-v1.0.0.json:941
 msgid "lang_doi"
 msgstr "Dogri"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:948
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:983
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3459
+#: sonar/common/jsonschemas/language-v1.0.0.json:945
 msgid "lang_dra"
 msgstr "Dravidische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:952
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:987
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3463
+#: sonar/common/jsonschemas/language-v1.0.0.json:949
 msgid "lang_dsb"
 msgstr "Niedersorbisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:956
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:991
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3467
+#: sonar/common/jsonschemas/language-v1.0.0.json:953
 msgid "lang_dua"
 msgstr "Duala"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:960
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:995
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3471
+#: sonar/common/jsonschemas/language-v1.0.0.json:957
 msgid "lang_dum"
 msgstr "Mittelniederländisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:964
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:999
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3475
+#: sonar/common/jsonschemas/language-v1.0.0.json:961
 msgid "lang_dut"
 msgstr "Niederländisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:968
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1003
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3479
+#: sonar/common/jsonschemas/language-v1.0.0.json:965
 msgid "lang_dyu"
 msgstr "Dioula"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:972
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1007
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3483
+#: sonar/common/jsonschemas/language-v1.0.0.json:969
 msgid "lang_dzo"
 msgstr "Dzongkha"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:976
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1011
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3487
+#: sonar/common/jsonschemas/language-v1.0.0.json:973
 msgid "lang_efi"
 msgstr "Efik"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:980
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1015
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3491
+#: sonar/common/jsonschemas/language-v1.0.0.json:977
 msgid "lang_egy"
 msgstr "Ägyptisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:984
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1019
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3495
+#: sonar/common/jsonschemas/language-v1.0.0.json:981
 msgid "lang_eka"
 msgstr "Ekajuk"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:988
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1023
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3499
+#: sonar/common/jsonschemas/language-v1.0.0.json:985
 msgid "lang_elx"
 msgstr "Elamisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:992
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1027
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3503
+#: sonar/common/jsonschemas/language-v1.0.0.json:989
 msgid "lang_eng"
 msgstr "Englisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:997
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1032
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3508
+#: sonar/common/jsonschemas/language-v1.0.0.json:994
 msgid "lang_enm"
 msgstr "Mittelenglisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1001
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1036
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3512
+#: sonar/common/jsonschemas/language-v1.0.0.json:998
 msgid "lang_epo"
 msgstr "Esperanto"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1005
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1040
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3516
+#: sonar/common/jsonschemas/language-v1.0.0.json:1002
 msgid "lang_est"
 msgstr "Estnisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1009
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1044
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3520
+#: sonar/common/jsonschemas/language-v1.0.0.json:1006
 msgid "lang_ewe"
 msgstr "Ewe"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1013
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1048
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3524
+#: sonar/common/jsonschemas/language-v1.0.0.json:1010
 msgid "lang_ewo"
 msgstr "Ewondo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1017
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1052
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3528
+#: sonar/common/jsonschemas/language-v1.0.0.json:1014
 msgid "lang_fan"
 msgstr "Fang"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1021
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1056
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3532
+#: sonar/common/jsonschemas/language-v1.0.0.json:1018
 msgid "lang_fao"
 msgstr "Färöisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1025
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1060
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3536
+#: sonar/common/jsonschemas/language-v1.0.0.json:1022
 msgid "lang_fat"
 msgstr "Fante"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1029
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1064
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3540
+#: sonar/common/jsonschemas/language-v1.0.0.json:1026
 msgid "lang_fij"
 msgstr "Fidschi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1033
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1068
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3544
+#: sonar/common/jsonschemas/language-v1.0.0.json:1030
 msgid "lang_fil"
 msgstr "Filipino"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1037
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1072
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3548
+#: sonar/common/jsonschemas/language-v1.0.0.json:1034
 msgid "lang_fin"
 msgstr "Finnisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1041
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1076
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3552
+#: sonar/common/jsonschemas/language-v1.0.0.json:1038
 msgid "lang_fiu"
 msgstr "Finno-ugrische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1045
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1080
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3556
+#: sonar/common/jsonschemas/language-v1.0.0.json:1042
 msgid "lang_fon"
 msgstr "Fon"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1049
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1084
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3560
+#: sonar/common/jsonschemas/language-v1.0.0.json:1046
 msgid "lang_fre"
 msgstr "Französisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1054
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1089
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3565
+#: sonar/common/jsonschemas/language-v1.0.0.json:1051
 msgid "lang_frm"
 msgstr "Mittelfranzösisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1058
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1093
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3569
+#: sonar/common/jsonschemas/language-v1.0.0.json:1055
 msgid "lang_fro"
 msgstr "Altfranzösisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1062
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1097
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3573
+#: sonar/common/jsonschemas/language-v1.0.0.json:1059
 msgid "lang_frr"
 msgstr "Nordfriesisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1066
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1101
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3577
+#: sonar/common/jsonschemas/language-v1.0.0.json:1063
 msgid "lang_frs"
 msgstr "Ostfriesisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1070
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1105
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3581
+#: sonar/common/jsonschemas/language-v1.0.0.json:1067
 msgid "lang_fry"
 msgstr "Westfriesisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1074
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1109
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3585
+#: sonar/common/jsonschemas/language-v1.0.0.json:1071
 msgid "lang_ful"
 msgstr "Fulfulde"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1078
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1113
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3589
+#: sonar/common/jsonschemas/language-v1.0.0.json:1075
 msgid "lang_fur"
 msgstr "Friulian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1082
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1117
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3593
+#: sonar/common/jsonschemas/language-v1.0.0.json:1079
 msgid "lang_gaa"
 msgstr "Ga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1086
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1121
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3597
+#: sonar/common/jsonschemas/language-v1.0.0.json:1083
 msgid "lang_gay"
 msgstr "Gayo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1090
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1125
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3601
+#: sonar/common/jsonschemas/language-v1.0.0.json:1087
 msgid "lang_gba"
 msgstr "Gbaya"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1094
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1129
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3605
+#: sonar/common/jsonschemas/language-v1.0.0.json:1091
 msgid "lang_gem"
 msgstr "Germanische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1098
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1133
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3609
+#: sonar/common/jsonschemas/language-v1.0.0.json:1095
 msgid "lang_geo"
 msgstr "Georgisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1102
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1137
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3613
+#: sonar/common/jsonschemas/language-v1.0.0.json:1099
 msgid "lang_ger"
 msgstr "Deutsch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1107
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1142
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3618
+#: sonar/common/jsonschemas/language-v1.0.0.json:1104
 msgid "lang_gez"
 msgstr "Geez"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1111
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1146
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3622
+#: sonar/common/jsonschemas/language-v1.0.0.json:1108
 msgid "lang_gil"
 msgstr "Kiribatisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1115
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1150
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3626
+#: sonar/common/jsonschemas/language-v1.0.0.json:1112
 msgid "lang_gla"
 msgstr "Schottisch-gälisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1119
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1154
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3630
+#: sonar/common/jsonschemas/language-v1.0.0.json:1116
 msgid "lang_gle"
 msgstr "Irisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1123
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1158
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3634
+#: sonar/common/jsonschemas/language-v1.0.0.json:1120
 msgid "lang_glg"
 msgstr "Galicisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1127
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1162
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3638
+#: sonar/common/jsonschemas/language-v1.0.0.json:1124
 msgid "lang_glv"
 msgstr "Manx"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1131
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1166
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3642
+#: sonar/common/jsonschemas/language-v1.0.0.json:1128
 msgid "lang_gmh"
 msgstr "Mittelhochdeutsch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1135
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1170
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3646
+#: sonar/common/jsonschemas/language-v1.0.0.json:1132
 msgid "lang_goh"
 msgstr "Althochdeutsch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1139
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1174
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3650
+#: sonar/common/jsonschemas/language-v1.0.0.json:1136
 msgid "lang_gon"
 msgstr "Gondi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1143
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1178
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3654
+#: sonar/common/jsonschemas/language-v1.0.0.json:1140
 msgid "lang_gor"
 msgstr "Gorontalo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1147
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1182
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3658
+#: sonar/common/jsonschemas/language-v1.0.0.json:1144
 msgid "lang_got"
 msgstr "Gotisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1151
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1186
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3662
+#: sonar/common/jsonschemas/language-v1.0.0.json:1148
 msgid "lang_grb"
 msgstr "Grebo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1155
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1190
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3666
+#: sonar/common/jsonschemas/language-v1.0.0.json:1152
 msgid "lang_grc"
 msgstr "Altgriechisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1159
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1194
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3670
+#: sonar/common/jsonschemas/language-v1.0.0.json:1156
 msgid "lang_gre"
 msgstr "Griechisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1163
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1198
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3674
+#: sonar/common/jsonschemas/language-v1.0.0.json:1160
 msgid "lang_grn"
 msgstr "Guarani"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1167
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1202
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3678
+#: sonar/common/jsonschemas/language-v1.0.0.json:1164
 msgid "lang_gsw"
 msgstr "Schweizerdeutsch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1171
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1206
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3682
+#: sonar/common/jsonschemas/language-v1.0.0.json:1168
 msgid "lang_guj"
 msgstr "Gujarati"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1175
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1210
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3686
+#: sonar/common/jsonschemas/language-v1.0.0.json:1172
 msgid "lang_gwi"
 msgstr "Gwich'in (Sprache)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1179
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1214
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3690
+#: sonar/common/jsonschemas/language-v1.0.0.json:1176
 msgid "lang_hai"
 msgstr "Haida"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1183
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1218
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3694
+#: sonar/common/jsonschemas/language-v1.0.0.json:1180
 msgid "lang_hat"
 msgstr "Haitianisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1187
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1222
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3698
+#: sonar/common/jsonschemas/language-v1.0.0.json:1184
 msgid "lang_hau"
 msgstr "Hausa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1191
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1226
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3702
+#: sonar/common/jsonschemas/language-v1.0.0.json:1188
 msgid "lang_haw"
 msgstr "Hawaiisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1195
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1230
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3706
+#: sonar/common/jsonschemas/language-v1.0.0.json:1192
 msgid "lang_heb"
 msgstr "Hebräisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1199
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1234
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3710
+#: sonar/common/jsonschemas/language-v1.0.0.json:1196
 msgid "lang_her"
 msgstr "Otjiherero"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1203
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1238
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3714
+#: sonar/common/jsonschemas/language-v1.0.0.json:1200
 msgid "lang_hil"
 msgstr "Hiligaynon"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1207
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1242
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3718
+#: sonar/common/jsonschemas/language-v1.0.0.json:1204
 msgid "lang_him"
 msgstr "West-Paharisprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1211
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1246
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3722
+#: sonar/common/jsonschemas/language-v1.0.0.json:1208
 msgid "lang_hin"
 msgstr "Hindi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1215
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1250
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3726
+#: sonar/common/jsonschemas/language-v1.0.0.json:1212
 msgid "lang_hit"
 msgstr "Hethitisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1219
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1254
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3730
+#: sonar/common/jsonschemas/language-v1.0.0.json:1216
 msgid "lang_hmn"
 msgstr "Hmong-Sprache"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1223
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1258
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3734
+#: sonar/common/jsonschemas/language-v1.0.0.json:1220
 msgid "lang_hmo"
 msgstr "Hiri-Motu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1227
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1262
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3738
+#: sonar/common/jsonschemas/language-v1.0.0.json:1224
 msgid "lang_hrv"
 msgstr "Kroatisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1231
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1266
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3742
+#: sonar/common/jsonschemas/language-v1.0.0.json:1228
 msgid "lang_hsb"
 msgstr "Obersorbisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1235
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1270
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3746
+#: sonar/common/jsonschemas/language-v1.0.0.json:1232
 msgid "lang_hun"
 msgstr "Ungarisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1239
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1274
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3750
+#: sonar/common/jsonschemas/language-v1.0.0.json:1236
 msgid "lang_hup"
 msgstr "Hoopa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1243
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1278
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3754
+#: sonar/common/jsonschemas/language-v1.0.0.json:1240
 msgid "lang_iba"
 msgstr "Iban"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1247
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1282
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3758
+#: sonar/common/jsonschemas/language-v1.0.0.json:1244
 msgid "lang_ibo"
 msgstr "Igbo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1251
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1286
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3762
+#: sonar/common/jsonschemas/language-v1.0.0.json:1248
 msgid "lang_ice"
 msgstr "Isländisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1255
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1290
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3766
+#: sonar/common/jsonschemas/language-v1.0.0.json:1252
 msgid "lang_ido"
 msgstr "Ido"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1259
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1294
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3770
+#: sonar/common/jsonschemas/language-v1.0.0.json:1256
 msgid "lang_iii"
 msgstr "Yi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1263
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1298
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3774
+#: sonar/common/jsonschemas/language-v1.0.0.json:1260
 msgid "lang_ijo"
 msgstr "Ijo-Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1267
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1302
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3778
+#: sonar/common/jsonschemas/language-v1.0.0.json:1264
 msgid "lang_iku"
 msgstr "Inuktitut"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1271
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1306
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3782
+#: sonar/common/jsonschemas/language-v1.0.0.json:1268
 msgid "lang_ile"
 msgstr "Interlingue"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1275
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1310
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3786
+#: sonar/common/jsonschemas/language-v1.0.0.json:1272
 msgid "lang_ilo"
 msgstr "Ilokano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1279
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1314
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3790
+#: sonar/common/jsonschemas/language-v1.0.0.json:1276
 msgid "lang_ina"
 msgstr "Interlingua"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1283
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1318
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3794
+#: sonar/common/jsonschemas/language-v1.0.0.json:1280
 msgid "lang_inc"
 msgstr "Indoarische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1287
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1322
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3798
+#: sonar/common/jsonschemas/language-v1.0.0.json:1284
 msgid "lang_ind"
 msgstr "Indonesisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1291
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1326
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3802
+#: sonar/common/jsonschemas/language-v1.0.0.json:1288
 msgid "lang_ine"
 msgstr "Indogermanische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1295
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1330
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3806
+#: sonar/common/jsonschemas/language-v1.0.0.json:1292
 msgid "lang_inh"
 msgstr "Inguschisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1299
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1334
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3810
+#: sonar/common/jsonschemas/language-v1.0.0.json:1296
 msgid "lang_ipk"
 msgstr "Inupiaq"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1303
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1338
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3814
+#: sonar/common/jsonschemas/language-v1.0.0.json:1300
 msgid "lang_ira"
 msgstr "Iranische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1307
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1342
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3818
+#: sonar/common/jsonschemas/language-v1.0.0.json:1304
 msgid "lang_iro"
 msgstr "Irokesische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1311
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1346
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3822
+#: sonar/common/jsonschemas/language-v1.0.0.json:1308
 msgid "lang_ita"
 msgstr "Italienisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1316
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1351
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3827
+#: sonar/common/jsonschemas/language-v1.0.0.json:1313
 msgid "lang_jav"
 msgstr "Javanisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1320
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1355
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3831
+#: sonar/common/jsonschemas/language-v1.0.0.json:1317
 msgid "lang_jbo"
 msgstr "Lojban"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1324
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1359
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3835
+#: sonar/common/jsonschemas/language-v1.0.0.json:1321
 msgid "lang_jpn"
 msgstr "Japanisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1328
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1363
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3839
+#: sonar/common/jsonschemas/language-v1.0.0.json:1325
 msgid "lang_jpr"
 msgstr "Judäo-Persisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1332
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1367
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3843
+#: sonar/common/jsonschemas/language-v1.0.0.json:1329
 msgid "lang_jrb"
 msgstr "Judäo-Arabisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1336
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1371
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3847
+#: sonar/common/jsonschemas/language-v1.0.0.json:1333
 msgid "lang_kaa"
 msgstr "Karakalpakisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1340
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1375
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3851
+#: sonar/common/jsonschemas/language-v1.0.0.json:1337
 msgid "lang_kab"
 msgstr "Kabylisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1344
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1379
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3855
+#: sonar/common/jsonschemas/language-v1.0.0.json:1341
 msgid "lang_kac"
 msgstr "Jingpo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1348
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1383
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3859
+#: sonar/common/jsonschemas/language-v1.0.0.json:1345
 msgid "lang_kal"
 msgstr "Grönländisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1352
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1387
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3863
+#: sonar/common/jsonschemas/language-v1.0.0.json:1349
 msgid "lang_kam"
 msgstr "Kikamba"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1356
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1391
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3867
+#: sonar/common/jsonschemas/language-v1.0.0.json:1353
 msgid "lang_kan"
 msgstr "Kannada"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1360
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1395
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3871
+#: sonar/common/jsonschemas/language-v1.0.0.json:1357
 msgid "lang_kar"
 msgstr "Karenische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1364
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1399
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3875
+#: sonar/common/jsonschemas/language-v1.0.0.json:1361
 msgid "lang_kas"
 msgstr "Kaschmiri"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1368
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1403
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3879
+#: sonar/common/jsonschemas/language-v1.0.0.json:1365
 msgid "lang_kau"
 msgstr "Kanuri"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1372
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1407
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3883
+#: sonar/common/jsonschemas/language-v1.0.0.json:1369
 msgid "lang_kaw"
 msgstr "Kawi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1376
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1411
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3887
+#: sonar/common/jsonschemas/language-v1.0.0.json:1373
 msgid "lang_kaz"
 msgstr "Kasachisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1380
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1415
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3891
+#: sonar/common/jsonschemas/language-v1.0.0.json:1377
 msgid "lang_kbd"
 msgstr "Kabardinisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1384
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1419
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3895
+#: sonar/common/jsonschemas/language-v1.0.0.json:1381
 msgid "lang_kha"
 msgstr "Khasi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1388
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1423
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3899
+#: sonar/common/jsonschemas/language-v1.0.0.json:1385
 msgid "lang_khi"
 msgstr "Khoisansprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1392
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1427
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3903
+#: sonar/common/jsonschemas/language-v1.0.0.json:1389
 msgid "lang_khm"
 msgstr "Khmer"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1396
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1431
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3907
+#: sonar/common/jsonschemas/language-v1.0.0.json:1393
 msgid "lang_kho"
 msgstr "Khotanesisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1400
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1435
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3911
+#: sonar/common/jsonschemas/language-v1.0.0.json:1397
 msgid "lang_kik"
 msgstr "Kikuyu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1404
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1439
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3915
+#: sonar/common/jsonschemas/language-v1.0.0.json:1401
 msgid "lang_kin"
 msgstr "Kinyarwanda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1408
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1443
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3919
+#: sonar/common/jsonschemas/language-v1.0.0.json:1405
 msgid "lang_kir"
 msgstr "Kirgisisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1412
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1447
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3923
+#: sonar/common/jsonschemas/language-v1.0.0.json:1409
 msgid "lang_kmb"
 msgstr "Kimbundu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1416
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1451
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3927
+#: sonar/common/jsonschemas/language-v1.0.0.json:1413
 msgid "lang_kok"
 msgstr "Konkani"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1420
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1455
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3931
+#: sonar/common/jsonschemas/language-v1.0.0.json:1417
 msgid "lang_kom"
 msgstr "Komi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1424
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1459
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3935
+#: sonar/common/jsonschemas/language-v1.0.0.json:1421
 msgid "lang_kon"
 msgstr "Kikongo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1428
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1463
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3939
+#: sonar/common/jsonschemas/language-v1.0.0.json:1425
 msgid "lang_kor"
 msgstr "Koreanisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1432
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1467
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3943
+#: sonar/common/jsonschemas/language-v1.0.0.json:1429
 msgid "lang_kos"
 msgstr "Kosraeanisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1436
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1471
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3947
+#: sonar/common/jsonschemas/language-v1.0.0.json:1433
 msgid "lang_kpe"
 msgstr "Kpelle"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1440
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1475
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3951
+#: sonar/common/jsonschemas/language-v1.0.0.json:1437
 msgid "lang_krc"
 msgstr "Karatschai-balkarisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1444
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1479
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3955
+#: sonar/common/jsonschemas/language-v1.0.0.json:1441
 msgid "lang_krl"
 msgstr "Karelisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1448
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1483
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3959
+#: sonar/common/jsonschemas/language-v1.0.0.json:1445
 msgid "lang_kro"
 msgstr "Kru-Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1452
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1487
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3963
+#: sonar/common/jsonschemas/language-v1.0.0.json:1449
 msgid "lang_kru"
 msgstr "Kurukh"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1456
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1491
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3967
+#: sonar/common/jsonschemas/language-v1.0.0.json:1453
 msgid "lang_kua"
 msgstr "Kwanyama"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1460
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1495
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3971
+#: sonar/common/jsonschemas/language-v1.0.0.json:1457
 msgid "lang_kum"
 msgstr "Kumykisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1464
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1499
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3975
+#: sonar/common/jsonschemas/language-v1.0.0.json:1461
 msgid "lang_kur"
 msgstr "Kurdisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1468
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1503
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3979
+#: sonar/common/jsonschemas/language-v1.0.0.json:1465
 msgid "lang_kut"
 msgstr "Kutanaha"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1472
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1507
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3983
+#: sonar/common/jsonschemas/language-v1.0.0.json:1469
 msgid "lang_lad"
 msgstr "Judenspanisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1476
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1511
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3987
+#: sonar/common/jsonschemas/language-v1.0.0.json:1473
 msgid "lang_lah"
 msgstr "Lahnda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1480
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1515
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3991
+#: sonar/common/jsonschemas/language-v1.0.0.json:1477
 msgid "lang_lam"
 msgstr "Lamba"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1484
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1519
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3995
+#: sonar/common/jsonschemas/language-v1.0.0.json:1481
 msgid "lang_lao"
 msgstr "Laotisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1488
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1523
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3999
+#: sonar/common/jsonschemas/language-v1.0.0.json:1485
 msgid "lang_lat"
 msgstr "Latein"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1492
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1527
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4003
+#: sonar/common/jsonschemas/language-v1.0.0.json:1489
 msgid "lang_lav"
 msgstr "Lettisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1496
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1531
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4007
+#: sonar/common/jsonschemas/language-v1.0.0.json:1493
 msgid "lang_lez"
 msgstr "Lesgisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1500
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1535
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4011
+#: sonar/common/jsonschemas/language-v1.0.0.json:1497
 msgid "lang_lim"
 msgstr "Limburgisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1504
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1539
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4015
+#: sonar/common/jsonschemas/language-v1.0.0.json:1501
 msgid "lang_lin"
 msgstr "Lingála"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1508
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1543
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4019
+#: sonar/common/jsonschemas/language-v1.0.0.json:1505
 msgid "lang_lit"
 msgstr "Litauisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1512
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1547
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4023
+#: sonar/common/jsonschemas/language-v1.0.0.json:1509
 msgid "lang_lol"
 msgstr "Lomongo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1516
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1551
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4027
+#: sonar/common/jsonschemas/language-v1.0.0.json:1513
 msgid "lang_loz"
 msgstr "Lozi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1520
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1555
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4031
+#: sonar/common/jsonschemas/language-v1.0.0.json:1517
 msgid "lang_ltz"
 msgstr "Luxemburgisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1524
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1559
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4035
+#: sonar/common/jsonschemas/language-v1.0.0.json:1521
 msgid "lang_lua"
 msgstr "Tschiluba"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1528
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1563
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4039
+#: sonar/common/jsonschemas/language-v1.0.0.json:1525
 msgid "lang_lub"
 msgstr "Kiluba"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1532
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1567
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4043
+#: sonar/common/jsonschemas/language-v1.0.0.json:1529
 msgid "lang_lug"
 msgstr "Luganda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1536
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1571
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4047
+#: sonar/common/jsonschemas/language-v1.0.0.json:1533
 msgid "lang_lui"
 msgstr "Luiseño"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1540
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1575
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4051
+#: sonar/common/jsonschemas/language-v1.0.0.json:1537
 msgid "lang_lun"
 msgstr "Chilunda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1544
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1579
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4055
+#: sonar/common/jsonschemas/language-v1.0.0.json:1541
 msgid "lang_luo"
 msgstr "Luo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1548
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1583
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4059
+#: sonar/common/jsonschemas/language-v1.0.0.json:1545
 msgid "lang_lus"
 msgstr "Mizo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1552
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1587
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4063
+#: sonar/common/jsonschemas/language-v1.0.0.json:1549
 msgid "lang_mac"
 msgstr "Mazedonisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1556
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1591
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4067
+#: sonar/common/jsonschemas/language-v1.0.0.json:1553
 msgid "lang_mad"
 msgstr "Maduresisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1560
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1595
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4071
+#: sonar/common/jsonschemas/language-v1.0.0.json:1557
 msgid "lang_mag"
 msgstr "Magadhi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1564
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1599
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4075
+#: sonar/common/jsonschemas/language-v1.0.0.json:1561
 msgid "lang_mah"
 msgstr "Marschallesisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1568
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1603
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4079
+#: sonar/common/jsonschemas/language-v1.0.0.json:1565
 msgid "lang_mai"
 msgstr "Maithili"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1572
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1607
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4083
+#: sonar/common/jsonschemas/language-v1.0.0.json:1569
 msgid "lang_mak"
 msgstr "Makassar"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1576
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1611
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4087
+#: sonar/common/jsonschemas/language-v1.0.0.json:1573
 msgid "lang_mal"
 msgstr "Malayalam"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1580
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1615
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4091
+#: sonar/common/jsonschemas/language-v1.0.0.json:1577
 msgid "lang_man"
 msgstr "Manding"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1584
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1619
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4095
+#: sonar/common/jsonschemas/language-v1.0.0.json:1581
 msgid "lang_mao"
 msgstr "Maori"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1588
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1623
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4099
+#: sonar/common/jsonschemas/language-v1.0.0.json:1585
 msgid "lang_map"
 msgstr "Austronesische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1592
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1627
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4103
+#: sonar/common/jsonschemas/language-v1.0.0.json:1589
 msgid "lang_mar"
 msgstr "Marathi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1596
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1631
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4107
+#: sonar/common/jsonschemas/language-v1.0.0.json:1593
 msgid "lang_mas"
 msgstr "Maa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1600
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1635
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4111
+#: sonar/common/jsonschemas/language-v1.0.0.json:1597
 msgid "lang_may"
 msgstr "Malaiisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1604
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1639
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4115
+#: sonar/common/jsonschemas/language-v1.0.0.json:1601
 msgid "lang_mdf"
 msgstr "Mokschanisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1608
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1643
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4119
+#: sonar/common/jsonschemas/language-v1.0.0.json:1605
 msgid "lang_mdr"
 msgstr "Mandar"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1612
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1647
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4123
+#: sonar/common/jsonschemas/language-v1.0.0.json:1609
 msgid "lang_men"
 msgstr "Mende"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1616
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1651
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4127
+#: sonar/common/jsonschemas/language-v1.0.0.json:1613
 msgid "lang_mga"
 msgstr "Mittelirisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1620
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1655
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4131
+#: sonar/common/jsonschemas/language-v1.0.0.json:1617
 msgid "lang_mic"
 msgstr "Míkmawísimk"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1624
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1659
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4135
+#: sonar/common/jsonschemas/language-v1.0.0.json:1621
 msgid "lang_min"
 msgstr "Minangkabauisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1628
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1663
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4139
+#: sonar/common/jsonschemas/language-v1.0.0.json:1625
 msgid "lang_mis"
 msgstr "Verschiedene Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1632
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1667
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4143
+#: sonar/common/jsonschemas/language-v1.0.0.json:1629
 msgid "lang_mkh"
 msgstr "Mon-Khmer-Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1636
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1671
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4147
+#: sonar/common/jsonschemas/language-v1.0.0.json:1633
 msgid "lang_mlg"
 msgstr "Malagasy"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1640
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1675
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4151
+#: sonar/common/jsonschemas/language-v1.0.0.json:1637
 msgid "lang_mlt"
 msgstr "Maltesisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1644
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1679
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4155
+#: sonar/common/jsonschemas/language-v1.0.0.json:1641
 msgid "lang_mnc"
 msgstr "Mandschurisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1648
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1683
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4159
+#: sonar/common/jsonschemas/language-v1.0.0.json:1645
 msgid "lang_mni"
 msgstr "Meithei"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1652
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1687
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4163
+#: sonar/common/jsonschemas/language-v1.0.0.json:1649
 msgid "lang_mno"
 msgstr "Manobo Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1656
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1691
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4167
+#: sonar/common/jsonschemas/language-v1.0.0.json:1653
 msgid "lang_moh"
 msgstr "Mohawk"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1660
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1695
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4171
+#: sonar/common/jsonschemas/language-v1.0.0.json:1657
 msgid "lang_mon"
 msgstr "Mongolisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1664
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1699
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4175
+#: sonar/common/jsonschemas/language-v1.0.0.json:1661
 msgid "lang_mos"
 msgstr "Mòoré"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1668
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1703
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4179
+#: sonar/common/jsonschemas/language-v1.0.0.json:1665
 msgid "lang_mul"
 msgstr "Mehrsprachig"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1672
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1707
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4183
+#: sonar/common/jsonschemas/language-v1.0.0.json:1669
 msgid "lang_mun"
 msgstr "Munda-Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1676
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1711
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4187
+#: sonar/common/jsonschemas/language-v1.0.0.json:1673
 msgid "lang_mus"
 msgstr "Muskogee-Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1680
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1715
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4191
+#: sonar/common/jsonschemas/language-v1.0.0.json:1677
 msgid "lang_mwl"
 msgstr "Mirandés"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1684
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1719
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4195
+#: sonar/common/jsonschemas/language-v1.0.0.json:1681
 msgid "lang_mwr"
 msgstr "Marwari"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1688
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1723
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4199
+#: sonar/common/jsonschemas/language-v1.0.0.json:1685
 msgid "lang_myn"
 msgstr "Maya Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1692
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1727
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4203
+#: sonar/common/jsonschemas/language-v1.0.0.json:1689
 msgid "lang_myv"
 msgstr "Ersjanisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1696
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1731
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4207
+#: sonar/common/jsonschemas/language-v1.0.0.json:1693
 msgid "lang_nah"
 msgstr "Nahuatl"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1700
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1735
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4211
+#: sonar/common/jsonschemas/language-v1.0.0.json:1697
 msgid "lang_nai"
 msgstr "Nordamerikanische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1704
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1739
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4215
+#: sonar/common/jsonschemas/language-v1.0.0.json:1701
 msgid "lang_nap"
 msgstr "Neapolitanisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1708
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1743
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4219
+#: sonar/common/jsonschemas/language-v1.0.0.json:1705
 msgid "lang_nau"
 msgstr "Nauruisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1712
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1747
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4223
+#: sonar/common/jsonschemas/language-v1.0.0.json:1709
 msgid "lang_nav"
 msgstr "Navajo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1716
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1751
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4227
+#: sonar/common/jsonschemas/language-v1.0.0.json:1713
 msgid "lang_nbl"
 msgstr "Süd-Ndebele"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1720
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1755
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4231
+#: sonar/common/jsonschemas/language-v1.0.0.json:1717
 msgid "lang_nde"
 msgstr "Nord-Ndebele"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1724
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1759
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4235
+#: sonar/common/jsonschemas/language-v1.0.0.json:1721
 msgid "lang_ndo"
 msgstr "Ndonga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1728
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1763
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4239
+#: sonar/common/jsonschemas/language-v1.0.0.json:1725
 msgid "lang_nds"
 msgstr "Niederdeutsch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1732
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1767
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4243
+#: sonar/common/jsonschemas/language-v1.0.0.json:1729
 msgid "lang_nep"
 msgstr "Nepali"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1736
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1771
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4247
+#: sonar/common/jsonschemas/language-v1.0.0.json:1733
 msgid "lang_new"
 msgstr "Newari"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1740
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1775
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4251
+#: sonar/common/jsonschemas/language-v1.0.0.json:1737
 msgid "lang_nia"
 msgstr "Nias"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1744
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1779
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4255
+#: sonar/common/jsonschemas/language-v1.0.0.json:1741
 msgid "lang_nic"
 msgstr "Niger-Kongo-Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1748
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1783
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4259
+#: sonar/common/jsonschemas/language-v1.0.0.json:1745
 msgid "lang_niu"
 msgstr "Niueanisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1752
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1787
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4263
+#: sonar/common/jsonschemas/language-v1.0.0.json:1749
 msgid "lang_nno"
 msgstr "Nynorsk"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1756
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1791
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4267
+#: sonar/common/jsonschemas/language-v1.0.0.json:1753
 msgid "lang_nob"
 msgstr "Bokmål"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1760
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1795
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4271
+#: sonar/common/jsonschemas/language-v1.0.0.json:1757
 msgid "lang_nog"
 msgstr "Nogaisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1764
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1799
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4275
+#: sonar/common/jsonschemas/language-v1.0.0.json:1761
 msgid "lang_non"
 msgstr "Altnordisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1768
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1803
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4279
+#: sonar/common/jsonschemas/language-v1.0.0.json:1765
 msgid "lang_nor"
 msgstr "Norwegisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1772
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1807
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4283
+#: sonar/common/jsonschemas/language-v1.0.0.json:1769
 msgid "lang_nqo"
 msgstr "N’Ko"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1776
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1811
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4287
+#: sonar/common/jsonschemas/language-v1.0.0.json:1773
 msgid "lang_nso"
 msgstr "Nord-Sotho"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1780
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1815
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4291
+#: sonar/common/jsonschemas/language-v1.0.0.json:1777
 msgid "lang_nub"
 msgstr "Nubische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1784
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1819
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4295
+#: sonar/common/jsonschemas/language-v1.0.0.json:1781
 msgid "lang_nwc"
 msgstr "Klassisches Newari"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1788
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1823
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4299
+#: sonar/common/jsonschemas/language-v1.0.0.json:1785
 msgid "lang_nya"
 msgstr "Chichewa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1792
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1827
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4303
+#: sonar/common/jsonschemas/language-v1.0.0.json:1789
 msgid "lang_nym"
 msgstr "Nyamwesi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1796
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1831
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4307
+#: sonar/common/jsonschemas/language-v1.0.0.json:1793
 msgid "lang_nyn"
 msgstr "Runyankole"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1800
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1835
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4311
+#: sonar/common/jsonschemas/language-v1.0.0.json:1797
 msgid "lang_nyo"
 msgstr "Runyoro"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1804
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1839
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4315
+#: sonar/common/jsonschemas/language-v1.0.0.json:1801
 msgid "lang_nzi"
 msgstr "Nzema"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1808
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1843
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4319
+#: sonar/common/jsonschemas/language-v1.0.0.json:1805
 msgid "lang_oci"
 msgstr "Okzitanisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1812
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1847
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4323
+#: sonar/common/jsonschemas/language-v1.0.0.json:1809
 msgid "lang_oji"
 msgstr "Ojibwe"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1816
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1851
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4327
+#: sonar/common/jsonschemas/language-v1.0.0.json:1813
 msgid "lang_ori"
 msgstr "Oriya"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1820
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1855
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4331
+#: sonar/common/jsonschemas/language-v1.0.0.json:1817
 msgid "lang_orm"
 msgstr "Oromo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1824
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1859
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4335
+#: sonar/common/jsonschemas/language-v1.0.0.json:1821
 msgid "lang_osa"
 msgstr "Osage"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1828
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1863
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4339
+#: sonar/common/jsonschemas/language-v1.0.0.json:1825
 msgid "lang_oss"
 msgstr "Ossetisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1832
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1867
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4343
+#: sonar/common/jsonschemas/language-v1.0.0.json:1829
 msgid "lang_ota"
 msgstr "Osmanisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1836
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1871
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4347
+#: sonar/common/jsonschemas/language-v1.0.0.json:1833
 msgid "lang_oto"
 msgstr "Oto-Pame-Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1840
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1875
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4351
+#: sonar/common/jsonschemas/language-v1.0.0.json:1837
 msgid "lang_paa"
 msgstr "Papuasprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1844
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1879
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4355
+#: sonar/common/jsonschemas/language-v1.0.0.json:1841
 msgid "lang_pag"
 msgstr "Pangasinensisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1848
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1883
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4359
+#: sonar/common/jsonschemas/language-v1.0.0.json:1845
 msgid "lang_pal"
 msgstr "Mittelpersisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1852
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1887
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4363
+#: sonar/common/jsonschemas/language-v1.0.0.json:1849
 msgid "lang_pam"
 msgstr "Kapampangan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1856
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1891
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4367
+#: sonar/common/jsonschemas/language-v1.0.0.json:1853
 msgid "lang_pan"
 msgstr "Panjabi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1860
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1895
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4371
+#: sonar/common/jsonschemas/language-v1.0.0.json:1857
 msgid "lang_pap"
 msgstr "Papiamentu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1864
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1899
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4375
+#: sonar/common/jsonschemas/language-v1.0.0.json:1861
 msgid "lang_pau"
 msgstr "Palauisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1868
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1903
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4379
+#: sonar/common/jsonschemas/language-v1.0.0.json:1865
 msgid "lang_peo"
 msgstr "Altpersisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1872
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1907
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4383
+#: sonar/common/jsonschemas/language-v1.0.0.json:1869
 msgid "lang_per"
 msgstr "Persisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1876
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1911
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4387
+#: sonar/common/jsonschemas/language-v1.0.0.json:1873
 msgid "lang_phi"
 msgstr "Philippinische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1880
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1915
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4391
+#: sonar/common/jsonschemas/language-v1.0.0.json:1877
 msgid "lang_phn"
 msgstr "Phönizisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1884
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1919
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4395
+#: sonar/common/jsonschemas/language-v1.0.0.json:1881
 msgid "lang_pli"
 msgstr "Pali"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1888
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1923
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4399
+#: sonar/common/jsonschemas/language-v1.0.0.json:1885
 msgid "lang_pol"
 msgstr "Polnisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1892
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1927
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4403
+#: sonar/common/jsonschemas/language-v1.0.0.json:1889
 msgid "lang_pon"
 msgstr "Pohnpeanisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1896
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1931
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4407
+#: sonar/common/jsonschemas/language-v1.0.0.json:1893
 msgid "lang_por"
 msgstr "Portugiesisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1900
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1935
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4411
+#: sonar/common/jsonschemas/language-v1.0.0.json:1897
 msgid "lang_pra"
 msgstr "Prakrit"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1904
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1939
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4415
+#: sonar/common/jsonschemas/language-v1.0.0.json:1901
 msgid "lang_pro"
 msgstr "Altokzitanisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1908
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1943
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4419
+#: sonar/common/jsonschemas/language-v1.0.0.json:1905
 msgid "lang_pus"
 msgstr "Paschtunisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1912
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1947
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4423
+#: sonar/common/jsonschemas/language-v1.0.0.json:1909
 msgid "lang_que"
 msgstr "Quechua"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1916
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1951
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4427
+#: sonar/common/jsonschemas/language-v1.0.0.json:1913
 msgid "lang_raj"
 msgstr "Rajasthani"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1920
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1955
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4431
+#: sonar/common/jsonschemas/language-v1.0.0.json:1917
 msgid "lang_rap"
 msgstr "Rapanui"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1924
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1959
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4435
+#: sonar/common/jsonschemas/language-v1.0.0.json:1921
 msgid "lang_rar"
 msgstr "Rarotonganisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1928
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1963
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4439
+#: sonar/common/jsonschemas/language-v1.0.0.json:1925
 msgid "lang_roa"
 msgstr "Romanische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1932
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1967
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4443
+#: sonar/common/jsonschemas/language-v1.0.0.json:1929
 msgid "lang_roh"
 msgstr "Bündnerromanisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1936
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1971
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4447
+#: sonar/common/jsonschemas/language-v1.0.0.json:1933
 msgid "lang_rom"
 msgstr "Romani"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1940
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1975
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4451
+#: sonar/common/jsonschemas/language-v1.0.0.json:1937
 msgid "lang_rum"
 msgstr "Rumänisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1944
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1979
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4455
+#: sonar/common/jsonschemas/language-v1.0.0.json:1941
 msgid "lang_run"
 msgstr "Kirundi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1948
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1983
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4459
+#: sonar/common/jsonschemas/language-v1.0.0.json:1945
 msgid "lang_rup"
 msgstr "Aromunisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1952
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1987
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4463
+#: sonar/common/jsonschemas/language-v1.0.0.json:1949
 msgid "lang_rus"
 msgstr "Russisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1956
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1991
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4467
+#: sonar/common/jsonschemas/language-v1.0.0.json:1953
 msgid "lang_sad"
 msgstr "Sandawe"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1960
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1995
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4471
+#: sonar/common/jsonschemas/language-v1.0.0.json:1957
 msgid "lang_sag"
 msgstr "Sango"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1964
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1999
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4475
+#: sonar/common/jsonschemas/language-v1.0.0.json:1961
 msgid "lang_sah"
 msgstr "Jakutisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1968
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2003
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4479
+#: sonar/common/jsonschemas/language-v1.0.0.json:1965
 msgid "lang_sai"
 msgstr "Südamerikanische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1972
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2007
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4483
+#: sonar/common/jsonschemas/language-v1.0.0.json:1969
 msgid "lang_sal"
 msgstr "Salish-Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1976
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2011
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4487
+#: sonar/common/jsonschemas/language-v1.0.0.json:1973
 msgid "lang_sam"
 msgstr "Samaritanisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1980
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2015
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4491
+#: sonar/common/jsonschemas/language-v1.0.0.json:1977
 msgid "lang_san"
 msgstr "Sanskrit"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1984
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2019
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4495
+#: sonar/common/jsonschemas/language-v1.0.0.json:1981
 msgid "lang_sas"
 msgstr "Sasak"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1988
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2023
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4499
+#: sonar/common/jsonschemas/language-v1.0.0.json:1985
 msgid "lang_sat"
 msgstr "Santali"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1992
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2027
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4503
+#: sonar/common/jsonschemas/language-v1.0.0.json:1989
 msgid "lang_scn"
 msgstr "Sizilianisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1996
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2031
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4507
+#: sonar/common/jsonschemas/language-v1.0.0.json:1993
 msgid "lang_sco"
 msgstr "Scots"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2000
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2035
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4511
+#: sonar/common/jsonschemas/language-v1.0.0.json:1997
 msgid "lang_sel"
 msgstr "Selkupisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2004
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2039
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4515
+#: sonar/common/jsonschemas/language-v1.0.0.json:2001
 msgid "lang_sem"
 msgstr "Semitische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2008
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2043
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4519
+#: sonar/common/jsonschemas/language-v1.0.0.json:2005
 msgid "lang_sga"
 msgstr "Altirisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2012
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2047
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4523
+#: sonar/common/jsonschemas/language-v1.0.0.json:2009
 msgid "lang_sgn"
 msgstr "Gebärdensprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2016
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2051
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4527
+#: sonar/common/jsonschemas/language-v1.0.0.json:2013
 msgid "lang_shn"
 msgstr "Shan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2020
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2055
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4531
+#: sonar/common/jsonschemas/language-v1.0.0.json:2017
 msgid "lang_sid"
 msgstr "Sidama"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2024
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2059
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4535
+#: sonar/common/jsonschemas/language-v1.0.0.json:2021
 msgid "lang_sin"
 msgstr "Singhalesisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2028
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2063
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4539
+#: sonar/common/jsonschemas/language-v1.0.0.json:2025
 msgid "lang_sio"
 msgstr "Sioux-Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2032
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2067
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4543
+#: sonar/common/jsonschemas/language-v1.0.0.json:2029
 msgid "lang_sit"
 msgstr "Sinotibetische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2036
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2071
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4547
+#: sonar/common/jsonschemas/language-v1.0.0.json:2033
 msgid "lang_sla"
 msgstr "Slawische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2040
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2075
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4551
+#: sonar/common/jsonschemas/language-v1.0.0.json:2037
 msgid "lang_slo"
 msgstr "Slowakisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2044
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2079
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4555
+#: sonar/common/jsonschemas/language-v1.0.0.json:2041
 msgid "lang_slv"
 msgstr "Slowenisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2048
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2083
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4559
+#: sonar/common/jsonschemas/language-v1.0.0.json:2045
 msgid "lang_sma"
 msgstr "Südsamisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2052
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2087
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4563
+#: sonar/common/jsonschemas/language-v1.0.0.json:2049
 msgid "lang_sme"
 msgstr "Nordsamisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2056
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2091
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4567
+#: sonar/common/jsonschemas/language-v1.0.0.json:2053
 msgid "lang_smi"
 msgstr "Samische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2060
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2095
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4571
+#: sonar/common/jsonschemas/language-v1.0.0.json:2057
 msgid "lang_smj"
 msgstr "Lulesamisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2064
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2099
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4575
+#: sonar/common/jsonschemas/language-v1.0.0.json:2061
 msgid "lang_smn"
 msgstr "Inarisamisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2068
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2103
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4579
+#: sonar/common/jsonschemas/language-v1.0.0.json:2065
 msgid "lang_smo"
 msgstr "Samoanisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2072
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2107
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4583
+#: sonar/common/jsonschemas/language-v1.0.0.json:2069
 msgid "lang_sms"
 msgstr "Skoltsamisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2076
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2111
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4587
+#: sonar/common/jsonschemas/language-v1.0.0.json:2073
 msgid "lang_sna"
 msgstr "Shona"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2080
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2115
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4591
+#: sonar/common/jsonschemas/language-v1.0.0.json:2077
 msgid "lang_snd"
 msgstr "Sindhi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2084
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2119
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4595
+#: sonar/common/jsonschemas/language-v1.0.0.json:2081
 msgid "lang_snk"
 msgstr "Soninke"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2088
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2123
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4599
+#: sonar/common/jsonschemas/language-v1.0.0.json:2085
 msgid "lang_sog"
 msgstr "Sogdisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2092
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2127
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4603
+#: sonar/common/jsonschemas/language-v1.0.0.json:2089
 msgid "lang_som"
 msgstr "Somali"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2096
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2131
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4607
+#: sonar/common/jsonschemas/language-v1.0.0.json:2093
 msgid "lang_son"
 msgstr "Songhai-Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2100
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2135
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4611
+#: sonar/common/jsonschemas/language-v1.0.0.json:2097
 msgid "lang_sot"
 msgstr "Sesotho"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2104
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2139
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4615
+#: sonar/common/jsonschemas/language-v1.0.0.json:2101
 msgid "lang_spa"
 msgstr "Spanisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2108
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2143
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4619
+#: sonar/common/jsonschemas/language-v1.0.0.json:2105
 msgid "lang_srd"
 msgstr "Sardisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2112
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2147
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4623
+#: sonar/common/jsonschemas/language-v1.0.0.json:2109
 msgid "lang_srn"
 msgstr "Sranantongo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2116
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2151
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4627
+#: sonar/common/jsonschemas/language-v1.0.0.json:2113
 msgid "lang_srp"
 msgstr "Serbisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2120
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2155
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4631
+#: sonar/common/jsonschemas/language-v1.0.0.json:2117
 msgid "lang_srr"
 msgstr "Serer"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2124
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2159
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4635
+#: sonar/common/jsonschemas/language-v1.0.0.json:2121
 msgid "lang_ssa"
 msgstr "Nilosaharanische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2128
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2163
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4639
+#: sonar/common/jsonschemas/language-v1.0.0.json:2125
 msgid "lang_ssw"
 msgstr "Swahili"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2132
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2167
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4643
+#: sonar/common/jsonschemas/language-v1.0.0.json:2129
 msgid "lang_suk"
 msgstr "Sukuma"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2136
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2171
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4647
+#: sonar/common/jsonschemas/language-v1.0.0.json:2133
 msgid "lang_sun"
 msgstr "Sundanesisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2140
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2175
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4651
+#: sonar/common/jsonschemas/language-v1.0.0.json:2137
 msgid "lang_sus"
 msgstr "Susu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2144
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2179
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4655
+#: sonar/common/jsonschemas/language-v1.0.0.json:2141
 msgid "lang_sux"
 msgstr "Sumerisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2148
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2183
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4659
+#: sonar/common/jsonschemas/language-v1.0.0.json:2145
 msgid "lang_swa"
 msgstr "Suaheli"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2152
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2187
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4663
+#: sonar/common/jsonschemas/language-v1.0.0.json:2149
 msgid "lang_swe"
 msgstr "Schwedisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2156
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2191
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4667
+#: sonar/common/jsonschemas/language-v1.0.0.json:2153
 msgid "lang_syc"
 msgstr "Syrisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2160
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2195
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4671
+#: sonar/common/jsonschemas/language-v1.0.0.json:2157
 msgid "lang_syr"
 msgstr "Nordost-Neuaramäisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2164
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2199
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4675
+#: sonar/common/jsonschemas/language-v1.0.0.json:2161
 msgid "lang_tah"
 msgstr "Tahitianisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2168
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2203
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4679
+#: sonar/common/jsonschemas/language-v1.0.0.json:2165
 msgid "lang_tai"
 msgstr "Tai-Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2172
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2207
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4683
+#: sonar/common/jsonschemas/language-v1.0.0.json:2169
 msgid "lang_tam"
 msgstr "Tamil"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2176
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2211
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4687
+#: sonar/common/jsonschemas/language-v1.0.0.json:2173
 msgid "lang_tat"
 msgstr "Tatarisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2180
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2215
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4691
+#: sonar/common/jsonschemas/language-v1.0.0.json:2177
 msgid "lang_tel"
 msgstr "Telugu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2184
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2219
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4695
+#: sonar/common/jsonschemas/language-v1.0.0.json:2181
 msgid "lang_tem"
 msgstr "Temne"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2188
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2223
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4699
+#: sonar/common/jsonschemas/language-v1.0.0.json:2185
 msgid "lang_ter"
 msgstr "Terena"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2192
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2227
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4703
+#: sonar/common/jsonschemas/language-v1.0.0.json:2189
 msgid "lang_tet"
 msgstr "Tetum"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2196
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2231
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4707
+#: sonar/common/jsonschemas/language-v1.0.0.json:2193
 msgid "lang_tgk"
 msgstr "Tadschikisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2200
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2235
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4711
+#: sonar/common/jsonschemas/language-v1.0.0.json:2197
 msgid "lang_tgl"
 msgstr "Tagalog"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2204
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2239
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4715
+#: sonar/common/jsonschemas/language-v1.0.0.json:2201
 msgid "lang_tha"
 msgstr "Thai"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2208
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2243
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4719
+#: sonar/common/jsonschemas/language-v1.0.0.json:2205
 msgid "lang_tib"
 msgstr "Tibetisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2212
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2247
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4723
+#: sonar/common/jsonschemas/language-v1.0.0.json:2209
 msgid "lang_tig"
 msgstr "Tigre"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2216
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2251
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4727
+#: sonar/common/jsonschemas/language-v1.0.0.json:2213
 msgid "lang_tir"
 msgstr "Tigrinya"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2220
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2255
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4731
+#: sonar/common/jsonschemas/language-v1.0.0.json:2217
 msgid "lang_tiv"
 msgstr "Tiv"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2224
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2259
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4735
+#: sonar/common/jsonschemas/language-v1.0.0.json:2221
 msgid "lang_tkl"
 msgstr "Tokelauisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2228
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2263
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4739
+#: sonar/common/jsonschemas/language-v1.0.0.json:2225
 msgid "lang_tlh"
 msgstr "Klingonisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2232
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2267
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4743
+#: sonar/common/jsonschemas/language-v1.0.0.json:2229
 msgid "lang_tli"
 msgstr "Tlingit"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2236
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2271
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4747
+#: sonar/common/jsonschemas/language-v1.0.0.json:2233
 msgid "lang_tmh"
 msgstr "Tuareg"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2240
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2275
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4751
+#: sonar/common/jsonschemas/language-v1.0.0.json:2237
 msgid "lang_tog"
 msgstr "Tonga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2244
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2279
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4755
+#: sonar/common/jsonschemas/language-v1.0.0.json:2241
 msgid "lang_ton"
 msgstr "Tongaisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2248
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2283
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4759
+#: sonar/common/jsonschemas/language-v1.0.0.json:2245
 msgid "lang_tpi"
 msgstr "Tok Pisin"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2252
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2287
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4763
+#: sonar/common/jsonschemas/language-v1.0.0.json:2249
 msgid "lang_tsi"
 msgstr "Tsimshian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2256
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2291
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4767
+#: sonar/common/jsonschemas/language-v1.0.0.json:2253
 msgid "lang_tsn"
 msgstr "Setswana"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2260
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2295
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4771
+#: sonar/common/jsonschemas/language-v1.0.0.json:2257
 msgid "lang_tso"
 msgstr "Xitsonga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2264
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2299
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4775
+#: sonar/common/jsonschemas/language-v1.0.0.json:2261
 msgid "lang_tuk"
 msgstr "Turkmenisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2268
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2303
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4779
+#: sonar/common/jsonschemas/language-v1.0.0.json:2265
 msgid "lang_tum"
 msgstr "Tumbuka"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2272
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2307
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4783
+#: sonar/common/jsonschemas/language-v1.0.0.json:2269
 msgid "lang_tup"
 msgstr "Tupí-Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2276
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2311
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4787
+#: sonar/common/jsonschemas/language-v1.0.0.json:2273
 msgid "lang_tur"
 msgstr "Türkisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2280
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2315
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4791
+#: sonar/common/jsonschemas/language-v1.0.0.json:2277
 msgid "lang_tut"
 msgstr "Altaische Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2284
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2319
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4795
+#: sonar/common/jsonschemas/language-v1.0.0.json:2281
 msgid "lang_tvl"
 msgstr "Tuvaluisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2288
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2323
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4799
+#: sonar/common/jsonschemas/language-v1.0.0.json:2285
 msgid "lang_twi"
 msgstr "Twi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2292
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2327
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4803
+#: sonar/common/jsonschemas/language-v1.0.0.json:2289
 msgid "lang_tyv"
 msgstr "Tuwinisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2296
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2331
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4807
+#: sonar/common/jsonschemas/language-v1.0.0.json:2293
 msgid "lang_udm"
 msgstr "Udmurtisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2300
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2335
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4811
+#: sonar/common/jsonschemas/language-v1.0.0.json:2297
 msgid "lang_uga"
 msgstr "Ugaritisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2304
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2339
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4815
+#: sonar/common/jsonschemas/language-v1.0.0.json:2301
 msgid "lang_uig"
 msgstr "Uigurisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2308
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2343
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4819
+#: sonar/common/jsonschemas/language-v1.0.0.json:2305
 msgid "lang_ukr"
 msgstr "Ukrainisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2312
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2347
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4823
+#: sonar/common/jsonschemas/language-v1.0.0.json:2309
 msgid "lang_umb"
 msgstr "Umbundu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2316
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2351
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4827
+#: sonar/common/jsonschemas/language-v1.0.0.json:2313
 msgid "lang_und"
 msgstr "Unbekannte Sprache"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2320
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2355
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4831
+#: sonar/common/jsonschemas/language-v1.0.0.json:2317
 msgid "lang_urd"
 msgstr "Urdu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2324
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2359
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4835
+#: sonar/common/jsonschemas/language-v1.0.0.json:2321
 msgid "lang_uzb"
 msgstr "Usbekisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2328
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2363
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4839
+#: sonar/common/jsonschemas/language-v1.0.0.json:2325
 msgid "lang_vai"
 msgstr "Vai"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2332
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2367
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4843
+#: sonar/common/jsonschemas/language-v1.0.0.json:2329
 msgid "lang_ven"
 msgstr "Tshivenda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2336
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2371
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4847
+#: sonar/common/jsonschemas/language-v1.0.0.json:2333
 msgid "lang_vie"
 msgstr "Vietnamesisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2340
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2375
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4851
+#: sonar/common/jsonschemas/language-v1.0.0.json:2337
 msgid "lang_vol"
 msgstr "Volapük"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2344
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2379
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4855
+#: sonar/common/jsonschemas/language-v1.0.0.json:2341
 msgid "lang_vot"
 msgstr "Wotisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2348
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2383
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4859
+#: sonar/common/jsonschemas/language-v1.0.0.json:2345
 msgid "lang_wak"
 msgstr "Wakash-Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2352
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2387
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4863
+#: sonar/common/jsonschemas/language-v1.0.0.json:2349
 msgid "lang_wal"
 msgstr "Wolaytta"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2356
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2391
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4867
+#: sonar/common/jsonschemas/language-v1.0.0.json:2353
 msgid "lang_war"
 msgstr "Wáray-Wáray"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2360
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2395
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4871
+#: sonar/common/jsonschemas/language-v1.0.0.json:2357
 msgid "lang_was"
 msgstr "Washo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2364
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2399
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4875
+#: sonar/common/jsonschemas/language-v1.0.0.json:2361
 msgid "lang_wel"
 msgstr "Walisisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2368
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2403
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4879
+#: sonar/common/jsonschemas/language-v1.0.0.json:2365
 msgid "lang_wen"
 msgstr "Sorbische Sprache"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2372
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2407
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4883
+#: sonar/common/jsonschemas/language-v1.0.0.json:2369
 msgid "lang_wln"
 msgstr "Wallonisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2376
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2411
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4887
+#: sonar/common/jsonschemas/language-v1.0.0.json:2373
 msgid "lang_wol"
 msgstr "Wolof"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2380
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2415
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4891
+#: sonar/common/jsonschemas/language-v1.0.0.json:2377
 msgid "lang_xal"
 msgstr "Kalmückisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2384
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2419
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4895
+#: sonar/common/jsonschemas/language-v1.0.0.json:2381
 msgid "lang_xho"
 msgstr "Xhosa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2388
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2423
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4899
+#: sonar/common/jsonschemas/language-v1.0.0.json:2385
 msgid "lang_yao"
 msgstr "Yao"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2392
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2427
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4903
+#: sonar/common/jsonschemas/language-v1.0.0.json:2389
 msgid "lang_yap"
 msgstr "Yapesisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2396
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2431
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4907
+#: sonar/common/jsonschemas/language-v1.0.0.json:2393
 msgid "lang_yid"
 msgstr "Jiddisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2400
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2435
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4911
+#: sonar/common/jsonschemas/language-v1.0.0.json:2397
 msgid "lang_yor"
 msgstr "Yoruba"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2404
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2439
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4915
+#: sonar/common/jsonschemas/language-v1.0.0.json:2401
 msgid "lang_ypk"
 msgstr "Yupik-Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2408
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2443
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4919
+#: sonar/common/jsonschemas/language-v1.0.0.json:2405
 msgid "lang_zap"
 msgstr "Zapotekisch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2412
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2447
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4923
+#: sonar/common/jsonschemas/language-v1.0.0.json:2409
 msgid "lang_zbl"
 msgstr "Bliss-Symbole"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2416
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2451
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4927
+#: sonar/common/jsonschemas/language-v1.0.0.json:2413
 msgid "lang_zen"
 msgstr "Zenaga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2420
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2455
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4931
+#: sonar/common/jsonschemas/language-v1.0.0.json:2417
 msgid "lang_zha"
 msgstr "Zhuang"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2424
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2459
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4935
+#: sonar/common/jsonschemas/language-v1.0.0.json:2421
 msgid "lang_znd"
 msgstr "Zande-Sprachen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2428
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2463
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4939
+#: sonar/common/jsonschemas/language-v1.0.0.json:2425
 msgid "lang_zul"
 msgstr "Zulu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2432
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2467
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4943
+#: sonar/common/jsonschemas/language-v1.0.0.json:2429
 msgid "lang_zun"
 msgstr "Zuñi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2436
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2471
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4947
+#: sonar/common/jsonschemas/language-v1.0.0.json:2433
 msgid "lang_zxx"
 msgstr "Keine Sprachinhalte"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2440
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2475
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4951
+#: sonar/common/jsonschemas/language-v1.0.0.json:2437
 msgid "lang_zza"
 msgstr "Zazaisch"
 
@@ -5739,12 +4843,11 @@ msgstr "Zazaisch"
 msgid "mainTeam"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:923
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1743
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1034
 msgid "name"
 msgstr "Name"
 
-#: sonar/modules/documents/views.py:172
+#: sonar/modules/documents/views.py:178
 msgid "no."
 msgstr "Nr."
 
@@ -5752,11 +4855,11 @@ msgstr "Nr."
 msgid "other files"
 msgstr "andere Dateien"
 
-#: sonar/modules/documents/views.py:176
+#: sonar/modules/documents/views.py:182
 msgid "p."
 msgstr "S."
 
-#: sonar/config.py:546
+#: sonar/config.py:570
 msgid "pid"
 msgstr "PID"
 
@@ -5820,7 +4923,7 @@ msgstr ""
 msgid "startDate"
 msgstr ""
 
-#: sonar/config.py:547
+#: sonar/config.py:571
 msgid "status"
 msgstr "Status"
 
@@ -5834,15 +4937,55 @@ msgstr "gefördert durch"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:489
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:808
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1615
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1627
 msgid "uri"
 msgstr "URI"
 
-#: sonar/config.py:548
+#: sonar/config.py:572
 msgid "user"
 msgstr "Benutzer"
 
-#: sonar/modules/documents/views.py:168
+#: sonar/translations/manual_translations.txt:59
+msgid "validation_action_approve"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:61
+msgid "validation_action_ask_for_changes"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:58
+msgid "validation_action_publish"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:60
+msgid "validation_action_reject"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:57
+msgid "validation_action_save"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:54
+msgid "validation_status_ask_for_changes"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:50
+msgid "validation_status_in_progress"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:53
+msgid "validation_status_rejected"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:51
+msgid "validation_status_to_validate"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:52
+msgid "validation_status_validated"
+msgstr ""
+
+#: sonar/modules/documents/views.py:174
 msgid "vol."
 msgstr "Bd."
 
@@ -5921,3 +5064,19 @@ msgstr ""
 
 #~ msgid "\\u200bSwiss National Science Foundation"
 #~ msgstr ""
+
+#~ msgid "Editors"
+#~ msgstr "Herausgeber"
+
+#~ msgid "In the format \\"
+#~ msgstr "Im Format \"Vorname, Nachname\""
+
+#~ msgid "Not OA / Rights reserved"
+#~ msgstr "Nicht OA / Rechte vorbehalten"
+
+#~ msgid "Other OA / license undefined"
+#~ msgstr "Andere Art von OA / Lizenz unbestimmt"
+
+#~ msgid "Specific collections"
+#~ msgstr "Besondere Sammlungen"
+

--- a/sonar/translations/en/LC_MESSAGES/messages.po
+++ b/sonar/translations/en/LC_MESSAGES/messages.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
 "Report-Msgid-Bugs-To: nicolas.prongue@rero.ch\n"
-"POT-Creation-Date: 2021-06-01 15:56+0200\n"
-"PO-Revision-Date: 2021-05-27 12:34+0000\n"
+"POT-Creation-Date: 2021-06-14 13:34+0200\n"
+"PO-Revision-Date: 2021-06-11 07:32+0000\n"
 "Last-Translator: Nicolas Prongué <n.prongue@outlook.com>\n"
 "Language: en\n"
 "Language-Team: English "
@@ -21,7 +21,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.1\n"
 
-#: sonar/theme/views.py:65
+#: sonar/theme/views.py:67
 #, python-format
 msgid "%(icon)s Profile"
 msgstr "%(icon)s My account"
@@ -34,13 +34,13 @@ msgstr ""
 msgid "About SONAR"
 msgstr "About SONAR"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:681
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:697
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:795
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:811
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:663
 msgid "Abstract"
 msgstr "Abstract"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:678
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:792
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:659
 msgid "Abstracts"
 msgstr "Abstracts"
@@ -58,10 +58,11 @@ msgid "Accompanying material of the resource, i.e. maps."
 msgstr "Accompanying material of the resource, ie maps."
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:844
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1651
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1663
 msgid "Acquisition terms"
 msgstr "Term of availability"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:77
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:210
 msgid "Action"
 msgstr "Action"
@@ -74,7 +75,11 @@ msgstr ""
 msgid "Actor involved"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:933
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:704
+msgid "Add a new collection"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1044
 msgid "Add a new project"
 msgstr "Add a new project"
 
@@ -87,14 +92,13 @@ msgstr "Additional materials"
 msgid "Administration"
 msgstr "Administration"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:834
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1009
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1367
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:948
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1383
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:203
 msgid "Affiliation"
 msgstr "Affiliation"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1180
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1196
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:159
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:250
 msgid "Agent"
@@ -132,9 +136,13 @@ msgstr ""
 "At least 3 characters and must contain only lower case characters and "
 "underscores."
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1484
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1496
 msgid "Author or editor"
 msgstr "Author or editor"
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:612
+msgid "Authors / Editors"
+msgstr ""
 
 #: sonar/modules/documents/templates/documents/record.html:44
 #: sonar/theme/templates/sonar/projects/detail.html:15
@@ -145,7 +153,7 @@ msgstr "Back"
 msgid "Back to SONAR"
 msgstr "Back to SONAR"
 
-#: sonar/config.py:584
+#: sonar/config.py:608
 msgid "Best match"
 msgstr "Best match"
 
@@ -161,12 +169,12 @@ msgstr ""
 msgid "Brief description of the report"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1788
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:30
 msgid "Bronze"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4993
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5008
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:110
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:125
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:20
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:34
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:15
@@ -184,35 +192,35 @@ msgstr "Bucket UUID used to store files"
 msgid "CAS or DAS"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:27
+#: sonar/common/jsonschemas/license-v1.0.0.json:28
 msgid "CC BY"
 msgstr "CC BY"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:31
+#: sonar/common/jsonschemas/license-v1.0.0.json:32
 msgid "CC BY-NC"
 msgstr "CC BY-NC"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:35
+#: sonar/common/jsonschemas/license-v1.0.0.json:36
 msgid "CC BY-NC-ND"
 msgstr "CC BY-NC-ND"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:39
+#: sonar/common/jsonschemas/license-v1.0.0.json:40
 msgid "CC BY-NC-SA"
 msgstr "CC BY-NC-SA"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:43
+#: sonar/common/jsonschemas/license-v1.0.0.json:44
 msgid "CC BY-ND"
 msgstr "CC BY-ND"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:47
+#: sonar/common/jsonschemas/license-v1.0.0.json:48
 msgid "CC BY-SA"
 msgstr "CC BY-SA"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:23
+#: sonar/common/jsonschemas/license-v1.0.0.json:24
 msgid "CC0"
 msgstr "CC0"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5033
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:150
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:59
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:58
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:266
@@ -224,16 +232,16 @@ msgid "City"
 msgstr "City"
 
 #: sonar/common/jsonschemas/classification-v1.0.0.json:2
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1015
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1031
 #: sonar/modules/documents/templates/documents/record.html:262
 msgid "Classification"
 msgstr "Classification"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1066
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1082
 msgid "Classification portion"
 msgstr "Classification number"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1011
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1027
 msgid "Classifications"
 msgstr "Classifications"
 
@@ -245,7 +253,7 @@ msgstr ""
 msgid "Click here to reset your password"
 msgstr "Click here to reset your password"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1792
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:34
 msgid "Closed"
 msgstr ""
 
@@ -253,18 +261,27 @@ msgstr ""
 msgid "Code"
 msgstr "Code"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:999
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:680
 msgid "Collection"
 msgstr "Collection"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:4
+#: sonar/modules/collections/templates/collections/index.html:21
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:676
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:995
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:999
+#: sonar/modules/documents/templates/documents/record.html:288
 msgid "Collections"
 msgstr "Collections"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:106
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:245
 msgid "Comment"
 msgstr "Comment"
+
+#: sonar/common/jsonschemas/validation-v1.0.0.json:107
+msgid "Comment associated with the current action."
+msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:513
 msgid "Company"
@@ -282,37 +299,41 @@ msgstr "Confirm e-mail"
 msgid "Contact"
 msgstr "Contact"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1094
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:540
+msgid "Contained in (journal, book, proceedings)"
+msgstr ""
+
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1110
 msgid "Content note"
 msgstr "Content note"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1090
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1106
 msgid "Content notes"
 msgstr "Content notes"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1175
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1480
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1191
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1492
 msgid "Contribution"
 msgstr "Contribution"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1171
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1187
 msgid "Contributions"
 msgstr "Contributions"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:814
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:928
 msgid "Contributor"
 msgstr "Contributor"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:808
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:922
 msgid "Contributors"
 msgstr "Contributors"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1379
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1395
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:212
 msgid "Controlled affiliation"
 msgstr "Controlled affiliation"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1375
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1391
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:208
 msgid "Controlled affiliations"
 msgstr "Controlled affiliations"
@@ -322,27 +343,36 @@ msgstr "Controlled affiliations"
 msgid "Creativity, transformations and innovations in education"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:78
+msgid "Current action done in the validation process."
+msgstr ""
+
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:173
 msgid "Current cataloguing step."
 msgstr "Current cataloguing step."
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1799
+#: sonar/common/jsonschemas/validation-v1.0.0.json:65
+msgid "Current status of the record in the validation process."
+msgstr ""
+
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1774
 msgid "Custom field 1"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1819
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1794
 msgid "Custom field 2"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1839
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1814
 msgid "Custom field 3"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:42
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:240
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:777
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:891
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:496
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1123
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1295
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1139
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1311
 msgid "Date"
 msgstr "Date"
 
@@ -354,14 +384,18 @@ msgstr "Date in yyyy-mm-dd format, ex: 1970-01-01"
 msgid "Date of approval by the Team Leader"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1271
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1287
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:34
 msgid "Date of birth"
 msgstr "Date of birth"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1279
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1295
 msgid "Date of death"
 msgstr "Date of death"
+
+#: sonar/common/jsonschemas/validation-v1.0.0.json:43
+msgid "Date when the log is created."
+msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:640
 msgid "Dean of a school"
@@ -372,8 +406,8 @@ msgstr ""
 msgid "Dear %(email)s"
 msgstr "Dear %(email)s"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:762
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1108
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:876
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1124
 msgid "Degree"
 msgstr "Degree"
 
@@ -389,20 +423,22 @@ msgstr "Deposit rejection"
 msgid "Deposit to validate"
 msgstr "Deposit to validate"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5003
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:120
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:30
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:236
 msgid "Describes the information of a single file in the record."
 msgstr "Describes the information of a single file in the record."
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2497
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:941
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:56
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:740
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1052
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:38
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:55
 msgid "Description"
 msgstr "Description"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2493
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:52
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:736
 msgid "Descriptions"
 msgstr ""
 
@@ -418,8 +454,8 @@ msgstr ""
 msgid "Director, head of establishment"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:757
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1103
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:871
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1119
 msgid "Dissertation"
 msgstr "Dissertation"
 
@@ -435,12 +471,12 @@ msgstr ""
 msgid "Doctorate supported by the HEP-VS"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:558
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1117
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:556
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1124
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:3
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:958
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1411
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1445
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1423
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1457
 msgid "Document"
 msgstr "Document"
 
@@ -448,7 +484,7 @@ msgstr "Document"
 msgid "Document ID"
 msgstr "Document ID"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1118
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1125
 msgid "Document created on basis of this deposit."
 msgstr "Document created on basis of this deposit."
 
@@ -484,10 +520,6 @@ msgstr "E-mail"
 msgid "Edition"
 msgstr "Edition"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:596
-msgid "Editors"
-msgstr "Editors"
-
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:211
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:273
 msgid "Education, childhood and the learning Society 21"
@@ -516,7 +548,7 @@ msgid "Emotions, learning, and well-being at school"
 msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:80
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:959
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1075
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:79
 msgid "End date"
 msgstr "End date"
@@ -544,8 +576,15 @@ msgstr ""
 "Enter your email address below and we will send you a link to reset your "
 "password."
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:886
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1020
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:569
+msgid "Example: 1"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:586
+msgid "Example: 10"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1000
 msgid "Example: 1111-2222-3333-4444"
 msgstr "Example: 1111-2222-3333-4444"
 
@@ -554,13 +593,11 @@ msgstr "Example: 1111-2222-3333-4444"
 msgid "Example: 2019 or 2019-01-01"
 msgstr "Example: 2019 or 2019-01-01"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:782
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1127
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:896
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1143
 msgid "Example: 2019 or 2019-05-05"
 msgstr "Example: 2019 or 2019-05-05"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:953
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:960
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:153
 msgid "Example: 2019-05-05"
 msgstr "Example: 2019-05-05"
@@ -571,6 +608,8 @@ msgstr "Example: 2020"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:75
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:88
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1070
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1082
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:74
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:87
 msgid "Example: 2020-12-01"
@@ -584,17 +623,17 @@ msgstr "Example: Doe"
 msgid "Example: John"
 msgstr "Example: John"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1488
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1500
 msgid "Example: Muller, Hans"
 msgstr "Example: Muller, Hans"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:638
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:655
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:977
 msgid "Example: Published version"
 msgstr "Example: Published version"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:591
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1441
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:602
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1453
 msgid "Examples: 135, 5-27, …"
 msgstr "Examples: 135, 5-27, …"
 
@@ -602,7 +641,11 @@ msgstr "Examples: 135, 5-27, …"
 msgid "Except within organisation"
 msgstr "Except within organisation"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:913
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:685
+msgid "Existing collection"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1024
 msgid "Existing project"
 msgstr "Existing project"
 
@@ -630,20 +673,20 @@ msgstr ""
 msgid "External partners are involved"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5013
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:130
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:39
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:35
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:246
 msgid "File UUID"
 msgstr "File UUID"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5002
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:119
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:29
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:235
 msgid "File item"
 msgstr "File item"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4998
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:115
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:25
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:21
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:231
@@ -694,7 +737,7 @@ msgstr "Format, i.e. dimensions in cm."
 msgid "Formats"
 msgstr "Formats"
 
-#: sonar/config.py:72
+#: sonar/config.py:74
 msgid "French"
 msgstr "French"
 
@@ -715,12 +758,10 @@ msgstr ""
 msgid "Funding number"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1048
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:245
 msgid "Funding organisation"
 msgstr "Funding organisation"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1045
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:241
 #: sonar/theme/templates/sonar/projects/detail.html:64
 msgid "Funding organisations"
@@ -734,20 +775,20 @@ msgstr ""
 msgid "Funding was granted for the project"
 msgstr ""
 
-#: sonar/config.py:72
+#: sonar/config.py:74
 msgid "German"
 msgstr "German"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1780
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:22
 msgid "Gold"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:772
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1118
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:886
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1134
 msgid "Granting institution"
 msgstr "Granting institution"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1776
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:18
 msgid "Green"
 msgstr ""
 
@@ -775,7 +816,7 @@ msgstr "HTML markup admitted."
 msgid "Harvested"
 msgstr "Harvested"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:18
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:18
 msgid "Hash key"
 msgstr ""
 
@@ -783,8 +824,8 @@ msgstr ""
 msgid "Help & Documentation"
 msgstr "Help & documentation"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:559
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1451
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:557
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1463
 msgid ""
 "Host document, for example a journal for an article, or a book for a book"
 " chapter."
@@ -796,7 +837,7 @@ msgstr ""
 msgid "How are research results used in training?"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1784
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:26
 msgid "Hybrid"
 msgstr ""
 
@@ -805,24 +846,22 @@ msgid "IR hosting service"
 msgstr "IR hosting service"
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:867
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1674
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1686
 msgid "ISBN/ISSN status should be selected in the list below."
 msgstr "The ISBN/ISSN status should be selected in the list below."
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1220
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1236
 msgid "Identified by"
 msgstr "Identified by"
 
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:2
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:3
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:9
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:13
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:13
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:15
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:360
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:966
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1058
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:693
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1500
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1512
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:13
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:13
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:9
@@ -833,7 +872,7 @@ msgstr "Identifier"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:357
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:689
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1496
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1508
 #: sonar/modules/documents/templates/documents/record.html:237
 msgid "Identifiers"
 msgstr "Identifiers"
@@ -849,10 +888,6 @@ msgstr "If this field is filled in, the file points to the specified URL."
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:316
 msgid "In progress"
 msgstr ""
-
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:597
-msgid "In the format \\"
-msgstr "In the format \"Last name, first name\""
 
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:118
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:165
@@ -880,12 +915,10 @@ msgstr ""
 msgid "Invenio"
 msgstr "Invenio"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:974
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:154
 msgid "Investigator"
 msgstr "Investigator"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:971
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:150
 #: sonar/theme/templates/sonar/projects/detail.html:35
 msgid "Investigators"
@@ -899,21 +932,21 @@ msgstr "Is dedicated"
 msgid "Is shared"
 msgstr "Appears in the shared repository"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1429
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1441
 msgid "Issue"
 msgstr "Issue"
 
-#: sonar/config.py:73
+#: sonar/config.py:75
 msgid "Italian"
 msgstr "Italian"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:767
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1113
-#: sonar/modules/documents/views.py:234
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:881
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1129
+#: sonar/modules/documents/views.py:240
 msgid "Jury note"
 msgstr "Jury note"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5023
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:140
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:49
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:47
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:256
@@ -924,7 +957,12 @@ msgstr "Key"
 msgid "Key (filename) of the file."
 msgstr "Key (filename) of the file."
 
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:835
+msgid "Keyword"
+msgstr ""
+
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:391
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:832
 msgid "Keywords"
 msgstr ""
 
@@ -932,7 +970,7 @@ msgstr ""
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:69
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:503
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:903
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1154
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1170
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:94
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:141
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:188
@@ -943,11 +981,9 @@ msgstr "Label"
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:137
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:184
 msgid "Labels"
-msgstr ""
+msgstr "Labels"
 
 #: sonar/common/jsonschemas/language-v1.0.0.json:2
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:37
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2513
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:354
 #: sonar/modules/documents/templates/documents/record.html:221
 msgid "Language"
@@ -970,7 +1006,7 @@ msgstr "Last OAI-PMH set update (ISO8601 formatted timestamp)"
 msgid "Last name"
 msgstr "Last name"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:829
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:943
 msgid "Last name, first name, ex: Doe, John"
 msgstr "Last name, first name, ex: Doe, John"
 
@@ -979,9 +1015,13 @@ msgid "Lecturer/professor"
 msgstr ""
 
 #: sonar/common/jsonschemas/license-v1.0.0.json:2
-#: sonar/modules/documents/templates/documents/record.html:288
+#: sonar/modules/documents/templates/documents/record.html:306
 msgid "License"
 msgstr "License"
+
+#: sonar/common/jsonschemas/license-v1.0.0.json:52
+msgid "License undefined"
+msgstr ""
 
 #: sonar/theme/templates/sonar/projects/detail.html:79
 msgid "Linked documents"
@@ -999,17 +1039,22 @@ msgstr ""
 "organisation. Note: the bibliographic record (metadata) is always public."
 " Enter one rule per line."
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4999
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:116
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:26
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:22
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:232
 msgid "List of files attached to the record."
 msgstr "List of files attached to the record."
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:21
+msgid "List of logs."
+msgstr ""
+
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:878
 msgid "Locality (Valais)"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:25
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:188
 msgid "Log"
 msgstr "Log"
@@ -1044,11 +1089,12 @@ msgstr ""
 msgid "Logout"
 msgstr "Logout"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:20
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:184
 msgid "Logs"
 msgstr "Logs"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5034
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:151
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:60
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:59
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:267
@@ -1067,11 +1113,11 @@ msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:291
 msgid "Main title"
-msgstr "Title proper"
+msgstr "Title"
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:287
 msgid "Main titles"
-msgstr "Titles proper"
+msgstr "Titles"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:836
 msgid "Mandate"
@@ -1089,38 +1135,38 @@ msgstr ""
 msgid "Mediator"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5028
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:145
 msgid "Mimetype"
 msgstr ""
 
-#: sonar/config.py:578
+#: sonar/config.py:602
 msgid "Most recent"
 msgstr "Most recent"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:356
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:535
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:898
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:27
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:828
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:936
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:979
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1053
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:27
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:711
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:942
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1047
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:33
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:50
 msgid "Name"
 msgstr "Name"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:23
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:23
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:707
 msgid "Names"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:55
-msgid "Not OA / Rights reserved"
-msgstr "Not OA / Rights reserved"
+#: sonar/modules/collections/templates/collections/index.html:32
+msgid "No collection found"
+msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:650
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:828
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1635
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1647
 msgid "Note"
 msgstr "Note"
 
@@ -1137,8 +1183,8 @@ msgid "Notes"
 msgstr "Notes"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:741
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:577
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1303
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:579
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1319
 msgid "Number"
 msgstr "Number"
 
@@ -1158,8 +1204,7 @@ msgstr "OAI-PMH sets for record."
 msgid "OAI-PMH specific information."
 msgstr "OAI-PMH specific information."
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:880
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1014
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:994
 msgid "ORCID"
 msgstr "ORCID"
 
@@ -1168,18 +1213,17 @@ msgstr "ORCID"
 msgid "Object type"
 msgstr "Object type"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1760
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:2
 msgid "Open access status"
 msgstr "Open access status"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:93
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4969
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4973
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:86
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:90
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:222
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:5
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:84
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:287
-#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:291
 msgid "Organisation"
 msgstr "Organisation"
 
@@ -1202,7 +1246,7 @@ msgstr "Organisations"
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:720
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:890
 msgid "Other"
-msgstr ""
+msgstr "Other"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:517
 msgid "Other (free field)"
@@ -1220,26 +1264,22 @@ msgstr ""
 "Other material characteristics, i.e. illustrations, black and white, or "
 "coloured."
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:51
-msgid "Other OA / license undefined"
-msgstr "Other OA / license undefined"
-
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:882
 msgid "Other canton (Switzerland)"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:624
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:641
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:953
 #: sonar/modules/documents/templates/documents/record.html:208
 msgid "Other electronic version"
 msgstr "Other electronic version"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:621
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:638
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:949
 msgid "Other electronic versions"
 msgstr "Other electronic versions"
 
-#: sonar/modules/documents/templates/documents/record.html:311
+#: sonar/modules/documents/templates/documents/record.html:329
 msgid "Other files"
 msgstr "Other files"
 
@@ -1252,8 +1292,8 @@ msgstr ""
 msgid "PID type"
 msgstr "PID type"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:585
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1437
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:596
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1449
 msgid "Pages"
 msgstr "Pages"
 
@@ -1261,8 +1301,7 @@ msgstr "Pages"
 msgid "Parents"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:540
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1407
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1419
 msgid "Part of (host document)"
 msgstr "Contained in (host document)"
 
@@ -1274,7 +1313,7 @@ msgstr ""
 msgid "Period"
 msgstr "Period"
 
-#: sonar/modules/documents/templates/documents/record.html:301
+#: sonar/modules/documents/templates/documents/record.html:319
 msgid "Permalink"
 msgstr "Permalink"
 
@@ -1291,7 +1330,7 @@ msgstr "Phone number"
 msgid "Phone number with the international prefix, without spaces."
 msgstr "Phone number with the international prefix, without spaces."
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1287
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1303
 msgid "Place"
 msgstr "Place"
 
@@ -1302,6 +1341,15 @@ msgstr ""
 #: sonar/templates/security/email/welcome.html:5
 msgid "Please confirm your e-mail by clicking here"
 msgstr "Please confirm your e-mail by clicking here"
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:573
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:590
+msgid "Please enter a valid number."
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:606
+msgid "Please enter a valid pages range, example: 135, 5-27."
+msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:85
 msgid "Position"
@@ -1332,13 +1380,13 @@ msgstr ""
 msgid "Practitioner-trainer"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1210
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1226
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:164
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:255
 msgid "Preferred name"
 msgstr "Preferred name"
 
-#: sonar/modules/documents/templates/documents/record.html:329
+#: sonar/modules/documents/templates/documents/record.html:347
 #: sonar/theme/templates/sonar/preview/base.html:23
 msgid "Preview"
 msgstr "Preview"
@@ -1358,11 +1406,11 @@ msgstr ""
 
 #: sonar/theme/templates/sonar/partial/dropdown_user.html:21
 #: sonar/theme/templates/sonar/partial/dropdown_user.html:24
-#: sonar/theme/views.py:66
+#: sonar/theme/views.py:68
 msgid "Profile"
 msgstr "Profile"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:916
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1027
 msgid "Project"
 msgstr "Project"
 
@@ -1402,12 +1450,12 @@ msgstr "Public access from"
 msgid "Public foundation"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:633
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:650
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:973
 msgid "Public note"
 msgstr "Public note"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1456
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1468
 msgid "Publication"
 msgstr "Publication"
 
@@ -1420,12 +1468,12 @@ msgid "Published in"
 msgstr "Published in"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:332
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:606
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:623
 msgid "Publisher"
 msgstr "Publisher"
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:836
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1643
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1655
 msgid "Qualifier"
 msgstr "Qualification"
 
@@ -1433,15 +1481,19 @@ msgstr "Qualification"
 msgid "Realization framework"
 msgstr ""
 
+#: sonar/modules/validation/api.py:216
+msgid "Record validation"
+msgstr ""
+
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:4
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:908
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1732
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1019
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1744
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:4
 msgid "Research project"
 msgstr "Research project"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:901
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1728
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1015
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1740
 #: sonar/modules/documents/templates/documents/record.html:183
 msgid "Research projects"
 msgstr "Research projects"
@@ -1457,15 +1509,18 @@ msgstr "Reset password"
 msgid "Responsibility"
 msgstr "Responsibility"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:839
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:984
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1330
+#: sonar/common/jsonschemas/license-v1.0.0.json:56
+msgid "Rights reserved"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:953
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1346
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:99
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:181
 msgid "Role"
 msgstr "Role"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1326
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1342
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:177
 msgid "Roles"
 msgstr "Roles"
@@ -1488,6 +1543,10 @@ msgstr "SONAR logo"
 msgid "Schema"
 msgstr "Schema"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:3
+msgid "Schema representing a validation workflow."
+msgstr ""
+
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:9
 msgid "Schema to validate document against."
 msgstr "Schema to validate document against."
@@ -1502,6 +1561,10 @@ msgstr ""
 #: sonar/theme/templates/sonar/partial/organisation.html:21
 msgid "Search"
 msgstr "Search"
+
+#: sonar/modules/collections/templates/collections/item.html:48
+msgid "Search in collection"
+msgstr ""
 
 #: sonar/theme/templates/sonar/frontpage.html:57
 msgid "Search publications, authors, projects..."
@@ -1560,14 +1623,14 @@ msgstr "Sign-up with %(type)s"
 msgid "Sign-up with SWITCHaai"
 msgstr "Sign-up with SWITCHaai"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5039
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:156
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:65
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:64
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:272
 msgid "Size"
 msgstr "Size"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5040
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:157
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:66
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:65
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:273
@@ -1582,8 +1645,8 @@ msgstr ""
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:510
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:849
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:926
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1245
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1656
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1261
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1668
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:117
 msgid "Source"
 msgstr "Source"
@@ -1596,13 +1659,9 @@ msgstr "Source code on"
 msgid "Special education teacher"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:659
-msgid "Specific collections"
-msgstr "Specific collections"
-
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:67
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:952
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1461
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1063
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1473
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:66
 msgid "Start date"
 msgstr "Start date"
@@ -1628,7 +1687,7 @@ msgid "State of Valais, parastatal institution"
 msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:474
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1466
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1478
 msgid "Statement"
 msgstr "Statement"
 
@@ -1636,10 +1695,11 @@ msgstr "Statement"
 msgid "Statements"
 msgstr "Statements"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:64
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:39
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:136
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:860
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1667
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1679
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:39
 msgid "Status"
 msgstr "Status"
@@ -1668,14 +1728,11 @@ msgstr ""
 msgid "Student in training"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:721
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:898
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:915
 msgid "Subject"
 msgstr "Subject"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:718
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:737
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:894
 msgid "Subjects"
 msgstr "Subjects"
@@ -1697,7 +1754,7 @@ msgstr "Super administration"
 msgid "Suspended"
 msgstr ""
 
-#: sonar/config.py:94 sonar/config.py:98
+#: sonar/config.py:96 sonar/config.py:100
 msgid "Swiss Open Access Repository"
 msgstr "Swiss Open Access Repository"
 
@@ -1733,7 +1790,7 @@ msgstr ""
 " It collects and promotes open access publications by authors affiliated "
 "with Swiss public research institutions."
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:660
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:677
 msgid ""
 "The names of the organisation's specific/patrimonial collections to which"
 " this document belongs"
@@ -1764,7 +1821,7 @@ msgstr ""
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:304
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:264
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:627
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1450
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1462
 msgid "Title"
 msgstr "Title"
 
@@ -1807,11 +1864,11 @@ msgstr ""
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:449
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:478
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:698
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1022
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1052
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1185
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1225
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1505
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1038
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1068
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1201
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1241
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1517
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:97
 msgid "Type"
 msgstr "Type"
@@ -1824,7 +1881,7 @@ msgstr ""
 msgid "Type of the file"
 msgstr "Type of the file"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:643
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:660
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:963
 msgid "URL"
 msgstr "URL"
@@ -1841,10 +1898,12 @@ msgstr "UUID of the ObjectVersion object."
 msgid "UUID of the bucket the tile is assigned to."
 msgstr "UUID of the bucket the tile is assigned to."
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1146
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1162
 msgid "Usage and access policy"
 msgstr "Usage and access policy"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:90
+#: sonar/common/jsonschemas/validation-v1.0.0.json:96
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:116
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:121
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:120
@@ -1852,15 +1911,25 @@ msgstr "Usage and access policy"
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:198
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:202
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:5
-#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:311
-#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:316
+#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:310
+#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:315
 msgid "User"
 msgstr "User"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:91
+msgid "User which created the record."
+msgstr ""
+
+#: sonar/common/jsonschemas/validation-v1.0.0.json:2
+msgid "Validation"
+msgstr ""
+
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:39
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:32
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2502
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:32
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:61
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:505
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:716
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:745
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:296
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:320
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:405
@@ -1869,8 +1938,8 @@ msgstr "User"
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:668
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:823
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:911
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1256
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1630
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1272
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1642
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:99
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:146
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:193
@@ -1878,7 +1947,11 @@ msgstr "User"
 msgid "Value"
 msgstr "Value"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5018
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:851
+msgid "Values"
+msgstr ""
+
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:135
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:44
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:41
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:251
@@ -1889,8 +1962,8 @@ msgstr "Version UUID"
 msgid "Vice-rector HE"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:569
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1421
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:562
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1433
 msgid "Volume"
 msgstr "Volume"
 
@@ -1898,7 +1971,7 @@ msgstr "Volume"
 msgid "Welcome to SONAR"
 msgstr "Welcome to SONAR"
 
-#: sonar/config.py:125
+#: sonar/config.py:127
 msgid "Welcome to SONAR, the Swiss Open Access Repository!"
 msgstr "Welcome to SONAR, the Swiss Open Access Repository!"
 
@@ -1930,8 +2003,7 @@ msgstr ""
 msgid "Why?"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:564
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1416
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1428
 msgid "Year"
 msgstr "Year"
 
@@ -1953,78 +2025,78 @@ msgstr "agent"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:417
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:728
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1535
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1547
 msgid "bf:AudioIssueNumber"
 msgstr "Audio issue number"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1049
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1065
 msgid "bf:ClassificationDdc"
 msgstr "DDC classification"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1019
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1035
 msgid "bf:ClassificationUdc"
 msgstr "UDC classification"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:402
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:732
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1539
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1551
 msgid "bf:Doi"
 msgstr "DOI"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:421
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:736
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1543
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1555
 msgid "bf:Ean"
 msgstr "EAN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:425
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:740
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1547
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1559
 msgid "bf:Gtin14Number"
 msgstr "GTIN-14"
 
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:17
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:429
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:744
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1234
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1551
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1250
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1563
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:106
 msgid "bf:Identifier"
 msgstr "Identifier"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:433
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:748
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1555
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1567
 msgid "bf:Isan"
 msgstr "ISAN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:412
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:752
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1559
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1571
 msgid "bf:Isbn"
 msgstr "ISBN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:437
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:756
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1563
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1575
 msgid "bf:Ismn"
 msgstr "ISMN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:441
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:760
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1567
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1579
 msgid "bf:Isrc"
 msgstr "ISRC"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:445
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:764
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1571
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1583
 msgid "bf:Issn"
 msgstr "ISSN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:449
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:768
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1575
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1587
 msgid "bf:IssnL"
 msgstr "ISSN-L"
 
@@ -2035,8 +2107,8 @@ msgstr "language"
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:21
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:453
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:772
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1238
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1579
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1254
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1591
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:110
 msgid "bf:Local"
 msgstr "Local identifier"
@@ -2047,37 +2119,37 @@ msgstr "Manufacture"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:457
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:776
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1583
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1595
 msgid "bf:MatrixNumber"
 msgstr "Audio matrix number"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1203
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1219
 msgid "bf:Meeting"
 msgstr "Meeting"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:461
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:780
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1587
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1599
 msgid "bf:MusicDistributorNumber"
 msgstr "Music distributor number"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:465
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:784
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1591
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1603
 msgid "bf:MusicPlate"
 msgstr "Plate number (printed music)"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:469
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:788
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1595
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1607
 msgid "bf:MusicPublisherNumber"
 msgstr "Music publisher number"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1199
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1215
 msgid "bf:Organization"
-msgstr "Corporate body"
+msgstr "Organization"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1195
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1211
 msgid "bf:Person"
 msgstr "Person"
 
@@ -2091,41 +2163,41 @@ msgstr "Publication"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:473
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:792
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1599
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1611
 msgid "bf:PublisherNumber"
 msgstr "Publisher number"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:493
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:812
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1619
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1631
 msgid "bf:ReportNumber"
 msgstr "Report number"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:497
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:816
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1623
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1635
 msgid "bf:Strn"
 msgstr "STRN"
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:280
 msgid "bf:Title"
-msgstr "title"
+msgstr "title proper"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:477
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:796
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1603
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1615
 msgid "bf:Upc"
 msgstr "UPC"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:481
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:800
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1607
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1619
 msgid "bf:Urn"
 msgstr "URN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:485
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:804
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1611
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1623
 msgid "bf:VideoRecordingNumber"
 msgstr "Video recording number"
 
@@ -2489,41 +2561,40 @@ msgstr "Open access"
 msgid "coar:c_f1cf"
 msgstr "Embargoed access"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1002
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:195
 msgid "coinvestigator"
 msgstr "coinvestigator"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:857
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1351
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:971
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1367
 msgid "contribution_role_cre"
 msgstr "Author / creator"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:861
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1359
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:975
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1375
 msgid "contribution_role_ctb"
 msgstr "Contributor"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:869
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1343
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:983
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1359
 msgid "contribution_role_dgs"
 msgstr "Degree supervisor"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:865
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1355
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:979
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1371
 msgid "contribution_role_edt"
 msgstr "Editor"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:873
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1347
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:987
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1363
 msgid "contribution_role_prt"
 msgstr "Printer"
 
-#: sonar/modules/documents/views.py:266
+#: sonar/modules/documents/views.py:272
 msgid "contribution_role_{role}"
 msgstr "contribution_role_{role}"
 
-#: sonar/config.py:549
+#: sonar/config.py:573
 msgid "contributor"
 msgstr "contributor"
 
@@ -2807,7 +2878,6 @@ msgstr ""
 msgid "innerSearcher"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:998
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:191
 msgid "investigator"
 msgstr "investigator"
@@ -2816,2913 +2886,1948 @@ msgstr "investigator"
 msgid "keywords"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:500
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:535
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3011
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:694
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1010
+msgid "label"
+msgstr ""
+
+#: sonar/common/jsonschemas/language-v1.0.0.json:497
 msgid "lang_aar"
 msgstr "Afar"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:504
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:539
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3015
+#: sonar/common/jsonschemas/language-v1.0.0.json:501
 msgid "lang_abk"
 msgstr "Abkhazian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:508
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:543
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3019
+#: sonar/common/jsonschemas/language-v1.0.0.json:505
 msgid "lang_ace"
 msgstr "Achinese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:512
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:547
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3023
+#: sonar/common/jsonschemas/language-v1.0.0.json:509
 msgid "lang_ach"
 msgstr "Acoli"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:516
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:551
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3027
+#: sonar/common/jsonschemas/language-v1.0.0.json:513
 msgid "lang_ada"
 msgstr "Adangme"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:520
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:555
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3031
+#: sonar/common/jsonschemas/language-v1.0.0.json:517
 msgid "lang_ady"
 msgstr "Adyghe"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:524
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:559
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3035
+#: sonar/common/jsonschemas/language-v1.0.0.json:521
 msgid "lang_afa"
 msgstr "Afroasiatic (other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:528
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:563
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3039
+#: sonar/common/jsonschemas/language-v1.0.0.json:525
 msgid "lang_afh"
 msgstr "Afrihili (Artificial language)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:532
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:567
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3043
+#: sonar/common/jsonschemas/language-v1.0.0.json:529
 msgid "lang_afr"
 msgstr "Afrikaans"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:536
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:571
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3047
+#: sonar/common/jsonschemas/language-v1.0.0.json:533
 msgid "lang_ain"
 msgstr "Ainu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:540
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:575
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3051
+#: sonar/common/jsonschemas/language-v1.0.0.json:537
 msgid "lang_aka"
 msgstr "Akan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:544
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:579
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3055
+#: sonar/common/jsonschemas/language-v1.0.0.json:541
 msgid "lang_akk"
 msgstr "Akkadian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:548
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:583
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3059
+#: sonar/common/jsonschemas/language-v1.0.0.json:545
 msgid "lang_alb"
 msgstr "Albanian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:552
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:587
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3063
+#: sonar/common/jsonschemas/language-v1.0.0.json:549
 msgid "lang_ale"
 msgstr "Aleut"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:556
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:591
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3067
+#: sonar/common/jsonschemas/language-v1.0.0.json:553
 msgid "lang_alg"
 msgstr "Algonquian (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:560
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:595
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3071
+#: sonar/common/jsonschemas/language-v1.0.0.json:557
 msgid "lang_alt"
 msgstr "Altai"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:564
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:599
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3075
+#: sonar/common/jsonschemas/language-v1.0.0.json:561
 msgid "lang_amh"
 msgstr "Amharic"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:568
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:603
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3079
+#: sonar/common/jsonschemas/language-v1.0.0.json:565
 msgid "lang_ang"
 msgstr "English, Old (ca. 450-1100)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:572
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:607
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3083
+#: sonar/common/jsonschemas/language-v1.0.0.json:569
 msgid "lang_anp"
 msgstr "Angika"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:576
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:611
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3087
+#: sonar/common/jsonschemas/language-v1.0.0.json:573
 msgid "lang_apa"
 msgstr "Apache languages"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:580
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:615
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3091
+#: sonar/common/jsonschemas/language-v1.0.0.json:577
 msgid "lang_ara"
 msgstr "Arabic"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:584
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:619
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3095
+#: sonar/common/jsonschemas/language-v1.0.0.json:581
 msgid "lang_arc"
 msgstr "Aramaic"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:588
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:623
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3099
+#: sonar/common/jsonschemas/language-v1.0.0.json:585
 msgid "lang_arg"
 msgstr "Aragonese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:592
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:627
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3103
+#: sonar/common/jsonschemas/language-v1.0.0.json:589
 msgid "lang_arm"
 msgstr "Armenian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:596
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:631
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3107
+#: sonar/common/jsonschemas/language-v1.0.0.json:593
 msgid "lang_arn"
 msgstr "Mapuche"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:600
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:635
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3111
+#: sonar/common/jsonschemas/language-v1.0.0.json:597
 msgid "lang_arp"
 msgstr "Arapaho"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:604
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:639
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3115
+#: sonar/common/jsonschemas/language-v1.0.0.json:601
 msgid "lang_art"
 msgstr "Artificial (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:608
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:643
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3119
+#: sonar/common/jsonschemas/language-v1.0.0.json:605
 msgid "lang_arw"
 msgstr "Arawak"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:612
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:647
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3123
+#: sonar/common/jsonschemas/language-v1.0.0.json:609
 msgid "lang_asm"
 msgstr "Assamese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:616
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:651
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3127
+#: sonar/common/jsonschemas/language-v1.0.0.json:613
 msgid "lang_ast"
 msgstr "Bable"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:620
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:655
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3131
+#: sonar/common/jsonschemas/language-v1.0.0.json:617
 msgid "lang_ath"
 msgstr "Athapascan (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:624
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:659
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3135
+#: sonar/common/jsonschemas/language-v1.0.0.json:621
 msgid "lang_aus"
 msgstr "Australian languages"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:628
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:663
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3139
+#: sonar/common/jsonschemas/language-v1.0.0.json:625
 msgid "lang_ava"
 msgstr "Avaric"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:632
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:667
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3143
+#: sonar/common/jsonschemas/language-v1.0.0.json:629
 msgid "lang_ave"
 msgstr "Avestan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:636
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:671
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3147
+#: sonar/common/jsonschemas/language-v1.0.0.json:633
 msgid "lang_awa"
 msgstr "Awadhi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:640
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:675
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3151
+#: sonar/common/jsonschemas/language-v1.0.0.json:637
 msgid "lang_aym"
 msgstr "Aymara"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:644
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:679
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3155
+#: sonar/common/jsonschemas/language-v1.0.0.json:641
 msgid "lang_aze"
 msgstr "Azerbaijani"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:648
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:683
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3159
+#: sonar/common/jsonschemas/language-v1.0.0.json:645
 msgid "lang_bad"
 msgstr "Banda languages"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:652
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:687
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3163
+#: sonar/common/jsonschemas/language-v1.0.0.json:649
 msgid "lang_bai"
 msgstr "Bamileke languages"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:656
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:691
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3167
+#: sonar/common/jsonschemas/language-v1.0.0.json:653
 msgid "lang_bak"
 msgstr "Bashkir"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:660
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:695
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3171
+#: sonar/common/jsonschemas/language-v1.0.0.json:657
 msgid "lang_bal"
 msgstr "Baluchi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:664
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:699
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3175
+#: sonar/common/jsonschemas/language-v1.0.0.json:661
 msgid "lang_bam"
 msgstr "Bambara"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:668
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:703
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3179
+#: sonar/common/jsonschemas/language-v1.0.0.json:665
 msgid "lang_ban"
 msgstr "Balinese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:672
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:707
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3183
+#: sonar/common/jsonschemas/language-v1.0.0.json:669
 msgid "lang_baq"
 msgstr "Basque"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:676
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:711
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3187
+#: sonar/common/jsonschemas/language-v1.0.0.json:673
 msgid "lang_bas"
 msgstr "Basa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:680
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:715
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3191
+#: sonar/common/jsonschemas/language-v1.0.0.json:677
 msgid "lang_bat"
 msgstr "Baltic (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:684
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:719
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3195
+#: sonar/common/jsonschemas/language-v1.0.0.json:681
 msgid "lang_bej"
 msgstr "Beja"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:688
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:723
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3199
+#: sonar/common/jsonschemas/language-v1.0.0.json:685
 msgid "lang_bel"
 msgstr "Belarusian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:692
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:727
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3203
+#: sonar/common/jsonschemas/language-v1.0.0.json:689
 msgid "lang_bem"
 msgstr "Bemba"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:696
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:731
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3207
+#: sonar/common/jsonschemas/language-v1.0.0.json:693
 msgid "lang_ben"
 msgstr "Bengali"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:700
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:735
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3211
+#: sonar/common/jsonschemas/language-v1.0.0.json:697
 msgid "lang_ber"
 msgstr "Berber (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:704
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:739
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3215
+#: sonar/common/jsonschemas/language-v1.0.0.json:701
 msgid "lang_bho"
 msgstr "Bhojpuri"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:708
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:743
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3219
+#: sonar/common/jsonschemas/language-v1.0.0.json:705
 msgid "lang_bih"
 msgstr "Bihari (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:712
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:747
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3223
+#: sonar/common/jsonschemas/language-v1.0.0.json:709
 msgid "lang_bik"
 msgstr "Bikol"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:716
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:751
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3227
+#: sonar/common/jsonschemas/language-v1.0.0.json:713
 msgid "lang_bin"
 msgstr "Edo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:720
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:755
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3231
+#: sonar/common/jsonschemas/language-v1.0.0.json:717
 msgid "lang_bis"
 msgstr "Bislama"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:724
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:759
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3235
+#: sonar/common/jsonschemas/language-v1.0.0.json:721
 msgid "lang_bla"
 msgstr "Siksika"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:728
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:763
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3239
+#: sonar/common/jsonschemas/language-v1.0.0.json:725
 msgid "lang_bnt"
 msgstr "Bantu (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:732
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:767
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3243
+#: sonar/common/jsonschemas/language-v1.0.0.json:729
 msgid "lang_bos"
 msgstr "Bosnian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:736
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:771
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3247
+#: sonar/common/jsonschemas/language-v1.0.0.json:733
 msgid "lang_bra"
 msgstr "Braj"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:740
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:775
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3251
+#: sonar/common/jsonschemas/language-v1.0.0.json:737
 msgid "lang_bre"
 msgstr "Breton"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:744
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:779
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3255
+#: sonar/common/jsonschemas/language-v1.0.0.json:741
 msgid "lang_btk"
 msgstr "Batak"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:748
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:783
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3259
+#: sonar/common/jsonschemas/language-v1.0.0.json:745
 msgid "lang_bua"
 msgstr "Buriat"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:752
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:787
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3263
+#: sonar/common/jsonschemas/language-v1.0.0.json:749
 msgid "lang_bug"
 msgstr "Bugis"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:756
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:791
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3267
+#: sonar/common/jsonschemas/language-v1.0.0.json:753
 msgid "lang_bul"
 msgstr "Bulgarian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:760
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:795
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3271
+#: sonar/common/jsonschemas/language-v1.0.0.json:757
 msgid "lang_bur"
 msgstr "Burmese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:764
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:799
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3275
+#: sonar/common/jsonschemas/language-v1.0.0.json:761
 msgid "lang_byn"
 msgstr "Bilin"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:768
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:803
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3279
+#: sonar/common/jsonschemas/language-v1.0.0.json:765
 msgid "lang_cad"
 msgstr "Caddo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:772
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:807
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3283
+#: sonar/common/jsonschemas/language-v1.0.0.json:769
 msgid "lang_cai"
 msgstr "Central American Indian (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:776
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:811
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3287
+#: sonar/common/jsonschemas/language-v1.0.0.json:773
 msgid "lang_car"
 msgstr "Carib"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:780
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:815
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3291
+#: sonar/common/jsonschemas/language-v1.0.0.json:777
 msgid "lang_cat"
 msgstr "Catalan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:784
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:819
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3295
+#: sonar/common/jsonschemas/language-v1.0.0.json:781
 msgid "lang_cau"
 msgstr "Caucasian (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:788
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:823
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3299
+#: sonar/common/jsonschemas/language-v1.0.0.json:785
 msgid "lang_ceb"
 msgstr "Cebuano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:792
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:827
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3303
+#: sonar/common/jsonschemas/language-v1.0.0.json:789
 msgid "lang_cel"
 msgstr "Celtic (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:796
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:831
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3307
+#: sonar/common/jsonschemas/language-v1.0.0.json:793
 msgid "lang_cha"
 msgstr "Chamorro"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:800
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:835
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3311
+#: sonar/common/jsonschemas/language-v1.0.0.json:797
 msgid "lang_chb"
 msgstr "Chibcha"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:804
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:839
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3315
+#: sonar/common/jsonschemas/language-v1.0.0.json:801
 msgid "lang_che"
 msgstr "Chechen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:808
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:843
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3319
+#: sonar/common/jsonschemas/language-v1.0.0.json:805
 msgid "lang_chg"
 msgstr "Chagatai"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:812
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:847
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3323
+#: sonar/common/jsonschemas/language-v1.0.0.json:809
 msgid "lang_chi"
 msgstr "Chinese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:816
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:851
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3327
+#: sonar/common/jsonschemas/language-v1.0.0.json:813
 msgid "lang_chk"
 msgstr "Chuukese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:820
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:855
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3331
+#: sonar/common/jsonschemas/language-v1.0.0.json:817
 msgid "lang_chm"
 msgstr "Mari"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:824
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:859
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3335
+#: sonar/common/jsonschemas/language-v1.0.0.json:821
 msgid "lang_chn"
 msgstr "Chinook jargon"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:828
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:863
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3339
+#: sonar/common/jsonschemas/language-v1.0.0.json:825
 msgid "lang_cho"
 msgstr "Choctaw"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:832
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:867
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3343
+#: sonar/common/jsonschemas/language-v1.0.0.json:829
 msgid "lang_chp"
 msgstr "Chipewyan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:836
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:871
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3347
+#: sonar/common/jsonschemas/language-v1.0.0.json:833
 msgid "lang_chr"
 msgstr "Cherokee"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:840
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:875
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3351
+#: sonar/common/jsonschemas/language-v1.0.0.json:837
 msgid "lang_chu"
 msgstr "Church Slavic"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:844
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:879
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3355
+#: sonar/common/jsonschemas/language-v1.0.0.json:841
 msgid "lang_chv"
 msgstr "Chuvash"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:848
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:883
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3359
+#: sonar/common/jsonschemas/language-v1.0.0.json:845
 msgid "lang_chy"
 msgstr "Cheyenne"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:852
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:887
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3363
+#: sonar/common/jsonschemas/language-v1.0.0.json:849
 msgid "lang_cmc"
 msgstr "Chamic languages"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:856
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:891
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3367
+#: sonar/common/jsonschemas/language-v1.0.0.json:853
 msgid "lang_cnr"
 msgstr "Montenegrin"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:860
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:895
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3371
+#: sonar/common/jsonschemas/language-v1.0.0.json:857
 msgid "lang_cop"
 msgstr "Coptic"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:864
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:899
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3375
+#: sonar/common/jsonschemas/language-v1.0.0.json:861
 msgid "lang_cor"
 msgstr "Cornish"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:868
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:903
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3379
+#: sonar/common/jsonschemas/language-v1.0.0.json:865
 msgid "lang_cos"
 msgstr "Corsican"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:872
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:907
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3383
+#: sonar/common/jsonschemas/language-v1.0.0.json:869
 msgid "lang_cpe"
 msgstr "Creoles and Pidgins, English-based (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:876
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:911
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3387
+#: sonar/common/jsonschemas/language-v1.0.0.json:873
 msgid "lang_cpf"
 msgstr "Creoles and Pidgins, French-based (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:880
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:915
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3391
+#: sonar/common/jsonschemas/language-v1.0.0.json:877
 msgid "lang_cpp"
 msgstr "Creoles and Pidgins, Portuguese-based (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:884
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:919
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3395
+#: sonar/common/jsonschemas/language-v1.0.0.json:881
 msgid "lang_cre"
 msgstr "Cree"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:888
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:923
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3399
+#: sonar/common/jsonschemas/language-v1.0.0.json:885
 msgid "lang_crh"
 msgstr "Crimean Tatar"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:892
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:927
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3403
+#: sonar/common/jsonschemas/language-v1.0.0.json:889
 msgid "lang_crp"
 msgstr "Creoles and Pidgins (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:896
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:931
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3407
+#: sonar/common/jsonschemas/language-v1.0.0.json:893
 msgid "lang_csb"
 msgstr "Kashubian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:900
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:935
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3411
+#: sonar/common/jsonschemas/language-v1.0.0.json:897
 msgid "lang_cus"
 msgstr "Cushitic (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:904
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:939
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3415
+#: sonar/common/jsonschemas/language-v1.0.0.json:901
 msgid "lang_cze"
 msgstr "Czech"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:908
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:943
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3419
+#: sonar/common/jsonschemas/language-v1.0.0.json:905
 msgid "lang_dak"
 msgstr "Dakota"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:912
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:947
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3423
+#: sonar/common/jsonschemas/language-v1.0.0.json:909
 msgid "lang_dan"
 msgstr "Danish"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:916
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:951
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3427
+#: sonar/common/jsonschemas/language-v1.0.0.json:913
 msgid "lang_dar"
 msgstr "Dargwa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:920
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:955
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3431
+#: sonar/common/jsonschemas/language-v1.0.0.json:917
 msgid "lang_day"
 msgstr "Dayak"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:924
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:959
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3435
+#: sonar/common/jsonschemas/language-v1.0.0.json:921
 msgid "lang_del"
 msgstr "Delaware"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:928
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:963
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3439
+#: sonar/common/jsonschemas/language-v1.0.0.json:925
 msgid "lang_den"
 msgstr "Slavey"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:932
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:967
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3443
+#: sonar/common/jsonschemas/language-v1.0.0.json:929
 msgid "lang_dgr"
 msgstr "Dogrib"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:936
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:971
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3447
+#: sonar/common/jsonschemas/language-v1.0.0.json:933
 msgid "lang_din"
 msgstr "Dinka"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:940
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:975
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3451
+#: sonar/common/jsonschemas/language-v1.0.0.json:937
 msgid "lang_div"
 msgstr "Divehi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:944
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:979
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3455
+#: sonar/common/jsonschemas/language-v1.0.0.json:941
 msgid "lang_doi"
 msgstr "Dogri"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:948
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:983
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3459
+#: sonar/common/jsonschemas/language-v1.0.0.json:945
 msgid "lang_dra"
 msgstr "Dravidian (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:952
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:987
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3463
+#: sonar/common/jsonschemas/language-v1.0.0.json:949
 msgid "lang_dsb"
 msgstr "Lower Sorbian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:956
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:991
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3467
+#: sonar/common/jsonschemas/language-v1.0.0.json:953
 msgid "lang_dua"
 msgstr "Duala"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:960
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:995
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3471
+#: sonar/common/jsonschemas/language-v1.0.0.json:957
 msgid "lang_dum"
 msgstr "Dutch, Middle (ca. 1050-1350)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:964
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:999
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3475
+#: sonar/common/jsonschemas/language-v1.0.0.json:961
 msgid "lang_dut"
 msgstr "Dutch"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:968
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1003
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3479
+#: sonar/common/jsonschemas/language-v1.0.0.json:965
 msgid "lang_dyu"
 msgstr "Dyula"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:972
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1007
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3483
+#: sonar/common/jsonschemas/language-v1.0.0.json:969
 msgid "lang_dzo"
 msgstr "Dzongkha"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:976
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1011
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3487
+#: sonar/common/jsonschemas/language-v1.0.0.json:973
 msgid "lang_efi"
 msgstr "Efik"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:980
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1015
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3491
+#: sonar/common/jsonschemas/language-v1.0.0.json:977
 msgid "lang_egy"
 msgstr "Egyptian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:984
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1019
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3495
+#: sonar/common/jsonschemas/language-v1.0.0.json:981
 msgid "lang_eka"
 msgstr "Ekajuk"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:988
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1023
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3499
+#: sonar/common/jsonschemas/language-v1.0.0.json:985
 msgid "lang_elx"
 msgstr "Elamite"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:992
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1027
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3503
+#: sonar/common/jsonschemas/language-v1.0.0.json:989
 msgid "lang_eng"
 msgstr "English"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:997
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1032
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3508
+#: sonar/common/jsonschemas/language-v1.0.0.json:994
 msgid "lang_enm"
 msgstr "English, Middle (1100-1500)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1001
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1036
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3512
+#: sonar/common/jsonschemas/language-v1.0.0.json:998
 msgid "lang_epo"
 msgstr "Esperanto"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1005
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1040
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3516
+#: sonar/common/jsonschemas/language-v1.0.0.json:1002
 msgid "lang_est"
 msgstr "Estonian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1009
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1044
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3520
+#: sonar/common/jsonschemas/language-v1.0.0.json:1006
 msgid "lang_ewe"
 msgstr "Ewe"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1013
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1048
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3524
+#: sonar/common/jsonschemas/language-v1.0.0.json:1010
 msgid "lang_ewo"
 msgstr "Ewondo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1017
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1052
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3528
+#: sonar/common/jsonschemas/language-v1.0.0.json:1014
 msgid "lang_fan"
 msgstr "Fang"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1021
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1056
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3532
+#: sonar/common/jsonschemas/language-v1.0.0.json:1018
 msgid "lang_fao"
 msgstr "Faroese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1025
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1060
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3536
+#: sonar/common/jsonschemas/language-v1.0.0.json:1022
 msgid "lang_fat"
 msgstr "Fanti"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1029
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1064
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3540
+#: sonar/common/jsonschemas/language-v1.0.0.json:1026
 msgid "lang_fij"
 msgstr "Fijian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1033
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1068
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3544
+#: sonar/common/jsonschemas/language-v1.0.0.json:1030
 msgid "lang_fil"
 msgstr "Filipino"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1037
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1072
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3548
+#: sonar/common/jsonschemas/language-v1.0.0.json:1034
 msgid "lang_fin"
 msgstr "Finnish"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1041
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1076
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3552
+#: sonar/common/jsonschemas/language-v1.0.0.json:1038
 msgid "lang_fiu"
 msgstr "Finno-Ugrian (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1045
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1080
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3556
+#: sonar/common/jsonschemas/language-v1.0.0.json:1042
 msgid "lang_fon"
 msgstr "Fon"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1049
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1084
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3560
+#: sonar/common/jsonschemas/language-v1.0.0.json:1046
 msgid "lang_fre"
 msgstr "French"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1054
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1089
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3565
+#: sonar/common/jsonschemas/language-v1.0.0.json:1051
 msgid "lang_frm"
 msgstr "French, Middle (ca. 1300-1600)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1058
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1093
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3569
+#: sonar/common/jsonschemas/language-v1.0.0.json:1055
 msgid "lang_fro"
 msgstr "French, Old (ca. 842-1300)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1062
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1097
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3573
+#: sonar/common/jsonschemas/language-v1.0.0.json:1059
 msgid "lang_frr"
 msgstr "North Frisian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1066
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1101
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3577
+#: sonar/common/jsonschemas/language-v1.0.0.json:1063
 msgid "lang_frs"
 msgstr "East Frisian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1070
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1105
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3581
+#: sonar/common/jsonschemas/language-v1.0.0.json:1067
 msgid "lang_fry"
 msgstr "Frisian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1074
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1109
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3585
+#: sonar/common/jsonschemas/language-v1.0.0.json:1071
 msgid "lang_ful"
 msgstr "Fula"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1078
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1113
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3589
+#: sonar/common/jsonschemas/language-v1.0.0.json:1075
 msgid "lang_fur"
 msgstr "Friulian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1082
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1117
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3593
+#: sonar/common/jsonschemas/language-v1.0.0.json:1079
 msgid "lang_gaa"
 msgstr "Gã"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1086
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1121
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3597
+#: sonar/common/jsonschemas/language-v1.0.0.json:1083
 msgid "lang_gay"
 msgstr "Gayo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1090
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1125
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3601
+#: sonar/common/jsonschemas/language-v1.0.0.json:1087
 msgid "lang_gba"
 msgstr "Gbaya"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1094
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1129
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3605
+#: sonar/common/jsonschemas/language-v1.0.0.json:1091
 msgid "lang_gem"
 msgstr "Germanic (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1098
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1133
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3609
+#: sonar/common/jsonschemas/language-v1.0.0.json:1095
 msgid "lang_geo"
 msgstr "Georgian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1102
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1137
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3613
+#: sonar/common/jsonschemas/language-v1.0.0.json:1099
 msgid "lang_ger"
 msgstr "German"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1107
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1142
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3618
+#: sonar/common/jsonschemas/language-v1.0.0.json:1104
 msgid "lang_gez"
 msgstr "Ethiopic"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1111
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1146
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3622
+#: sonar/common/jsonschemas/language-v1.0.0.json:1108
 msgid "lang_gil"
 msgstr "Gilbertese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1115
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1150
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3626
+#: sonar/common/jsonschemas/language-v1.0.0.json:1112
 msgid "lang_gla"
 msgstr "Scottish Gaelic"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1119
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1154
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3630
+#: sonar/common/jsonschemas/language-v1.0.0.json:1116
 msgid "lang_gle"
 msgstr "Irish"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1123
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1158
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3634
+#: sonar/common/jsonschemas/language-v1.0.0.json:1120
 msgid "lang_glg"
 msgstr "Galician"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1127
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1162
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3638
+#: sonar/common/jsonschemas/language-v1.0.0.json:1124
 msgid "lang_glv"
 msgstr "Manx"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1131
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1166
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3642
+#: sonar/common/jsonschemas/language-v1.0.0.json:1128
 msgid "lang_gmh"
 msgstr "German, Middle High (ca. 1050-1500)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1135
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1170
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3646
+#: sonar/common/jsonschemas/language-v1.0.0.json:1132
 msgid "lang_goh"
 msgstr "German, Old High (ca. 750-1050)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1139
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1174
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3650
+#: sonar/common/jsonschemas/language-v1.0.0.json:1136
 msgid "lang_gon"
 msgstr "Gondi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1143
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1178
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3654
+#: sonar/common/jsonschemas/language-v1.0.0.json:1140
 msgid "lang_gor"
 msgstr "Gorontalo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1147
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1182
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3658
+#: sonar/common/jsonschemas/language-v1.0.0.json:1144
 msgid "lang_got"
 msgstr "Gothic"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1151
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1186
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3662
+#: sonar/common/jsonschemas/language-v1.0.0.json:1148
 msgid "lang_grb"
 msgstr "Grebo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1155
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1190
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3666
+#: sonar/common/jsonschemas/language-v1.0.0.json:1152
 msgid "lang_grc"
 msgstr "Greek, Ancient (to 1453)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1159
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1194
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3670
+#: sonar/common/jsonschemas/language-v1.0.0.json:1156
 msgid "lang_gre"
 msgstr "Greek, Modern (1453- )"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1163
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1198
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3674
+#: sonar/common/jsonschemas/language-v1.0.0.json:1160
 msgid "lang_grn"
 msgstr "Guarani"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1167
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1202
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3678
+#: sonar/common/jsonschemas/language-v1.0.0.json:1164
 msgid "lang_gsw"
 msgstr "Swiss German"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1171
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1206
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3682
+#: sonar/common/jsonschemas/language-v1.0.0.json:1168
 msgid "lang_guj"
 msgstr "Gujarati"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1175
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1210
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3686
+#: sonar/common/jsonschemas/language-v1.0.0.json:1172
 msgid "lang_gwi"
 msgstr "Gwich'in"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1179
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1214
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3690
+#: sonar/common/jsonschemas/language-v1.0.0.json:1176
 msgid "lang_hai"
 msgstr "Haida"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1183
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1218
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3694
+#: sonar/common/jsonschemas/language-v1.0.0.json:1180
 msgid "lang_hat"
 msgstr "Haitian French Creole"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1187
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1222
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3698
+#: sonar/common/jsonschemas/language-v1.0.0.json:1184
 msgid "lang_hau"
 msgstr "Hausa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1191
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1226
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3702
+#: sonar/common/jsonschemas/language-v1.0.0.json:1188
 msgid "lang_haw"
 msgstr "Hawaiian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1195
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1230
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3706
+#: sonar/common/jsonschemas/language-v1.0.0.json:1192
 msgid "lang_heb"
 msgstr "Hebrew"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1199
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1234
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3710
+#: sonar/common/jsonschemas/language-v1.0.0.json:1196
 msgid "lang_her"
 msgstr "Herero"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1203
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1238
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3714
+#: sonar/common/jsonschemas/language-v1.0.0.json:1200
 msgid "lang_hil"
 msgstr "Hiligaynon"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1207
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1242
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3718
+#: sonar/common/jsonschemas/language-v1.0.0.json:1204
 msgid "lang_him"
 msgstr "Western Pahari languages"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1211
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1246
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3722
+#: sonar/common/jsonschemas/language-v1.0.0.json:1208
 msgid "lang_hin"
 msgstr "Hindi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1215
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1250
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3726
+#: sonar/common/jsonschemas/language-v1.0.0.json:1212
 msgid "lang_hit"
 msgstr "Hittite"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1219
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1254
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3730
+#: sonar/common/jsonschemas/language-v1.0.0.json:1216
 msgid "lang_hmn"
 msgstr "Hmong"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1223
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1258
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3734
+#: sonar/common/jsonschemas/language-v1.0.0.json:1220
 msgid "lang_hmo"
 msgstr "Hiri Motu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1227
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1262
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3738
+#: sonar/common/jsonschemas/language-v1.0.0.json:1224
 msgid "lang_hrv"
 msgstr "Croatian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1231
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1266
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3742
+#: sonar/common/jsonschemas/language-v1.0.0.json:1228
 msgid "lang_hsb"
 msgstr "Upper Sorbian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1235
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1270
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3746
+#: sonar/common/jsonschemas/language-v1.0.0.json:1232
 msgid "lang_hun"
 msgstr "Hungarian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1239
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1274
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3750
+#: sonar/common/jsonschemas/language-v1.0.0.json:1236
 msgid "lang_hup"
 msgstr "Hupa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1243
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1278
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3754
+#: sonar/common/jsonschemas/language-v1.0.0.json:1240
 msgid "lang_iba"
 msgstr "Iban"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1247
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1282
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3758
+#: sonar/common/jsonschemas/language-v1.0.0.json:1244
 msgid "lang_ibo"
 msgstr "Igbo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1251
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1286
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3762
+#: sonar/common/jsonschemas/language-v1.0.0.json:1248
 msgid "lang_ice"
 msgstr "Icelandic"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1255
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1290
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3766
+#: sonar/common/jsonschemas/language-v1.0.0.json:1252
 msgid "lang_ido"
 msgstr "Ido"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1259
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1294
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3770
+#: sonar/common/jsonschemas/language-v1.0.0.json:1256
 msgid "lang_iii"
 msgstr "Sichuan Yi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1263
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1298
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3774
+#: sonar/common/jsonschemas/language-v1.0.0.json:1260
 msgid "lang_ijo"
 msgstr "Ijo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1267
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1302
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3778
+#: sonar/common/jsonschemas/language-v1.0.0.json:1264
 msgid "lang_iku"
 msgstr "Inuktitut"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1271
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1306
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3782
+#: sonar/common/jsonschemas/language-v1.0.0.json:1268
 msgid "lang_ile"
 msgstr "Interlingue"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1275
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1310
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3786
+#: sonar/common/jsonschemas/language-v1.0.0.json:1272
 msgid "lang_ilo"
 msgstr "Iloko"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1279
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1314
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3790
+#: sonar/common/jsonschemas/language-v1.0.0.json:1276
 msgid "lang_ina"
 msgstr "Interlingua (International Auxiliary Language Association)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1283
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1318
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3794
+#: sonar/common/jsonschemas/language-v1.0.0.json:1280
 msgid "lang_inc"
 msgstr "Indic (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1287
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1322
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3798
+#: sonar/common/jsonschemas/language-v1.0.0.json:1284
 msgid "lang_ind"
 msgstr "Indonesian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1291
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1326
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3802
+#: sonar/common/jsonschemas/language-v1.0.0.json:1288
 msgid "lang_ine"
 msgstr "Indo-European (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1295
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1330
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3806
+#: sonar/common/jsonschemas/language-v1.0.0.json:1292
 msgid "lang_inh"
 msgstr "Ingush"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1299
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1334
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3810
+#: sonar/common/jsonschemas/language-v1.0.0.json:1296
 msgid "lang_ipk"
 msgstr "Inupiaq"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1303
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1338
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3814
+#: sonar/common/jsonschemas/language-v1.0.0.json:1300
 msgid "lang_ira"
 msgstr "Iranian (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1307
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1342
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3818
+#: sonar/common/jsonschemas/language-v1.0.0.json:1304
 msgid "lang_iro"
 msgstr "Iroquoian (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1311
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1346
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3822
+#: sonar/common/jsonschemas/language-v1.0.0.json:1308
 msgid "lang_ita"
 msgstr "Italian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1316
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1351
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3827
+#: sonar/common/jsonschemas/language-v1.0.0.json:1313
 msgid "lang_jav"
 msgstr "Javanese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1320
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1355
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3831
+#: sonar/common/jsonschemas/language-v1.0.0.json:1317
 msgid "lang_jbo"
 msgstr "Lojban (Artificial language)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1324
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1359
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3835
+#: sonar/common/jsonschemas/language-v1.0.0.json:1321
 msgid "lang_jpn"
 msgstr "Japanese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1328
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1363
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3839
+#: sonar/common/jsonschemas/language-v1.0.0.json:1325
 msgid "lang_jpr"
 msgstr "Judeo-Persian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1332
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1367
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3843
+#: sonar/common/jsonschemas/language-v1.0.0.json:1329
 msgid "lang_jrb"
 msgstr "Judeo-Arabic"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1336
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1371
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3847
+#: sonar/common/jsonschemas/language-v1.0.0.json:1333
 msgid "lang_kaa"
 msgstr "Kara-Kalpak"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1340
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1375
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3851
+#: sonar/common/jsonschemas/language-v1.0.0.json:1337
 msgid "lang_kab"
 msgstr "Kabyle"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1344
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1379
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3855
+#: sonar/common/jsonschemas/language-v1.0.0.json:1341
 msgid "lang_kac"
 msgstr "Kachin"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1348
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1383
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3859
+#: sonar/common/jsonschemas/language-v1.0.0.json:1345
 msgid "lang_kal"
 msgstr "Kalâtdlisut"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1352
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1387
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3863
+#: sonar/common/jsonschemas/language-v1.0.0.json:1349
 msgid "lang_kam"
 msgstr "Kamba"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1356
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1391
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3867
+#: sonar/common/jsonschemas/language-v1.0.0.json:1353
 msgid "lang_kan"
 msgstr "Kannada"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1360
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1395
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3871
+#: sonar/common/jsonschemas/language-v1.0.0.json:1357
 msgid "lang_kar"
 msgstr "Karen languages"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1364
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1399
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3875
+#: sonar/common/jsonschemas/language-v1.0.0.json:1361
 msgid "lang_kas"
 msgstr "Kashmiri"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1368
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1403
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3879
+#: sonar/common/jsonschemas/language-v1.0.0.json:1365
 msgid "lang_kau"
 msgstr "Kanuri"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1372
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1407
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3883
+#: sonar/common/jsonschemas/language-v1.0.0.json:1369
 msgid "lang_kaw"
 msgstr "Kawi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1376
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1411
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3887
+#: sonar/common/jsonschemas/language-v1.0.0.json:1373
 msgid "lang_kaz"
 msgstr "Kazakh"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1380
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1415
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3891
+#: sonar/common/jsonschemas/language-v1.0.0.json:1377
 msgid "lang_kbd"
 msgstr "Kabardian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1384
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1419
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3895
+#: sonar/common/jsonschemas/language-v1.0.0.json:1381
 msgid "lang_kha"
 msgstr "Khasi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1388
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1423
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3899
+#: sonar/common/jsonschemas/language-v1.0.0.json:1385
 msgid "lang_khi"
 msgstr "Khoisan (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1392
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1427
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3903
+#: sonar/common/jsonschemas/language-v1.0.0.json:1389
 msgid "lang_khm"
 msgstr "Khmer"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1396
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1431
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3907
+#: sonar/common/jsonschemas/language-v1.0.0.json:1393
 msgid "lang_kho"
 msgstr "Khotanese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1400
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1435
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3911
+#: sonar/common/jsonschemas/language-v1.0.0.json:1397
 msgid "lang_kik"
 msgstr "Kikuyu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1404
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1439
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3915
+#: sonar/common/jsonschemas/language-v1.0.0.json:1401
 msgid "lang_kin"
 msgstr "Kinyarwanda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1408
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1443
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3919
+#: sonar/common/jsonschemas/language-v1.0.0.json:1405
 msgid "lang_kir"
 msgstr "Kyrgyz"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1412
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1447
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3923
+#: sonar/common/jsonschemas/language-v1.0.0.json:1409
 msgid "lang_kmb"
 msgstr "Kimbundu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1416
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1451
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3927
+#: sonar/common/jsonschemas/language-v1.0.0.json:1413
 msgid "lang_kok"
 msgstr "Konkani"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1420
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1455
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3931
+#: sonar/common/jsonschemas/language-v1.0.0.json:1417
 msgid "lang_kom"
 msgstr "Komi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1424
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1459
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3935
+#: sonar/common/jsonschemas/language-v1.0.0.json:1421
 msgid "lang_kon"
 msgstr "Kongo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1428
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1463
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3939
+#: sonar/common/jsonschemas/language-v1.0.0.json:1425
 msgid "lang_kor"
 msgstr "Korean"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1432
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1467
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3943
+#: sonar/common/jsonschemas/language-v1.0.0.json:1429
 msgid "lang_kos"
 msgstr "Kosraean"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1436
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1471
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3947
+#: sonar/common/jsonschemas/language-v1.0.0.json:1433
 msgid "lang_kpe"
 msgstr "Kpelle"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1440
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1475
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3951
+#: sonar/common/jsonschemas/language-v1.0.0.json:1437
 msgid "lang_krc"
 msgstr "Karachay-Balkar"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1444
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1479
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3955
+#: sonar/common/jsonschemas/language-v1.0.0.json:1441
 msgid "lang_krl"
 msgstr "Karelian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1448
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1483
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3959
+#: sonar/common/jsonschemas/language-v1.0.0.json:1445
 msgid "lang_kro"
 msgstr "Kru (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1452
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1487
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3963
+#: sonar/common/jsonschemas/language-v1.0.0.json:1449
 msgid "lang_kru"
 msgstr "Kurukh"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1456
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1491
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3967
+#: sonar/common/jsonschemas/language-v1.0.0.json:1453
 msgid "lang_kua"
 msgstr "Kuanyama"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1460
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1495
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3971
+#: sonar/common/jsonschemas/language-v1.0.0.json:1457
 msgid "lang_kum"
 msgstr "Kumyk"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1464
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1499
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3975
+#: sonar/common/jsonschemas/language-v1.0.0.json:1461
 msgid "lang_kur"
 msgstr "Kurdish"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1468
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1503
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3979
+#: sonar/common/jsonschemas/language-v1.0.0.json:1465
 msgid "lang_kut"
 msgstr "Kootenai"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1472
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1507
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3983
+#: sonar/common/jsonschemas/language-v1.0.0.json:1469
 msgid "lang_lad"
 msgstr "Ladino"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1476
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1511
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3987
+#: sonar/common/jsonschemas/language-v1.0.0.json:1473
 msgid "lang_lah"
 msgstr "Lahndā"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1480
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1515
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3991
+#: sonar/common/jsonschemas/language-v1.0.0.json:1477
 msgid "lang_lam"
 msgstr "Lamba (Zambia and Congo)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1484
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1519
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3995
+#: sonar/common/jsonschemas/language-v1.0.0.json:1481
 msgid "lang_lao"
 msgstr "Lao"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1488
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1523
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3999
+#: sonar/common/jsonschemas/language-v1.0.0.json:1485
 msgid "lang_lat"
 msgstr "Latin"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1492
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1527
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4003
+#: sonar/common/jsonschemas/language-v1.0.0.json:1489
 msgid "lang_lav"
 msgstr "Latvian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1496
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1531
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4007
+#: sonar/common/jsonschemas/language-v1.0.0.json:1493
 msgid "lang_lez"
 msgstr "Lezgian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1500
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1535
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4011
+#: sonar/common/jsonschemas/language-v1.0.0.json:1497
 msgid "lang_lim"
 msgstr "Limburgish"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1504
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1539
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4015
+#: sonar/common/jsonschemas/language-v1.0.0.json:1501
 msgid "lang_lin"
 msgstr "Lingala"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1508
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1543
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4019
+#: sonar/common/jsonschemas/language-v1.0.0.json:1505
 msgid "lang_lit"
 msgstr "Lithuanian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1512
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1547
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4023
+#: sonar/common/jsonschemas/language-v1.0.0.json:1509
 msgid "lang_lol"
 msgstr "Mongo-Nkundu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1516
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1551
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4027
+#: sonar/common/jsonschemas/language-v1.0.0.json:1513
 msgid "lang_loz"
 msgstr "Lozi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1520
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1555
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4031
+#: sonar/common/jsonschemas/language-v1.0.0.json:1517
 msgid "lang_ltz"
 msgstr "Luxembourgish"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1524
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1559
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4035
+#: sonar/common/jsonschemas/language-v1.0.0.json:1521
 msgid "lang_lua"
 msgstr "Luba-Lulua"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1528
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1563
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4039
+#: sonar/common/jsonschemas/language-v1.0.0.json:1525
 msgid "lang_lub"
 msgstr "Luba-Katanga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1532
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1567
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4043
+#: sonar/common/jsonschemas/language-v1.0.0.json:1529
 msgid "lang_lug"
 msgstr "Ganda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1536
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1571
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4047
+#: sonar/common/jsonschemas/language-v1.0.0.json:1533
 msgid "lang_lui"
 msgstr "Luiseño"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1540
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1575
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4051
+#: sonar/common/jsonschemas/language-v1.0.0.json:1537
 msgid "lang_lun"
 msgstr "Lunda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1544
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1579
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4055
+#: sonar/common/jsonschemas/language-v1.0.0.json:1541
 msgid "lang_luo"
 msgstr "Luo (Kenya and Tanzania)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1548
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1583
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4059
+#: sonar/common/jsonschemas/language-v1.0.0.json:1545
 msgid "lang_lus"
 msgstr "Lushai"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1552
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1587
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4063
+#: sonar/common/jsonschemas/language-v1.0.0.json:1549
 msgid "lang_mac"
 msgstr "Macedonian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1556
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1591
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4067
+#: sonar/common/jsonschemas/language-v1.0.0.json:1553
 msgid "lang_mad"
 msgstr "Madurese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1560
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1595
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4071
+#: sonar/common/jsonschemas/language-v1.0.0.json:1557
 msgid "lang_mag"
 msgstr "Magahi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1564
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1599
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4075
+#: sonar/common/jsonschemas/language-v1.0.0.json:1561
 msgid "lang_mah"
 msgstr "Marshallese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1568
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1603
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4079
+#: sonar/common/jsonschemas/language-v1.0.0.json:1565
 msgid "lang_mai"
 msgstr "Maithili"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1572
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1607
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4083
+#: sonar/common/jsonschemas/language-v1.0.0.json:1569
 msgid "lang_mak"
 msgstr "Makasar"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1576
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1611
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4087
+#: sonar/common/jsonschemas/language-v1.0.0.json:1573
 msgid "lang_mal"
 msgstr "Malayalam"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1580
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1615
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4091
+#: sonar/common/jsonschemas/language-v1.0.0.json:1577
 msgid "lang_man"
 msgstr "Mandingo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1584
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1619
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4095
+#: sonar/common/jsonschemas/language-v1.0.0.json:1581
 msgid "lang_mao"
 msgstr "Maori"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1588
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1623
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4099
+#: sonar/common/jsonschemas/language-v1.0.0.json:1585
 msgid "lang_map"
 msgstr "Austronesian (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1592
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1627
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4103
+#: sonar/common/jsonschemas/language-v1.0.0.json:1589
 msgid "lang_mar"
 msgstr "Marathi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1596
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1631
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4107
+#: sonar/common/jsonschemas/language-v1.0.0.json:1593
 msgid "lang_mas"
 msgstr "Maasai"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1600
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1635
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4111
+#: sonar/common/jsonschemas/language-v1.0.0.json:1597
 msgid "lang_may"
 msgstr "Malay"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1604
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1639
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4115
+#: sonar/common/jsonschemas/language-v1.0.0.json:1601
 msgid "lang_mdf"
 msgstr "Moksha"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1608
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1643
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4119
+#: sonar/common/jsonschemas/language-v1.0.0.json:1605
 msgid "lang_mdr"
 msgstr "Mandar"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1612
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1647
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4123
+#: sonar/common/jsonschemas/language-v1.0.0.json:1609
 msgid "lang_men"
 msgstr "Mende"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1616
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1651
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4127
+#: sonar/common/jsonschemas/language-v1.0.0.json:1613
 msgid "lang_mga"
 msgstr "Irish, Middle (ca. 1100-1550)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1620
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1655
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4131
+#: sonar/common/jsonschemas/language-v1.0.0.json:1617
 msgid "lang_mic"
 msgstr "Micmac"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1624
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1659
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4135
+#: sonar/common/jsonschemas/language-v1.0.0.json:1621
 msgid "lang_min"
 msgstr "Minangkabau"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1628
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1663
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4139
+#: sonar/common/jsonschemas/language-v1.0.0.json:1625
 msgid "lang_mis"
 msgstr "Miscellaneous languages"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1632
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1667
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4143
+#: sonar/common/jsonschemas/language-v1.0.0.json:1629
 msgid "lang_mkh"
 msgstr "Mon-Khmer (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1636
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1671
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4147
+#: sonar/common/jsonschemas/language-v1.0.0.json:1633
 msgid "lang_mlg"
 msgstr "Malagasy"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1640
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1675
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4151
+#: sonar/common/jsonschemas/language-v1.0.0.json:1637
 msgid "lang_mlt"
 msgstr "Maltese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1644
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1679
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4155
+#: sonar/common/jsonschemas/language-v1.0.0.json:1641
 msgid "lang_mnc"
 msgstr "Manchu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1648
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1683
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4159
+#: sonar/common/jsonschemas/language-v1.0.0.json:1645
 msgid "lang_mni"
 msgstr "Manipuri"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1652
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1687
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4163
+#: sonar/common/jsonschemas/language-v1.0.0.json:1649
 msgid "lang_mno"
 msgstr "Manobo languages"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1656
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1691
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4167
+#: sonar/common/jsonschemas/language-v1.0.0.json:1653
 msgid "lang_moh"
 msgstr "Mohawk"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1660
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1695
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4171
+#: sonar/common/jsonschemas/language-v1.0.0.json:1657
 msgid "lang_mon"
 msgstr "Mongolian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1664
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1699
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4175
+#: sonar/common/jsonschemas/language-v1.0.0.json:1661
 msgid "lang_mos"
 msgstr "Mooré"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1668
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1703
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4179
+#: sonar/common/jsonschemas/language-v1.0.0.json:1665
 msgid "lang_mul"
 msgstr "Multiple languages"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1672
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1707
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4183
+#: sonar/common/jsonschemas/language-v1.0.0.json:1669
 msgid "lang_mun"
 msgstr "Munda (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1676
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1711
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4187
+#: sonar/common/jsonschemas/language-v1.0.0.json:1673
 msgid "lang_mus"
 msgstr "Creek"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1680
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1715
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4191
+#: sonar/common/jsonschemas/language-v1.0.0.json:1677
 msgid "lang_mwl"
 msgstr "Mirandese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1684
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1719
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4195
+#: sonar/common/jsonschemas/language-v1.0.0.json:1681
 msgid "lang_mwr"
 msgstr "Marwari"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1688
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1723
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4199
+#: sonar/common/jsonschemas/language-v1.0.0.json:1685
 msgid "lang_myn"
 msgstr "Mayan languages"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1692
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1727
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4203
+#: sonar/common/jsonschemas/language-v1.0.0.json:1689
 msgid "lang_myv"
 msgstr "Erzya"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1696
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1731
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4207
+#: sonar/common/jsonschemas/language-v1.0.0.json:1693
 msgid "lang_nah"
 msgstr "Nahuatl"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1700
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1735
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4211
+#: sonar/common/jsonschemas/language-v1.0.0.json:1697
 msgid "lang_nai"
 msgstr "North American Indian (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1704
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1739
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4215
+#: sonar/common/jsonschemas/language-v1.0.0.json:1701
 msgid "lang_nap"
 msgstr "Neapolitan Italian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1708
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1743
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4219
+#: sonar/common/jsonschemas/language-v1.0.0.json:1705
 msgid "lang_nau"
 msgstr "Nauru"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1712
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1747
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4223
+#: sonar/common/jsonschemas/language-v1.0.0.json:1709
 msgid "lang_nav"
 msgstr "Navajo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1716
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1751
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4227
+#: sonar/common/jsonschemas/language-v1.0.0.json:1713
 msgid "lang_nbl"
 msgstr "Ndebele (South Africa)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1720
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1755
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4231
+#: sonar/common/jsonschemas/language-v1.0.0.json:1717
 msgid "lang_nde"
 msgstr "Ndebele (Zimbabwe)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1724
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1759
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4235
+#: sonar/common/jsonschemas/language-v1.0.0.json:1721
 msgid "lang_ndo"
 msgstr "Ndonga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1728
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1763
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4239
+#: sonar/common/jsonschemas/language-v1.0.0.json:1725
 msgid "lang_nds"
 msgstr "Low German"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1732
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1767
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4243
+#: sonar/common/jsonschemas/language-v1.0.0.json:1729
 msgid "lang_nep"
 msgstr "Nepali"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1736
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1771
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4247
+#: sonar/common/jsonschemas/language-v1.0.0.json:1733
 msgid "lang_new"
 msgstr "Newari"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1740
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1775
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4251
+#: sonar/common/jsonschemas/language-v1.0.0.json:1737
 msgid "lang_nia"
 msgstr "Nias"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1744
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1779
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4255
+#: sonar/common/jsonschemas/language-v1.0.0.json:1741
 msgid "lang_nic"
 msgstr "Niger-Kordofanian (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1748
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1783
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4259
+#: sonar/common/jsonschemas/language-v1.0.0.json:1745
 msgid "lang_niu"
 msgstr "Niuean"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1752
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1787
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4263
+#: sonar/common/jsonschemas/language-v1.0.0.json:1749
 msgid "lang_nno"
 msgstr "Norwegian (Nynorsk)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1756
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1791
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4267
+#: sonar/common/jsonschemas/language-v1.0.0.json:1753
 msgid "lang_nob"
 msgstr "Norwegian (Bokmål)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1760
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1795
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4271
+#: sonar/common/jsonschemas/language-v1.0.0.json:1757
 msgid "lang_nog"
 msgstr "Nogai"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1764
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1799
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4275
+#: sonar/common/jsonschemas/language-v1.0.0.json:1761
 msgid "lang_non"
 msgstr "Old Norse"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1768
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1803
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4279
+#: sonar/common/jsonschemas/language-v1.0.0.json:1765
 msgid "lang_nor"
 msgstr "Norwegian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1772
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1807
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4283
+#: sonar/common/jsonschemas/language-v1.0.0.json:1769
 msgid "lang_nqo"
 msgstr "N'Ko"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1776
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1811
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4287
+#: sonar/common/jsonschemas/language-v1.0.0.json:1773
 msgid "lang_nso"
 msgstr "Northern Sotho"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1780
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1815
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4291
+#: sonar/common/jsonschemas/language-v1.0.0.json:1777
 msgid "lang_nub"
 msgstr "Nubian languages"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1784
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1819
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4295
+#: sonar/common/jsonschemas/language-v1.0.0.json:1781
 msgid "lang_nwc"
 msgstr "Newari, Old"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1788
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1823
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4299
+#: sonar/common/jsonschemas/language-v1.0.0.json:1785
 msgid "lang_nya"
 msgstr "Nyanja"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1792
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1827
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4303
+#: sonar/common/jsonschemas/language-v1.0.0.json:1789
 msgid "lang_nym"
 msgstr "Nyamwezi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1796
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1831
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4307
+#: sonar/common/jsonschemas/language-v1.0.0.json:1793
 msgid "lang_nyn"
 msgstr "Nyankole"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1800
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1835
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4311
+#: sonar/common/jsonschemas/language-v1.0.0.json:1797
 msgid "lang_nyo"
 msgstr "Nyoro"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1804
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1839
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4315
+#: sonar/common/jsonschemas/language-v1.0.0.json:1801
 msgid "lang_nzi"
 msgstr "Nzima"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1808
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1843
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4319
+#: sonar/common/jsonschemas/language-v1.0.0.json:1805
 msgid "lang_oci"
 msgstr "Occitan (post-1500)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1812
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1847
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4323
+#: sonar/common/jsonschemas/language-v1.0.0.json:1809
 msgid "lang_oji"
 msgstr "Ojibwa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1816
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1851
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4327
+#: sonar/common/jsonschemas/language-v1.0.0.json:1813
 msgid "lang_ori"
 msgstr "Oriya"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1820
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1855
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4331
+#: sonar/common/jsonschemas/language-v1.0.0.json:1817
 msgid "lang_orm"
 msgstr "Oromo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1824
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1859
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4335
+#: sonar/common/jsonschemas/language-v1.0.0.json:1821
 msgid "lang_osa"
 msgstr "Osage"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1828
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1863
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4339
+#: sonar/common/jsonschemas/language-v1.0.0.json:1825
 msgid "lang_oss"
 msgstr "Ossetic"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1832
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1867
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4343
+#: sonar/common/jsonschemas/language-v1.0.0.json:1829
 msgid "lang_ota"
 msgstr "Turkish, Ottoman"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1836
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1871
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4347
+#: sonar/common/jsonschemas/language-v1.0.0.json:1833
 msgid "lang_oto"
 msgstr "Otomian languages"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1840
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1875
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4351
+#: sonar/common/jsonschemas/language-v1.0.0.json:1837
 msgid "lang_paa"
 msgstr "Papuan (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1844
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1879
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4355
+#: sonar/common/jsonschemas/language-v1.0.0.json:1841
 msgid "lang_pag"
 msgstr "Pangasinan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1848
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1883
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4359
+#: sonar/common/jsonschemas/language-v1.0.0.json:1845
 msgid "lang_pal"
 msgstr "Pahlavi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1852
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1887
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4363
+#: sonar/common/jsonschemas/language-v1.0.0.json:1849
 msgid "lang_pam"
 msgstr "Pampanga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1856
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1891
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4367
+#: sonar/common/jsonschemas/language-v1.0.0.json:1853
 msgid "lang_pan"
 msgstr "Panjabi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1860
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1895
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4371
+#: sonar/common/jsonschemas/language-v1.0.0.json:1857
 msgid "lang_pap"
 msgstr "Papiamento"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1864
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1899
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4375
+#: sonar/common/jsonschemas/language-v1.0.0.json:1861
 msgid "lang_pau"
 msgstr "paluan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1868
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1903
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4379
+#: sonar/common/jsonschemas/language-v1.0.0.json:1865
 msgid "lang_peo"
 msgstr "Old Persian (ca. 600-400 B.C.)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1872
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1907
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4383
+#: sonar/common/jsonschemas/language-v1.0.0.json:1869
 msgid "lang_per"
 msgstr "Persian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1876
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1911
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4387
+#: sonar/common/jsonschemas/language-v1.0.0.json:1873
 msgid "lang_phi"
 msgstr "Philippine (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1880
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1915
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4391
+#: sonar/common/jsonschemas/language-v1.0.0.json:1877
 msgid "lang_phn"
 msgstr "Phoenician"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1884
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1919
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4395
+#: sonar/common/jsonschemas/language-v1.0.0.json:1881
 msgid "lang_pli"
 msgstr "Pali"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1888
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1923
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4399
+#: sonar/common/jsonschemas/language-v1.0.0.json:1885
 msgid "lang_pol"
 msgstr "Polish"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1892
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1927
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4403
+#: sonar/common/jsonschemas/language-v1.0.0.json:1889
 msgid "lang_pon"
 msgstr "Pohnpeian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1896
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1931
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4407
+#: sonar/common/jsonschemas/language-v1.0.0.json:1893
 msgid "lang_por"
 msgstr "Portuguese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1900
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1935
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4411
+#: sonar/common/jsonschemas/language-v1.0.0.json:1897
 msgid "lang_pra"
 msgstr "Prakrit languages"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1904
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1939
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4415
+#: sonar/common/jsonschemas/language-v1.0.0.json:1901
 msgid "lang_pro"
 msgstr "Provençal (to 1500)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1908
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1943
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4419
+#: sonar/common/jsonschemas/language-v1.0.0.json:1905
 msgid "lang_pus"
 msgstr "Pushto"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1912
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1947
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4423
+#: sonar/common/jsonschemas/language-v1.0.0.json:1909
 msgid "lang_que"
 msgstr "Quechua"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1916
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1951
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4427
+#: sonar/common/jsonschemas/language-v1.0.0.json:1913
 msgid "lang_raj"
 msgstr "Rajasthani"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1920
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1955
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4431
+#: sonar/common/jsonschemas/language-v1.0.0.json:1917
 msgid "lang_rap"
 msgstr "Rapanui"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1924
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1959
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4435
+#: sonar/common/jsonschemas/language-v1.0.0.json:1921
 msgid "lang_rar"
 msgstr "Rarotongan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1928
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1963
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4439
+#: sonar/common/jsonschemas/language-v1.0.0.json:1925
 msgid "lang_roa"
 msgstr "Romance (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1932
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1967
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4443
+#: sonar/common/jsonschemas/language-v1.0.0.json:1929
 msgid "lang_roh"
 msgstr "Raeto-Romance"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1936
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1971
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4447
+#: sonar/common/jsonschemas/language-v1.0.0.json:1933
 msgid "lang_rom"
 msgstr "Romani"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1940
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1975
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4451
+#: sonar/common/jsonschemas/language-v1.0.0.json:1937
 msgid "lang_rum"
 msgstr "Romanian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1944
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1979
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4455
+#: sonar/common/jsonschemas/language-v1.0.0.json:1941
 msgid "lang_run"
 msgstr "Rundi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1948
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1983
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4459
+#: sonar/common/jsonschemas/language-v1.0.0.json:1945
 msgid "lang_rup"
 msgstr "Aromanian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1952
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1987
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4463
+#: sonar/common/jsonschemas/language-v1.0.0.json:1949
 msgid "lang_rus"
 msgstr "Russian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1956
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1991
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4467
+#: sonar/common/jsonschemas/language-v1.0.0.json:1953
 msgid "lang_sad"
 msgstr "Sandawe"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1960
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1995
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4471
+#: sonar/common/jsonschemas/language-v1.0.0.json:1957
 msgid "lang_sag"
 msgstr "Sango (Ubangi Creole)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1964
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1999
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4475
+#: sonar/common/jsonschemas/language-v1.0.0.json:1961
 msgid "lang_sah"
 msgstr "Yakut"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1968
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2003
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4479
+#: sonar/common/jsonschemas/language-v1.0.0.json:1965
 msgid "lang_sai"
 msgstr "South American Indian (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1972
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2007
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4483
+#: sonar/common/jsonschemas/language-v1.0.0.json:1969
 msgid "lang_sal"
 msgstr "Salishan languages"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1976
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2011
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4487
+#: sonar/common/jsonschemas/language-v1.0.0.json:1973
 msgid "lang_sam"
 msgstr "Samaritan Aramaic"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1980
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2015
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4491
+#: sonar/common/jsonschemas/language-v1.0.0.json:1977
 msgid "lang_san"
 msgstr "Sanskrit"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1984
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2019
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4495
+#: sonar/common/jsonschemas/language-v1.0.0.json:1981
 msgid "lang_sas"
 msgstr "Sasak"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1988
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2023
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4499
+#: sonar/common/jsonschemas/language-v1.0.0.json:1985
 msgid "lang_sat"
 msgstr "Santali"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1992
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2027
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4503
+#: sonar/common/jsonschemas/language-v1.0.0.json:1989
 msgid "lang_scn"
 msgstr "Sicilian Italian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1996
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2031
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4507
+#: sonar/common/jsonschemas/language-v1.0.0.json:1993
 msgid "lang_sco"
 msgstr "Scots"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2000
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2035
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4511
+#: sonar/common/jsonschemas/language-v1.0.0.json:1997
 msgid "lang_sel"
 msgstr "Selkup"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2004
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2039
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4515
+#: sonar/common/jsonschemas/language-v1.0.0.json:2001
 msgid "lang_sem"
 msgstr "Semitic (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2008
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2043
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4519
+#: sonar/common/jsonschemas/language-v1.0.0.json:2005
 msgid "lang_sga"
 msgstr "Irish, Old (to 1100)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2012
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2047
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4523
+#: sonar/common/jsonschemas/language-v1.0.0.json:2009
 msgid "lang_sgn"
 msgstr "Sign languages"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2016
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2051
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4527
+#: sonar/common/jsonschemas/language-v1.0.0.json:2013
 msgid "lang_shn"
 msgstr "Shan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2020
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2055
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4531
+#: sonar/common/jsonschemas/language-v1.0.0.json:2017
 msgid "lang_sid"
 msgstr "Sidamo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2024
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2059
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4535
+#: sonar/common/jsonschemas/language-v1.0.0.json:2021
 msgid "lang_sin"
 msgstr "Sinhalese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2028
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2063
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4539
+#: sonar/common/jsonschemas/language-v1.0.0.json:2025
 msgid "lang_sio"
 msgstr "Siouan (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2032
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2067
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4543
+#: sonar/common/jsonschemas/language-v1.0.0.json:2029
 msgid "lang_sit"
 msgstr "Sino-Tibetan (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2036
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2071
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4547
+#: sonar/common/jsonschemas/language-v1.0.0.json:2033
 msgid "lang_sla"
 msgstr "Slavic (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2040
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2075
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4551
+#: sonar/common/jsonschemas/language-v1.0.0.json:2037
 msgid "lang_slo"
 msgstr "Slovak"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2044
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2079
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4555
+#: sonar/common/jsonschemas/language-v1.0.0.json:2041
 msgid "lang_slv"
 msgstr "Slovenian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2048
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2083
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4559
+#: sonar/common/jsonschemas/language-v1.0.0.json:2045
 msgid "lang_sma"
 msgstr "Southern Sami"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2052
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2087
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4563
+#: sonar/common/jsonschemas/language-v1.0.0.json:2049
 msgid "lang_sme"
 msgstr "Northern Sami"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2056
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2091
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4567
+#: sonar/common/jsonschemas/language-v1.0.0.json:2053
 msgid "lang_smi"
 msgstr "Sami"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2060
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2095
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4571
+#: sonar/common/jsonschemas/language-v1.0.0.json:2057
 msgid "lang_smj"
 msgstr "Lule Sami"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2064
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2099
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4575
+#: sonar/common/jsonschemas/language-v1.0.0.json:2061
 msgid "lang_smn"
 msgstr "Inari Sami"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2068
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2103
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4579
+#: sonar/common/jsonschemas/language-v1.0.0.json:2065
 msgid "lang_smo"
 msgstr "Samoan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2072
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2107
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4583
+#: sonar/common/jsonschemas/language-v1.0.0.json:2069
 msgid "lang_sms"
 msgstr "Skolt Sami"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2076
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2111
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4587
+#: sonar/common/jsonschemas/language-v1.0.0.json:2073
 msgid "lang_sna"
 msgstr "Shona"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2080
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2115
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4591
+#: sonar/common/jsonschemas/language-v1.0.0.json:2077
 msgid "lang_snd"
 msgstr "Sindhi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2084
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2119
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4595
+#: sonar/common/jsonschemas/language-v1.0.0.json:2081
 msgid "lang_snk"
 msgstr "Soninke"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2088
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2123
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4599
+#: sonar/common/jsonschemas/language-v1.0.0.json:2085
 msgid "lang_sog"
 msgstr "Sogdian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2092
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2127
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4603
+#: sonar/common/jsonschemas/language-v1.0.0.json:2089
 msgid "lang_som"
 msgstr "Somali"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2096
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2131
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4607
+#: sonar/common/jsonschemas/language-v1.0.0.json:2093
 msgid "lang_son"
 msgstr "Songhai"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2100
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2135
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4611
+#: sonar/common/jsonschemas/language-v1.0.0.json:2097
 msgid "lang_sot"
 msgstr "Sotho"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2104
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2139
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4615
+#: sonar/common/jsonschemas/language-v1.0.0.json:2101
 msgid "lang_spa"
 msgstr "Spanish"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2108
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2143
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4619
+#: sonar/common/jsonschemas/language-v1.0.0.json:2105
 msgid "lang_srd"
 msgstr "Sardinian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2112
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2147
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4623
+#: sonar/common/jsonschemas/language-v1.0.0.json:2109
 msgid "lang_srn"
 msgstr "Sranan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2116
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2151
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4627
+#: sonar/common/jsonschemas/language-v1.0.0.json:2113
 msgid "lang_srp"
 msgstr "Serbian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2120
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2155
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4631
+#: sonar/common/jsonschemas/language-v1.0.0.json:2117
 msgid "lang_srr"
 msgstr "Serer"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2124
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2159
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4635
+#: sonar/common/jsonschemas/language-v1.0.0.json:2121
 msgid "lang_ssa"
 msgstr "Nilo-Saharan (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2128
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2163
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4639
+#: sonar/common/jsonschemas/language-v1.0.0.json:2125
 msgid "lang_ssw"
 msgstr "Swazi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2132
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2167
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4643
+#: sonar/common/jsonschemas/language-v1.0.0.json:2129
 msgid "lang_suk"
 msgstr "Sukuma"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2136
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2171
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4647
+#: sonar/common/jsonschemas/language-v1.0.0.json:2133
 msgid "lang_sun"
 msgstr "Sundanese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2140
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2175
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4651
+#: sonar/common/jsonschemas/language-v1.0.0.json:2137
 msgid "lang_sus"
 msgstr "Susu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2144
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2179
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4655
+#: sonar/common/jsonschemas/language-v1.0.0.json:2141
 msgid "lang_sux"
 msgstr "Sumerian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2148
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2183
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4659
+#: sonar/common/jsonschemas/language-v1.0.0.json:2145
 msgid "lang_swa"
 msgstr "Swahili"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2152
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2187
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4663
+#: sonar/common/jsonschemas/language-v1.0.0.json:2149
 msgid "lang_swe"
 msgstr "Swedish"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2156
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2191
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4667
+#: sonar/common/jsonschemas/language-v1.0.0.json:2153
 msgid "lang_syc"
 msgstr "Syriac"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2160
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2195
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4671
+#: sonar/common/jsonschemas/language-v1.0.0.json:2157
 msgid "lang_syr"
 msgstr "Syriac, Modern"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2164
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2199
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4675
+#: sonar/common/jsonschemas/language-v1.0.0.json:2161
 msgid "lang_tah"
 msgstr "Tahitian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2168
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2203
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4679
+#: sonar/common/jsonschemas/language-v1.0.0.json:2165
 msgid "lang_tai"
 msgstr "Tai (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2172
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2207
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4683
+#: sonar/common/jsonschemas/language-v1.0.0.json:2169
 msgid "lang_tam"
 msgstr "Tamil"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2176
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2211
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4687
+#: sonar/common/jsonschemas/language-v1.0.0.json:2173
 msgid "lang_tat"
 msgstr "Tatar"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2180
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2215
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4691
+#: sonar/common/jsonschemas/language-v1.0.0.json:2177
 msgid "lang_tel"
 msgstr "Telugu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2184
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2219
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4695
+#: sonar/common/jsonschemas/language-v1.0.0.json:2181
 msgid "lang_tem"
 msgstr "Temne"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2188
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2223
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4699
+#: sonar/common/jsonschemas/language-v1.0.0.json:2185
 msgid "lang_ter"
 msgstr "Terena"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2192
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2227
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4703
+#: sonar/common/jsonschemas/language-v1.0.0.json:2189
 msgid "lang_tet"
 msgstr "Tetum"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2196
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2231
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4707
+#: sonar/common/jsonschemas/language-v1.0.0.json:2193
 msgid "lang_tgk"
 msgstr "Tajik"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2200
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2235
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4711
+#: sonar/common/jsonschemas/language-v1.0.0.json:2197
 msgid "lang_tgl"
 msgstr "Tagalog"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2204
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2239
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4715
+#: sonar/common/jsonschemas/language-v1.0.0.json:2201
 msgid "lang_tha"
 msgstr "Thai"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2208
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2243
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4719
+#: sonar/common/jsonschemas/language-v1.0.0.json:2205
 msgid "lang_tib"
 msgstr "Tibetan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2212
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2247
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4723
+#: sonar/common/jsonschemas/language-v1.0.0.json:2209
 msgid "lang_tig"
 msgstr "Tigré"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2216
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2251
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4727
+#: sonar/common/jsonschemas/language-v1.0.0.json:2213
 msgid "lang_tir"
 msgstr "Tigrinya"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2220
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2255
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4731
+#: sonar/common/jsonschemas/language-v1.0.0.json:2217
 msgid "lang_tiv"
 msgstr "Tiv"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2224
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2259
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4735
+#: sonar/common/jsonschemas/language-v1.0.0.json:2221
 msgid "lang_tkl"
 msgstr "Tokelauan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2228
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2263
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4739
+#: sonar/common/jsonschemas/language-v1.0.0.json:2225
 msgid "lang_tlh"
 msgstr "Klingon (Artificial language)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2232
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2267
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4743
+#: sonar/common/jsonschemas/language-v1.0.0.json:2229
 msgid "lang_tli"
 msgstr "Tlingit"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2236
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2271
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4747
+#: sonar/common/jsonschemas/language-v1.0.0.json:2233
 msgid "lang_tmh"
 msgstr "Tamashek"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2240
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2275
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4751
+#: sonar/common/jsonschemas/language-v1.0.0.json:2237
 msgid "lang_tog"
 msgstr "Tonga (Nyasa)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2244
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2279
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4755
+#: sonar/common/jsonschemas/language-v1.0.0.json:2241
 msgid "lang_ton"
 msgstr "Tongan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2248
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2283
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4759
+#: sonar/common/jsonschemas/language-v1.0.0.json:2245
 msgid "lang_tpi"
 msgstr "Tok Pisin"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2252
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2287
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4763
+#: sonar/common/jsonschemas/language-v1.0.0.json:2249
 msgid "lang_tsi"
 msgstr "Tsimshian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2256
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2291
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4767
+#: sonar/common/jsonschemas/language-v1.0.0.json:2253
 msgid "lang_tsn"
 msgstr "Tswana"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2260
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2295
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4771
+#: sonar/common/jsonschemas/language-v1.0.0.json:2257
 msgid "lang_tso"
 msgstr "Tsonga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2264
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2299
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4775
+#: sonar/common/jsonschemas/language-v1.0.0.json:2261
 msgid "lang_tuk"
 msgstr "Turkmen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2268
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2303
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4779
+#: sonar/common/jsonschemas/language-v1.0.0.json:2265
 msgid "lang_tum"
 msgstr "Tumbuka"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2272
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2307
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4783
+#: sonar/common/jsonschemas/language-v1.0.0.json:2269
 msgid "lang_tup"
 msgstr "Tupi languages"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2276
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2311
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4787
+#: sonar/common/jsonschemas/language-v1.0.0.json:2273
 msgid "lang_tur"
 msgstr "Turkish"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2280
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2315
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4791
+#: sonar/common/jsonschemas/language-v1.0.0.json:2277
 msgid "lang_tut"
 msgstr "Altaic (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2284
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2319
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4795
+#: sonar/common/jsonschemas/language-v1.0.0.json:2281
 msgid "lang_tvl"
 msgstr "Tuvaluan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2288
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2323
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4799
+#: sonar/common/jsonschemas/language-v1.0.0.json:2285
 msgid "lang_twi"
 msgstr "Twi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2292
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2327
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4803
+#: sonar/common/jsonschemas/language-v1.0.0.json:2289
 msgid "lang_tyv"
 msgstr "Tuvinian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2296
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2331
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4807
+#: sonar/common/jsonschemas/language-v1.0.0.json:2293
 msgid "lang_udm"
 msgstr "Udmurt"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2300
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2335
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4811
+#: sonar/common/jsonschemas/language-v1.0.0.json:2297
 msgid "lang_uga"
 msgstr "Ugaritic"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2304
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2339
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4815
+#: sonar/common/jsonschemas/language-v1.0.0.json:2301
 msgid "lang_uig"
 msgstr "Uighur"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2308
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2343
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4819
+#: sonar/common/jsonschemas/language-v1.0.0.json:2305
 msgid "lang_ukr"
 msgstr "Ukrainian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2312
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2347
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4823
+#: sonar/common/jsonschemas/language-v1.0.0.json:2309
 msgid "lang_umb"
 msgstr "Umbundu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2316
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2351
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4827
+#: sonar/common/jsonschemas/language-v1.0.0.json:2313
 msgid "lang_und"
 msgstr "Undetermined"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2320
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2355
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4831
+#: sonar/common/jsonschemas/language-v1.0.0.json:2317
 msgid "lang_urd"
 msgstr "Urdu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2324
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2359
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4835
+#: sonar/common/jsonschemas/language-v1.0.0.json:2321
 msgid "lang_uzb"
 msgstr "Uzbek"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2328
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2363
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4839
+#: sonar/common/jsonschemas/language-v1.0.0.json:2325
 msgid "lang_vai"
 msgstr "Vai"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2332
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2367
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4843
+#: sonar/common/jsonschemas/language-v1.0.0.json:2329
 msgid "lang_ven"
 msgstr "Venda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2336
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2371
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4847
+#: sonar/common/jsonschemas/language-v1.0.0.json:2333
 msgid "lang_vie"
 msgstr "Vietnamese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2340
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2375
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4851
+#: sonar/common/jsonschemas/language-v1.0.0.json:2337
 msgid "lang_vol"
 msgstr "Volapük"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2344
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2379
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4855
+#: sonar/common/jsonschemas/language-v1.0.0.json:2341
 msgid "lang_vot"
 msgstr "Votic"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2348
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2383
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4859
+#: sonar/common/jsonschemas/language-v1.0.0.json:2345
 msgid "lang_wak"
 msgstr "Wakashan languages"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2352
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2387
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4863
+#: sonar/common/jsonschemas/language-v1.0.0.json:2349
 msgid "lang_wal"
 msgstr "Wolayta"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2356
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2391
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4867
+#: sonar/common/jsonschemas/language-v1.0.0.json:2353
 msgid "lang_war"
 msgstr "Waray"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2360
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2395
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4871
+#: sonar/common/jsonschemas/language-v1.0.0.json:2357
 msgid "lang_was"
 msgstr "Washoe"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2364
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2399
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4875
+#: sonar/common/jsonschemas/language-v1.0.0.json:2361
 msgid "lang_wel"
 msgstr "Welsh"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2368
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2403
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4879
+#: sonar/common/jsonschemas/language-v1.0.0.json:2365
 msgid "lang_wen"
 msgstr "Sorbian (Other)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2372
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2407
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4883
+#: sonar/common/jsonschemas/language-v1.0.0.json:2369
 msgid "lang_wln"
 msgstr "Walloon"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2376
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2411
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4887
+#: sonar/common/jsonschemas/language-v1.0.0.json:2373
 msgid "lang_wol"
 msgstr "Wolof"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2380
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2415
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4891
+#: sonar/common/jsonschemas/language-v1.0.0.json:2377
 msgid "lang_xal"
 msgstr "Oirat"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2384
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2419
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4895
+#: sonar/common/jsonschemas/language-v1.0.0.json:2381
 msgid "lang_xho"
 msgstr "Xhosa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2388
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2423
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4899
+#: sonar/common/jsonschemas/language-v1.0.0.json:2385
 msgid "lang_yao"
 msgstr "Yao (Africa)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2392
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2427
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4903
+#: sonar/common/jsonschemas/language-v1.0.0.json:2389
 msgid "lang_yap"
 msgstr "Yapese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2396
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2431
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4907
+#: sonar/common/jsonschemas/language-v1.0.0.json:2393
 msgid "lang_yid"
 msgstr "Yiddish"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2400
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2435
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4911
+#: sonar/common/jsonschemas/language-v1.0.0.json:2397
 msgid "lang_yor"
 msgstr "Yoruba"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2404
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2439
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4915
+#: sonar/common/jsonschemas/language-v1.0.0.json:2401
 msgid "lang_ypk"
 msgstr "Yupik languages"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2408
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2443
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4919
+#: sonar/common/jsonschemas/language-v1.0.0.json:2405
 msgid "lang_zap"
 msgstr "Zapotec"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2412
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2447
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4923
+#: sonar/common/jsonschemas/language-v1.0.0.json:2409
 msgid "lang_zbl"
 msgstr "Blissymbolics"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2416
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2451
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4927
+#: sonar/common/jsonschemas/language-v1.0.0.json:2413
 msgid "lang_zen"
 msgstr "Zenaga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2420
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2455
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4931
+#: sonar/common/jsonschemas/language-v1.0.0.json:2417
 msgid "lang_zha"
 msgstr "Zhuang"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2424
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2459
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4935
+#: sonar/common/jsonschemas/language-v1.0.0.json:2421
 msgid "lang_znd"
 msgstr "Zande languages"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2428
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2463
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4939
+#: sonar/common/jsonschemas/language-v1.0.0.json:2425
 msgid "lang_zul"
 msgstr "Zulu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2432
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2467
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4943
+#: sonar/common/jsonschemas/language-v1.0.0.json:2429
 msgid "lang_zun"
 msgstr "Zuni"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2436
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2471
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4947
+#: sonar/common/jsonschemas/language-v1.0.0.json:2433
 msgid "lang_zxx"
 msgstr "No linguistic content"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2440
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2475
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4951
+#: sonar/common/jsonschemas/language-v1.0.0.json:2437
 msgid "lang_zza"
 msgstr "Zaza"
 
@@ -5730,12 +4835,11 @@ msgstr "Zaza"
 msgid "mainTeam"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:923
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1743
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1034
 msgid "name"
 msgstr "name"
 
-#: sonar/modules/documents/views.py:172
+#: sonar/modules/documents/views.py:178
 msgid "no."
 msgstr "no."
 
@@ -5743,11 +4847,11 @@ msgstr "no."
 msgid "other files"
 msgstr "other files"
 
-#: sonar/modules/documents/views.py:176
+#: sonar/modules/documents/views.py:182
 msgid "p."
 msgstr "p."
 
-#: sonar/config.py:546
+#: sonar/config.py:570
 msgid "pid"
 msgstr "pid"
 
@@ -5811,7 +4915,7 @@ msgstr ""
 msgid "startDate"
 msgstr ""
 
-#: sonar/config.py:547
+#: sonar/config.py:571
 msgid "status"
 msgstr "status"
 
@@ -5825,15 +4929,55 @@ msgstr "supported by"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:489
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:808
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1615
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1627
 msgid "uri"
 msgstr "URI"
 
-#: sonar/config.py:548
+#: sonar/config.py:572
 msgid "user"
 msgstr "user"
 
-#: sonar/modules/documents/views.py:168
+#: sonar/translations/manual_translations.txt:59
+msgid "validation_action_approve"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:61
+msgid "validation_action_ask_for_changes"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:58
+msgid "validation_action_publish"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:60
+msgid "validation_action_reject"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:57
+msgid "validation_action_save"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:54
+msgid "validation_status_ask_for_changes"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:50
+msgid "validation_status_in_progress"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:53
+msgid "validation_status_rejected"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:51
+msgid "validation_status_to_validate"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:52
+msgid "validation_status_validated"
+msgstr ""
+
+#: sonar/modules/documents/views.py:174
 msgid "vol."
 msgstr "vol."
 
@@ -5900,4 +5044,19 @@ msgstr ""
 
 #~ msgid "\\u200bSwiss National Science Foundation"
 #~ msgstr ""
+
+#~ msgid "Editors"
+#~ msgstr "Editors"
+
+#~ msgid "In the format \\"
+#~ msgstr "In the format \"Last name, first name\""
+
+#~ msgid "Not OA / Rights reserved"
+#~ msgstr "Not OA / Rights reserved"
+
+#~ msgid "Other OA / license undefined"
+#~ msgstr "Other OA / license undefined"
+
+#~ msgid "Specific collections"
+#~ msgstr "Specific collections"
 

--- a/sonar/translations/eo/LC_MESSAGES/messages.po
+++ b/sonar/translations/eo/LC_MESSAGES/messages.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 1.0.0\n"
 "Report-Msgid-Bugs-To: nicolas.prongue@rero.ch\n"
-"POT-Creation-Date: 2021-06-01 15:56+0200\n"
-"PO-Revision-Date: 2021-04-05 02:27+0000\n"
-"Last-Translator: phlostically <phlostically@mailinator.com>\n"
+"POT-Creation-Date: 2021-06-14 13:34+0200\n"
+"PO-Revision-Date: 2021-06-11 07:32+0000\n"
+"Last-Translator: Nicolas Prongué <n.prongue@outlook.com>\n"
 "Language: eo\n"
 "Language-Team: Esperanto "
 "<https://hosted.weblate.org/projects/rero_plus/sonar/eo/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.1\n"
 
-#: sonar/theme/views.py:65
+#: sonar/theme/views.py:67
 #, python-format
 msgid "%(icon)s Profile"
 msgstr "%(icon)s Mia konto"
@@ -32,13 +32,13 @@ msgstr ""
 msgid "About SONAR"
 msgstr "Pri SONAR"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:681
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:697
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:795
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:811
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:663
 msgid "Abstract"
 msgstr "Resumo"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:678
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:792
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:659
 msgid "Abstracts"
 msgstr "Resumoj"
@@ -56,10 +56,11 @@ msgid "Accompanying material of the resource, i.e. maps."
 msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:844
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1651
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1663
 msgid "Acquisition terms"
 msgstr "Kondiĉoj de akiro"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:77
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:210
 msgid "Action"
 msgstr "Ago"
@@ -72,7 +73,11 @@ msgstr ""
 msgid "Actor involved"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:933
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:704
+msgid "Add a new collection"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1044
 msgid "Add a new project"
 msgstr "Aldoni novan projekton"
 
@@ -85,14 +90,13 @@ msgstr "Pliaj materialoj"
 msgid "Administration"
 msgstr "Administro"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:834
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1009
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1367
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:948
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1383
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:203
 msgid "Affiliation"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1180
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1196
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:159
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:250
 msgid "Agent"
@@ -128,9 +132,13 @@ msgid ""
 "underscores."
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1484
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1496
 msgid "Author or editor"
 msgstr "Aŭtoro aŭ redaktoro"
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:612
+msgid "Authors / Editors"
+msgstr ""
 
 #: sonar/modules/documents/templates/documents/record.html:44
 #: sonar/theme/templates/sonar/projects/detail.html:15
@@ -141,7 +149,7 @@ msgstr "Reen"
 msgid "Back to SONAR"
 msgstr "Reen al SONAR"
 
-#: sonar/config.py:584
+#: sonar/config.py:608
 msgid "Best match"
 msgstr ""
 
@@ -157,12 +165,12 @@ msgstr ""
 msgid "Brief description of the report"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1788
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:30
 msgid "Bronze"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4993
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5008
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:110
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:125
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:20
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:34
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:15
@@ -180,35 +188,35 @@ msgstr "UUID de sitelo enhavanta dosierojn"
 msgid "CAS or DAS"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:27
+#: sonar/common/jsonschemas/license-v1.0.0.json:28
 msgid "CC BY"
 msgstr "CC BY"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:31
+#: sonar/common/jsonschemas/license-v1.0.0.json:32
 msgid "CC BY-NC"
 msgstr "CC BY-NC"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:35
+#: sonar/common/jsonschemas/license-v1.0.0.json:36
 msgid "CC BY-NC-ND"
 msgstr "CC BY-NC-ND"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:39
+#: sonar/common/jsonschemas/license-v1.0.0.json:40
 msgid "CC BY-NC-SA"
 msgstr "CC BY-NC-SA"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:43
+#: sonar/common/jsonschemas/license-v1.0.0.json:44
 msgid "CC BY-ND"
 msgstr "CC BY-ND"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:47
+#: sonar/common/jsonschemas/license-v1.0.0.json:48
 msgid "CC BY-SA"
 msgstr "CC BY-SA"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:23
+#: sonar/common/jsonschemas/license-v1.0.0.json:24
 msgid "CC0"
 msgstr "CC0"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5033
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:150
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:59
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:58
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:266
@@ -220,16 +228,16 @@ msgid "City"
 msgstr "Urbo"
 
 #: sonar/common/jsonschemas/classification-v1.0.0.json:2
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1015
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1031
 #: sonar/modules/documents/templates/documents/record.html:262
 msgid "Classification"
 msgstr "Klasifiko"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1066
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1082
 msgid "Classification portion"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1011
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1027
 msgid "Classifications"
 msgstr "Klasifikoj"
 
@@ -241,7 +249,7 @@ msgstr ""
 msgid "Click here to reset your password"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1792
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:34
 msgid "Closed"
 msgstr ""
 
@@ -249,18 +257,27 @@ msgstr ""
 msgid "Code"
 msgstr "Kodo"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:999
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:680
 msgid "Collection"
 msgstr "Kolekto"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:4
+#: sonar/modules/collections/templates/collections/index.html:21
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:676
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:995
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:999
+#: sonar/modules/documents/templates/documents/record.html:288
 msgid "Collections"
 msgstr "Kolektoj"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:106
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:245
 msgid "Comment"
 msgstr "Komento"
+
+#: sonar/common/jsonschemas/validation-v1.0.0.json:107
+msgid "Comment associated with the current action."
+msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:513
 msgid "Company"
@@ -278,37 +295,41 @@ msgstr "Konfirmu retpoŝtan adreson"
 msgid "Contact"
 msgstr "Kontakto"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1094
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:540
+msgid "Contained in (journal, book, proceedings)"
+msgstr ""
+
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1110
 msgid "Content note"
 msgstr "Noto pri enhavo"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1090
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1106
 msgid "Content notes"
 msgstr "Notoj pri enhavo"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1175
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1480
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1191
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1492
 msgid "Contribution"
 msgstr "Kontribuo"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1171
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1187
 msgid "Contributions"
 msgstr "Kontribuoj"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:814
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:928
 msgid "Contributor"
 msgstr "Kontribuinto"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:808
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:922
 msgid "Contributors"
 msgstr "Kontribuintoj"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1379
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1395
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:212
 msgid "Controlled affiliation"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1375
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1391
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:208
 msgid "Controlled affiliations"
 msgstr ""
@@ -318,27 +339,36 @@ msgstr ""
 msgid "Creativity, transformations and innovations in education"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:78
+msgid "Current action done in the validation process."
+msgstr ""
+
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:173
 msgid "Current cataloguing step."
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1799
+#: sonar/common/jsonschemas/validation-v1.0.0.json:65
+msgid "Current status of the record in the validation process."
+msgstr ""
+
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1774
 msgid "Custom field 1"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1819
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1794
 msgid "Custom field 2"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1839
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1814
 msgid "Custom field 3"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:42
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:240
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:777
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:891
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:496
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1123
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1295
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1139
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1311
 msgid "Date"
 msgstr "Dato"
 
@@ -350,14 +380,18 @@ msgstr "Dato laŭ la aranĝo jjjj-mm-tt, ekz. 1970-07-21"
 msgid "Date of approval by the Team Leader"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1271
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1287
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:34
 msgid "Date of birth"
 msgstr "Dato de nasko"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1279
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1295
 msgid "Date of death"
 msgstr "Dato de morto"
+
+#: sonar/common/jsonschemas/validation-v1.0.0.json:43
+msgid "Date when the log is created."
+msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:640
 msgid "Dean of a school"
@@ -368,8 +402,8 @@ msgstr ""
 msgid "Dear %(email)s"
 msgstr "Kara %(email)s"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:762
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1108
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:876
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1124
 msgid "Degree"
 msgstr ""
 
@@ -385,20 +419,22 @@ msgstr ""
 msgid "Deposit to validate"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5003
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:120
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:30
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:236
 msgid "Describes the information of a single file in the record."
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2497
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:941
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:56
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:740
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1052
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:38
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:55
 msgid "Description"
 msgstr "Priskribo"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2493
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:52
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:736
 msgid "Descriptions"
 msgstr ""
 
@@ -414,8 +450,8 @@ msgstr ""
 msgid "Director, head of establishment"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:757
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1103
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:871
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1119
 msgid "Dissertation"
 msgstr "Disertacio"
 
@@ -431,12 +467,12 @@ msgstr ""
 msgid "Doctorate supported by the HEP-VS"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:558
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1117
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:556
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1124
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:3
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:958
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1411
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1445
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1423
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1457
 msgid "Document"
 msgstr "Dokumento"
 
@@ -444,7 +480,7 @@ msgstr "Dokumento"
 msgid "Document ID"
 msgstr "Identigilo de dokumento"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1118
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1125
 msgid "Document created on basis of this deposit."
 msgstr ""
 
@@ -480,10 +516,6 @@ msgstr "Retpoŝta adreso"
 msgid "Edition"
 msgstr "Eldono"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:596
-msgid "Editors"
-msgstr "Redaktoroj"
-
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:211
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:273
 msgid "Education, childhood and the learning Society 21"
@@ -512,7 +544,7 @@ msgid "Emotions, learning, and well-being at school"
 msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:80
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:959
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1075
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:79
 msgid "End date"
 msgstr "Fina dato"
@@ -538,8 +570,15 @@ msgid ""
 "password."
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:886
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1020
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:569
+msgid "Example: 1"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:586
+msgid "Example: 10"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1000
 msgid "Example: 1111-2222-3333-4444"
 msgstr "Ekzemple: 1111-2222-3333-4444"
 
@@ -548,13 +587,11 @@ msgstr "Ekzemple: 1111-2222-3333-4444"
 msgid "Example: 2019 or 2019-01-01"
 msgstr "Ekzemple: 2019 aŭ 2019-01-01"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:782
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1127
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:896
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1143
 msgid "Example: 2019 or 2019-05-05"
 msgstr "Ekzemple: 2019 aŭ 2019-05-05"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:953
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:960
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:153
 msgid "Example: 2019-05-05"
 msgstr "Ekzemple: 2019-05-05"
@@ -565,6 +602,8 @@ msgstr "Ekzemple: 2020"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:75
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:88
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1070
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1082
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:74
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:87
 msgid "Example: 2020-12-01"
@@ -578,17 +617,17 @@ msgstr "Ekzemple: Doe"
 msgid "Example: John"
 msgstr "Ekzemple: Johano"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1488
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1500
 msgid "Example: Muller, Hans"
 msgstr "Ekzemple: Zamenhof, Ludoviko"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:638
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:655
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:977
 msgid "Example: Published version"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:591
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1441
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:602
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1453
 msgid "Examples: 135, 5-27, …"
 msgstr "Ekzemploj: 135, 5-27, …"
 
@@ -596,7 +635,11 @@ msgstr "Ekzemploj: 135, 5-27, …"
 msgid "Except within organisation"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:913
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:685
+msgid "Existing collection"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1024
 msgid "Existing project"
 msgstr "Ekzistanta projekto"
 
@@ -624,20 +667,20 @@ msgstr ""
 msgid "External partners are involved"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5013
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:130
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:39
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:35
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:246
 msgid "File UUID"
 msgstr "UUID de dosiero"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5002
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:119
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:29
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:235
 msgid "File item"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4998
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:115
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:25
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:21
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:231
@@ -686,7 +729,7 @@ msgstr ""
 msgid "Formats"
 msgstr ""
 
-#: sonar/config.py:72
+#: sonar/config.py:74
 msgid "French"
 msgstr "Franca"
 
@@ -707,12 +750,10 @@ msgstr ""
 msgid "Funding number"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1048
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:245
 msgid "Funding organisation"
 msgstr "Financa organizaĵo"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1045
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:241
 #: sonar/theme/templates/sonar/projects/detail.html:64
 msgid "Funding organisations"
@@ -726,20 +767,20 @@ msgstr ""
 msgid "Funding was granted for the project"
 msgstr ""
 
-#: sonar/config.py:72
+#: sonar/config.py:74
 msgid "German"
 msgstr "Germana"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1780
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:22
 msgid "Gold"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:772
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1118
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:886
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1134
 msgid "Granting institution"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1776
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:18
 msgid "Green"
 msgstr ""
 
@@ -767,7 +808,7 @@ msgstr ""
 msgid "Harvested"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:18
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:18
 msgid "Hash key"
 msgstr ""
 
@@ -775,8 +816,8 @@ msgstr ""
 msgid "Help & Documentation"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:559
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1451
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:557
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1463
 msgid ""
 "Host document, for example a journal for an article, or a book for a book"
 " chapter."
@@ -786,7 +827,7 @@ msgstr ""
 msgid "How are research results used in training?"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1784
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:26
 msgid "Hybrid"
 msgstr ""
 
@@ -795,24 +836,22 @@ msgid "IR hosting service"
 msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:867
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1674
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1686
 msgid "ISBN/ISSN status should be selected in the list below."
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1220
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1236
 msgid "Identified by"
 msgstr ""
 
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:2
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:3
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:9
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:13
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:13
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:15
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:360
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:966
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1058
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:693
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1500
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1512
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:13
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:13
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:9
@@ -823,7 +862,7 @@ msgstr "Identigilo"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:357
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:689
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1496
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1508
 #: sonar/modules/documents/templates/documents/record.html:237
 msgid "Identifiers"
 msgstr "Identigiloj"
@@ -838,10 +877,6 @@ msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:316
 msgid "In progress"
-msgstr ""
-
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:597
-msgid "In the format \\"
 msgstr ""
 
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:118
@@ -870,12 +905,10 @@ msgstr ""
 msgid "Invenio"
 msgstr "Invenio"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:974
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:154
 msgid "Investigator"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:971
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:150
 #: sonar/theme/templates/sonar/projects/detail.html:35
 msgid "Investigators"
@@ -889,21 +922,21 @@ msgstr "Estas dediĉita organizaĵo"
 msgid "Is shared"
 msgstr "Partoprenas en la komuna deponejo"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1429
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1441
 msgid "Issue"
 msgstr "Numero"
 
-#: sonar/config.py:73
+#: sonar/config.py:75
 msgid "Italian"
 msgstr "Itala"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:767
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1113
-#: sonar/modules/documents/views.py:234
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:881
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1129
+#: sonar/modules/documents/views.py:240
 msgid "Jury note"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5023
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:140
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:49
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:47
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:256
@@ -914,7 +947,12 @@ msgstr "Ŝlosilo"
 msgid "Key (filename) of the file."
 msgstr ""
 
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:835
+msgid "Keyword"
+msgstr ""
+
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:391
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:832
 msgid "Keywords"
 msgstr ""
 
@@ -922,7 +960,7 @@ msgstr ""
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:69
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:503
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:903
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1154
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1170
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:94
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:141
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:188
@@ -936,8 +974,6 @@ msgid "Labels"
 msgstr ""
 
 #: sonar/common/jsonschemas/language-v1.0.0.json:2
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:37
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2513
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:354
 #: sonar/modules/documents/templates/documents/record.html:221
 msgid "Language"
@@ -960,7 +996,7 @@ msgstr ""
 msgid "Last name"
 msgstr "Familia nomo"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:829
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:943
 msgid "Last name, first name, ex: Doe, John"
 msgstr "Familia nomo, persona nomo; ekz. Zamenhof, Ludoviko"
 
@@ -969,9 +1005,13 @@ msgid "Lecturer/professor"
 msgstr ""
 
 #: sonar/common/jsonschemas/license-v1.0.0.json:2
-#: sonar/modules/documents/templates/documents/record.html:288
+#: sonar/modules/documents/templates/documents/record.html:306
 msgid "License"
 msgstr "Permesilo"
+
+#: sonar/common/jsonschemas/license-v1.0.0.json:52
+msgid "License undefined"
+msgstr ""
 
 #: sonar/theme/templates/sonar/projects/detail.html:79
 msgid "Linked documents"
@@ -985,17 +1025,22 @@ msgid ""
 " Enter one rule per line."
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4999
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:116
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:26
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:22
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:232
 msgid "List of files attached to the record."
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:21
+msgid "List of logs."
+msgstr ""
+
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:878
 msgid "Locality (Valais)"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:25
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:188
 msgid "Log"
 msgstr "Protokolo"
@@ -1030,11 +1075,12 @@ msgstr ""
 msgid "Logout"
 msgstr "Adiaŭi"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:20
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:184
 msgid "Logs"
 msgstr "Protokoloj"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5034
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:151
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:60
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:59
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:267
@@ -1053,11 +1099,11 @@ msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:291
 msgid "Main title"
-msgstr "Ĉeftitolo"
+msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:287
 msgid "Main titles"
-msgstr "Ĉeftitoloj"
+msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:836
 msgid "Mandate"
@@ -1075,38 +1121,38 @@ msgstr ""
 msgid "Mediator"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5028
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:145
 msgid "Mimetype"
 msgstr ""
 
-#: sonar/config.py:578
+#: sonar/config.py:602
 msgid "Most recent"
 msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:356
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:535
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:898
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:27
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:828
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:936
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:979
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1053
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:27
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:711
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:942
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1047
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:33
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:50
 msgid "Name"
 msgstr "Nomo"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:23
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:23
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:707
 msgid "Names"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:55
-msgid "Not OA / Rights reserved"
+#: sonar/modules/collections/templates/collections/index.html:32
+msgid "No collection found"
 msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:650
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:828
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1635
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1647
 msgid "Note"
 msgstr "Noto"
 
@@ -1121,8 +1167,8 @@ msgid "Notes"
 msgstr "Notoj"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:741
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:577
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1303
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:579
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1319
 msgid "Number"
 msgstr "Numero"
 
@@ -1142,8 +1188,7 @@ msgstr ""
 msgid "OAI-PMH specific information."
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:880
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1014
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:994
 msgid "ORCID"
 msgstr "ORCID"
 
@@ -1152,18 +1197,17 @@ msgstr "ORCID"
 msgid "Object type"
 msgstr "Tipo de objekto"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1760
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:2
 msgid "Open access status"
 msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:93
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4969
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4973
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:86
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:90
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:222
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:5
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:84
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:287
-#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:291
 msgid "Organisation"
 msgstr "Organizaĵo"
 
@@ -1202,26 +1246,22 @@ msgid ""
 "coloured."
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:51
-msgid "Other OA / license undefined"
-msgstr ""
-
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:882
 msgid "Other canton (Switzerland)"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:624
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:641
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:953
 #: sonar/modules/documents/templates/documents/record.html:208
 msgid "Other electronic version"
 msgstr "Alia elektronika versio"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:621
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:638
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:949
 msgid "Other electronic versions"
 msgstr "Aliaj elektronikaj versioj"
 
-#: sonar/modules/documents/templates/documents/record.html:311
+#: sonar/modules/documents/templates/documents/record.html:329
 msgid "Other files"
 msgstr "Aliaj dosieroj"
 
@@ -1234,8 +1274,8 @@ msgstr ""
 msgid "PID type"
 msgstr "Tipo de PID"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:585
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1437
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:596
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1449
 msgid "Pages"
 msgstr "Paĝoj"
 
@@ -1243,8 +1283,7 @@ msgstr "Paĝoj"
 msgid "Parents"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:540
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1407
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1419
 msgid "Part of (host document)"
 msgstr ""
 
@@ -1256,7 +1295,7 @@ msgstr ""
 msgid "Period"
 msgstr "Periodo"
 
-#: sonar/modules/documents/templates/documents/record.html:301
+#: sonar/modules/documents/templates/documents/record.html:319
 msgid "Permalink"
 msgstr "Konstanta ligilo"
 
@@ -1273,7 +1312,7 @@ msgstr "Telefonnumero"
 msgid "Phone number with the international prefix, without spaces."
 msgstr "Telefonnumero kun la internacia prefikso, sen spacetoj."
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1287
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1303
 msgid "Place"
 msgstr "Loko"
 
@@ -1283,6 +1322,15 @@ msgstr ""
 
 #: sonar/templates/security/email/welcome.html:5
 msgid "Please confirm your e-mail by clicking here"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:573
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:590
+msgid "Please enter a valid number."
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:606
+msgid "Please enter a valid pages range, example: 135, 5-27."
 msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:85
@@ -1314,13 +1362,13 @@ msgstr ""
 msgid "Practitioner-trainer"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1210
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1226
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:164
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:255
 msgid "Preferred name"
 msgstr "Preferata nomo"
 
-#: sonar/modules/documents/templates/documents/record.html:329
+#: sonar/modules/documents/templates/documents/record.html:347
 #: sonar/theme/templates/sonar/preview/base.html:23
 msgid "Preview"
 msgstr "Antaŭrigardo"
@@ -1340,11 +1388,11 @@ msgstr ""
 
 #: sonar/theme/templates/sonar/partial/dropdown_user.html:21
 #: sonar/theme/templates/sonar/partial/dropdown_user.html:24
-#: sonar/theme/views.py:66
+#: sonar/theme/views.py:68
 msgid "Profile"
 msgstr "Profilo"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:916
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1027
 msgid "Project"
 msgstr "Projekto"
 
@@ -1384,12 +1432,12 @@ msgstr "Publika atingo el"
 msgid "Public foundation"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:633
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:650
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:973
 msgid "Public note"
 msgstr "Publika noto"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1456
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1468
 msgid "Publication"
 msgstr "Eldonaĵo"
 
@@ -1402,12 +1450,12 @@ msgid "Published in"
 msgstr "Eldonita en"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:332
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:606
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:623
 msgid "Publisher"
 msgstr "Eldonejo"
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:836
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1643
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1655
 msgid "Qualifier"
 msgstr ""
 
@@ -1415,15 +1463,19 @@ msgstr ""
 msgid "Realization framework"
 msgstr ""
 
+#: sonar/modules/validation/api.py:216
+msgid "Record validation"
+msgstr ""
+
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:4
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:908
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1732
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1019
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1744
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:4
 msgid "Research project"
 msgstr "Esplora projekto"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:901
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1728
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1015
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1740
 #: sonar/modules/documents/templates/documents/record.html:183
 msgid "Research projects"
 msgstr "Esploraj projektoj"
@@ -1439,15 +1491,18 @@ msgstr ""
 msgid "Responsibility"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:839
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:984
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1330
+#: sonar/common/jsonschemas/license-v1.0.0.json:56
+msgid "Rights reserved"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:953
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1346
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:99
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:181
 msgid "Role"
 msgstr "Rolo"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1326
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1342
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:177
 msgid "Roles"
 msgstr "Roloj"
@@ -1470,6 +1525,10 @@ msgstr "Emblemo de SONAR"
 msgid "Schema"
 msgstr "Skemo"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:3
+msgid "Schema representing a validation workflow."
+msgstr ""
+
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:9
 msgid "Schema to validate document against."
 msgstr ""
@@ -1484,6 +1543,10 @@ msgstr ""
 #: sonar/theme/templates/sonar/partial/organisation.html:21
 msgid "Search"
 msgstr "Serĉi"
+
+#: sonar/modules/collections/templates/collections/item.html:48
+msgid "Search in collection"
+msgstr ""
 
 #: sonar/theme/templates/sonar/frontpage.html:57
 msgid "Search publications, authors, projects..."
@@ -1542,14 +1605,14 @@ msgstr ""
 msgid "Sign-up with SWITCHaai"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5039
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:156
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:65
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:64
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:272
 msgid "Size"
 msgstr "Grando"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5040
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:157
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:66
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:65
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:273
@@ -1564,8 +1627,8 @@ msgstr ""
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:510
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:849
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:926
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1245
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1656
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1261
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1668
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:117
 msgid "Source"
 msgstr "Fonto"
@@ -1578,13 +1641,9 @@ msgstr "Fontokodo en"
 msgid "Special education teacher"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:659
-msgid "Specific collections"
-msgstr "Specifaj kolektoj"
-
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:67
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:952
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1461
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1063
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1473
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:66
 msgid "Start date"
 msgstr "Komenca dato"
@@ -1610,7 +1669,7 @@ msgid "State of Valais, parastatal institution"
 msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:474
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1466
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1478
 msgid "Statement"
 msgstr ""
 
@@ -1618,10 +1677,11 @@ msgstr ""
 msgid "Statements"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:64
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:39
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:136
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:860
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1667
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1679
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:39
 msgid "Status"
 msgstr "Stato"
@@ -1650,14 +1710,11 @@ msgstr ""
 msgid "Student in training"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:721
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:898
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:915
 msgid "Subject"
 msgstr "Temo"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:718
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:737
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:894
 msgid "Subjects"
 msgstr "Temoj"
@@ -1679,7 +1736,7 @@ msgstr ""
 msgid "Suspended"
 msgstr ""
 
-#: sonar/config.py:94 sonar/config.py:98
+#: sonar/config.py:96 sonar/config.py:100
 msgid "Swiss Open Access Repository"
 msgstr ""
 
@@ -1709,7 +1766,7 @@ msgid ""
 "with Swiss public research institutions."
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:660
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:677
 msgid ""
 "The names of the organisation's specific/patrimonial collections to which"
 " this document belongs"
@@ -1738,7 +1795,7 @@ msgstr ""
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:304
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:264
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:627
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1450
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1462
 msgid "Title"
 msgstr "Titolo"
 
@@ -1777,11 +1834,11 @@ msgstr ""
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:449
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:478
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:698
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1022
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1052
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1185
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1225
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1505
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1038
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1068
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1201
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1241
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1517
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:97
 msgid "Type"
 msgstr "Tipo"
@@ -1794,7 +1851,7 @@ msgstr ""
 msgid "Type of the file"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:643
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:660
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:963
 msgid "URL"
 msgstr "URL"
@@ -1811,10 +1868,12 @@ msgstr ""
 msgid "UUID of the bucket the tile is assigned to."
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1146
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1162
 msgid "Usage and access policy"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:90
+#: sonar/common/jsonschemas/validation-v1.0.0.json:96
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:116
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:121
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:120
@@ -1822,15 +1881,25 @@ msgstr ""
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:198
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:202
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:5
-#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:311
-#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:316
+#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:310
+#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:315
 msgid "User"
 msgstr "Uzanto"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:91
+msgid "User which created the record."
+msgstr ""
+
+#: sonar/common/jsonschemas/validation-v1.0.0.json:2
+msgid "Validation"
+msgstr ""
+
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:39
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:32
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2502
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:32
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:61
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:505
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:716
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:745
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:296
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:320
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:405
@@ -1839,8 +1908,8 @@ msgstr "Uzanto"
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:668
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:823
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:911
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1256
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1630
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1272
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1642
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:99
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:146
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:193
@@ -1848,7 +1917,11 @@ msgstr "Uzanto"
 msgid "Value"
 msgstr "Valoro"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5018
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:851
+msgid "Values"
+msgstr ""
+
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:135
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:44
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:41
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:251
@@ -1859,8 +1932,8 @@ msgstr "UUID de versio"
 msgid "Vice-rector HE"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:569
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1421
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:562
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1433
 msgid "Volume"
 msgstr "Volumo"
 
@@ -1868,7 +1941,7 @@ msgstr "Volumo"
 msgid "Welcome to SONAR"
 msgstr "Bonvenon al SONAR"
 
-#: sonar/config.py:125
+#: sonar/config.py:127
 msgid "Welcome to SONAR, the Swiss Open Access Repository!"
 msgstr ""
 
@@ -1900,8 +1973,7 @@ msgstr ""
 msgid "Why?"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:564
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1416
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1428
 msgid "Year"
 msgstr "Jaro"
 
@@ -1923,78 +1995,78 @@ msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:417
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:728
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1535
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1547
 msgid "bf:AudioIssueNumber"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1049
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1065
 msgid "bf:ClassificationDdc"
 msgstr "Decimala Klasifiko de Dewey"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1019
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1035
 msgid "bf:ClassificationUdc"
 msgstr "Universala Decimala Klasifiko"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:402
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:732
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1539
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1551
 msgid "bf:Doi"
 msgstr "DOI"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:421
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:736
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1543
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1555
 msgid "bf:Ean"
 msgstr "EAN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:425
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:740
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1547
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1559
 msgid "bf:Gtin14Number"
 msgstr "GTIN-14"
 
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:17
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:429
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:744
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1234
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1551
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1250
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1563
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:106
 msgid "bf:Identifier"
 msgstr "Identigilo"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:433
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:748
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1555
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1567
 msgid "bf:Isan"
 msgstr "ISAN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:412
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:752
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1559
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1571
 msgid "bf:Isbn"
 msgstr "ISBN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:437
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:756
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1563
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1575
 msgid "bf:Ismn"
 msgstr "ISMN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:441
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:760
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1567
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1579
 msgid "bf:Isrc"
 msgstr "ISRC"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:445
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:764
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1571
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1583
 msgid "bf:Issn"
 msgstr "ISSN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:449
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:768
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1575
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1587
 msgid "bf:IssnL"
 msgstr "ISSN-L"
 
@@ -2005,8 +2077,8 @@ msgstr "lingvo"
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:21
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:453
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:772
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1238
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1579
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1254
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1591
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:110
 msgid "bf:Local"
 msgstr ""
@@ -2017,37 +2089,37 @@ msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:457
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:776
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1583
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1595
 msgid "bf:MatrixNumber"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1203
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1219
 msgid "bf:Meeting"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:461
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:780
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1587
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1599
 msgid "bf:MusicDistributorNumber"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:465
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:784
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1591
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1603
 msgid "bf:MusicPlate"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:469
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:788
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1595
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1607
 msgid "bf:MusicPublisherNumber"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1199
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1215
 msgid "bf:Organization"
 msgstr "Organizaĵo"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1195
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1211
 msgid "bf:Person"
 msgstr "Persono"
 
@@ -2061,41 +2133,41 @@ msgstr "Eldonaĵo"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:473
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:792
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1599
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1611
 msgid "bf:PublisherNumber"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:493
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:812
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1619
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1631
 msgid "bf:ReportNumber"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:497
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:816
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1623
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1635
 msgid "bf:Strn"
 msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:280
 msgid "bf:Title"
-msgstr "Titolo"
+msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:477
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:796
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1603
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1615
 msgid "bf:Upc"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:481
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:800
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1607
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1619
 msgid "bf:Urn"
 msgstr "URN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:485
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:804
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1611
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1623
 msgid "bf:VideoRecordingNumber"
 msgstr ""
 
@@ -2459,41 +2531,40 @@ msgstr ""
 msgid "coar:c_f1cf"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1002
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:195
 msgid "coinvestigator"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:857
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1351
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:971
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1367
 msgid "contribution_role_cre"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:861
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1359
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:975
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1375
 msgid "contribution_role_ctb"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:869
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1343
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:983
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1359
 msgid "contribution_role_dgs"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:865
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1355
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:979
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1371
 msgid "contribution_role_edt"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:873
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1347
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:987
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1363
 msgid "contribution_role_prt"
 msgstr ""
 
-#: sonar/modules/documents/views.py:266
+#: sonar/modules/documents/views.py:272
 msgid "contribution_role_{role}"
 msgstr ""
 
-#: sonar/config.py:549
+#: sonar/config.py:573
 msgid "contributor"
 msgstr "Kontribuinto"
 
@@ -2777,7 +2848,6 @@ msgstr ""
 msgid "innerSearcher"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:998
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:191
 msgid "investigator"
 msgstr ""
@@ -2786,2913 +2856,1948 @@ msgstr ""
 msgid "keywords"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:500
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:535
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3011
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:694
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1010
+msgid "label"
+msgstr ""
+
+#: sonar/common/jsonschemas/language-v1.0.0.json:497
 msgid "lang_aar"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:504
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:539
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3015
+#: sonar/common/jsonschemas/language-v1.0.0.json:501
 msgid "lang_abk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:508
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:543
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3019
+#: sonar/common/jsonschemas/language-v1.0.0.json:505
 msgid "lang_ace"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:512
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:547
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3023
+#: sonar/common/jsonschemas/language-v1.0.0.json:509
 msgid "lang_ach"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:516
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:551
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3027
+#: sonar/common/jsonschemas/language-v1.0.0.json:513
 msgid "lang_ada"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:520
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:555
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3031
+#: sonar/common/jsonschemas/language-v1.0.0.json:517
 msgid "lang_ady"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:524
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:559
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3035
+#: sonar/common/jsonschemas/language-v1.0.0.json:521
 msgid "lang_afa"
 msgstr "Afrikazia (alia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:528
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:563
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3039
+#: sonar/common/jsonschemas/language-v1.0.0.json:525
 msgid "lang_afh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:532
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:567
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3043
+#: sonar/common/jsonschemas/language-v1.0.0.json:529
 msgid "lang_afr"
 msgstr "afrikanso"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:536
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:571
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3047
+#: sonar/common/jsonschemas/language-v1.0.0.json:533
 msgid "lang_ain"
 msgstr "ajnua"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:540
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:575
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3051
+#: sonar/common/jsonschemas/language-v1.0.0.json:537
 msgid "lang_aka"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:544
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:579
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3055
+#: sonar/common/jsonschemas/language-v1.0.0.json:541
 msgid "lang_akk"
 msgstr "akada"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:548
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:583
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3059
+#: sonar/common/jsonschemas/language-v1.0.0.json:545
 msgid "lang_alb"
 msgstr "albana"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:552
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:587
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3063
+#: sonar/common/jsonschemas/language-v1.0.0.json:549
 msgid "lang_ale"
 msgstr "aleuta"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:556
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:591
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3067
+#: sonar/common/jsonschemas/language-v1.0.0.json:553
 msgid "lang_alg"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:560
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:595
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3071
+#: sonar/common/jsonschemas/language-v1.0.0.json:557
 msgid "lang_alt"
 msgstr "sudaltaja"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:564
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:599
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3075
+#: sonar/common/jsonschemas/language-v1.0.0.json:561
 msgid "lang_amh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:568
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:603
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3079
+#: sonar/common/jsonschemas/language-v1.0.0.json:565
 msgid "lang_ang"
 msgstr "anglosaksa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:572
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:607
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3083
+#: sonar/common/jsonschemas/language-v1.0.0.json:569
 msgid "lang_anp"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:576
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:611
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3087
+#: sonar/common/jsonschemas/language-v1.0.0.json:573
 msgid "lang_apa"
 msgstr "apaĉaj lingvoj"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:580
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:615
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3091
+#: sonar/common/jsonschemas/language-v1.0.0.json:577
 msgid "lang_ara"
 msgstr "araba"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:584
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:619
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3095
+#: sonar/common/jsonschemas/language-v1.0.0.json:581
 msgid "lang_arc"
 msgstr "aramea"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:588
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:623
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3099
+#: sonar/common/jsonschemas/language-v1.0.0.json:585
 msgid "lang_arg"
 msgstr "aragona"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:592
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:627
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3103
+#: sonar/common/jsonschemas/language-v1.0.0.json:589
 msgid "lang_arm"
 msgstr "armena"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:596
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:631
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3107
+#: sonar/common/jsonschemas/language-v1.0.0.json:593
 msgid "lang_arn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:600
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:635
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3111
+#: sonar/common/jsonschemas/language-v1.0.0.json:597
 msgid "lang_arp"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:604
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:639
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3115
+#: sonar/common/jsonschemas/language-v1.0.0.json:601
 msgid "lang_art"
 msgstr "artefarita lingvo (alia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:608
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:643
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3119
+#: sonar/common/jsonschemas/language-v1.0.0.json:605
 msgid "lang_arw"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:612
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:647
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3123
+#: sonar/common/jsonschemas/language-v1.0.0.json:609
 msgid "lang_asm"
 msgstr "asama"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:616
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:651
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3127
+#: sonar/common/jsonschemas/language-v1.0.0.json:613
 msgid "lang_ast"
 msgstr "asturia"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:620
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:655
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3131
+#: sonar/common/jsonschemas/language-v1.0.0.json:617
 msgid "lang_ath"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:624
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:659
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3135
+#: sonar/common/jsonschemas/language-v1.0.0.json:621
 msgid "lang_aus"
 msgstr "aŭstraliaj lingvoj"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:628
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:663
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3139
+#: sonar/common/jsonschemas/language-v1.0.0.json:625
 msgid "lang_ava"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:632
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:667
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3143
+#: sonar/common/jsonschemas/language-v1.0.0.json:629
 msgid "lang_ave"
 msgstr "avesta"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:636
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:671
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3147
+#: sonar/common/jsonschemas/language-v1.0.0.json:633
 msgid "lang_awa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:640
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:675
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3151
+#: sonar/common/jsonschemas/language-v1.0.0.json:637
 msgid "lang_aym"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:644
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:679
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3155
+#: sonar/common/jsonschemas/language-v1.0.0.json:641
 msgid "lang_aze"
 msgstr "azerbajĝana"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:648
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:683
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3159
+#: sonar/common/jsonschemas/language-v1.0.0.json:645
 msgid "lang_bad"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:652
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:687
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3163
+#: sonar/common/jsonschemas/language-v1.0.0.json:649
 msgid "lang_bai"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:656
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:691
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3167
+#: sonar/common/jsonschemas/language-v1.0.0.json:653
 msgid "lang_bak"
 msgstr "baŝkira"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:660
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:695
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3171
+#: sonar/common/jsonschemas/language-v1.0.0.json:657
 msgid "lang_bal"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:664
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:699
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3175
+#: sonar/common/jsonschemas/language-v1.0.0.json:661
 msgid "lang_bam"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:668
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:703
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3179
+#: sonar/common/jsonschemas/language-v1.0.0.json:665
 msgid "lang_ban"
 msgstr "balia"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:672
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:707
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3183
+#: sonar/common/jsonschemas/language-v1.0.0.json:669
 msgid "lang_baq"
 msgstr "eŭska"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:676
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:711
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3187
+#: sonar/common/jsonschemas/language-v1.0.0.json:673
 msgid "lang_bas"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:680
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:715
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3191
+#: sonar/common/jsonschemas/language-v1.0.0.json:677
 msgid "lang_bat"
 msgstr "baltaj lingvoj (aliaj)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:684
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:719
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3195
+#: sonar/common/jsonschemas/language-v1.0.0.json:681
 msgid "lang_bej"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:688
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:723
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3199
+#: sonar/common/jsonschemas/language-v1.0.0.json:685
 msgid "lang_bel"
 msgstr "belorusa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:692
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:727
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3203
+#: sonar/common/jsonschemas/language-v1.0.0.json:689
 msgid "lang_bem"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:696
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:731
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3207
+#: sonar/common/jsonschemas/language-v1.0.0.json:693
 msgid "lang_ben"
 msgstr "bengala"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:700
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:735
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3211
+#: sonar/common/jsonschemas/language-v1.0.0.json:697
 msgid "lang_ber"
 msgstr "berbera (alia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:704
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:739
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3215
+#: sonar/common/jsonschemas/language-v1.0.0.json:701
 msgid "lang_bho"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:708
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:743
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3219
+#: sonar/common/jsonschemas/language-v1.0.0.json:705
 msgid "lang_bih"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:712
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:747
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3223
+#: sonar/common/jsonschemas/language-v1.0.0.json:709
 msgid "lang_bik"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:716
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:751
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3227
+#: sonar/common/jsonschemas/language-v1.0.0.json:713
 msgid "lang_bin"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:720
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:755
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3231
+#: sonar/common/jsonschemas/language-v1.0.0.json:717
 msgid "lang_bis"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:724
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:759
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3235
+#: sonar/common/jsonschemas/language-v1.0.0.json:721
 msgid "lang_bla"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:728
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:763
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3239
+#: sonar/common/jsonschemas/language-v1.0.0.json:725
 msgid "lang_bnt"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:732
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:767
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3243
+#: sonar/common/jsonschemas/language-v1.0.0.json:729
 msgid "lang_bos"
 msgstr "bosna"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:736
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:771
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3247
+#: sonar/common/jsonschemas/language-v1.0.0.json:733
 msgid "lang_bra"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:740
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:775
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3251
+#: sonar/common/jsonschemas/language-v1.0.0.json:737
 msgid "lang_bre"
 msgstr "bretona"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:744
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:779
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3255
+#: sonar/common/jsonschemas/language-v1.0.0.json:741
 msgid "lang_btk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:748
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:783
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3259
+#: sonar/common/jsonschemas/language-v1.0.0.json:745
 msgid "lang_bua"
 msgstr "burjata"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:752
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:787
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3263
+#: sonar/common/jsonschemas/language-v1.0.0.json:749
 msgid "lang_bug"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:756
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:791
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3267
+#: sonar/common/jsonschemas/language-v1.0.0.json:753
 msgid "lang_bul"
 msgstr "bulgara"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:760
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:795
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3271
+#: sonar/common/jsonschemas/language-v1.0.0.json:757
 msgid "lang_bur"
 msgstr "birma"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:764
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:799
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3275
+#: sonar/common/jsonschemas/language-v1.0.0.json:761
 msgid "lang_byn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:768
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:803
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3279
+#: sonar/common/jsonschemas/language-v1.0.0.json:765
 msgid "lang_cad"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:772
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:807
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3283
+#: sonar/common/jsonschemas/language-v1.0.0.json:769
 msgid "lang_cai"
 msgstr "mezamerika indiana lingvo (alia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:776
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:811
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3287
+#: sonar/common/jsonschemas/language-v1.0.0.json:773
 msgid "lang_car"
 msgstr "kariba"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:780
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:815
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3291
+#: sonar/common/jsonschemas/language-v1.0.0.json:777
 msgid "lang_cat"
 msgstr "kataluna"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:784
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:819
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3295
+#: sonar/common/jsonschemas/language-v1.0.0.json:781
 msgid "lang_cau"
 msgstr "kaŭkaza (alia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:788
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:823
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3299
+#: sonar/common/jsonschemas/language-v1.0.0.json:785
 msgid "lang_ceb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:792
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:827
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3303
+#: sonar/common/jsonschemas/language-v1.0.0.json:789
 msgid "lang_cel"
 msgstr "kelta (alia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:796
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:831
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3307
+#: sonar/common/jsonschemas/language-v1.0.0.json:793
 msgid "lang_cha"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:800
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:835
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3311
+#: sonar/common/jsonschemas/language-v1.0.0.json:797
 msgid "lang_chb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:804
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:839
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3315
+#: sonar/common/jsonschemas/language-v1.0.0.json:801
 msgid "lang_che"
 msgstr "ĉeĉena"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:808
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:843
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3319
+#: sonar/common/jsonschemas/language-v1.0.0.json:805
 msgid "lang_chg"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:812
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:847
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3323
+#: sonar/common/jsonschemas/language-v1.0.0.json:809
 msgid "lang_chi"
 msgstr "ĉina"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:816
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:851
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3327
+#: sonar/common/jsonschemas/language-v1.0.0.json:813
 msgid "lang_chk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:820
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:855
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3331
+#: sonar/common/jsonschemas/language-v1.0.0.json:817
 msgid "lang_chm"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:824
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:859
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3335
+#: sonar/common/jsonschemas/language-v1.0.0.json:821
 msgid "lang_chn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:828
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:863
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3339
+#: sonar/common/jsonschemas/language-v1.0.0.json:825
 msgid "lang_cho"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:832
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:867
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3343
+#: sonar/common/jsonschemas/language-v1.0.0.json:829
 msgid "lang_chp"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:836
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:871
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3347
+#: sonar/common/jsonschemas/language-v1.0.0.json:833
 msgid "lang_chr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:840
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:875
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3351
+#: sonar/common/jsonschemas/language-v1.0.0.json:837
 msgid "lang_chu"
 msgstr "slavono"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:844
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:879
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3355
+#: sonar/common/jsonschemas/language-v1.0.0.json:841
 msgid "lang_chv"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:848
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:883
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3359
+#: sonar/common/jsonschemas/language-v1.0.0.json:845
 msgid "lang_chy"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:852
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:887
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3363
+#: sonar/common/jsonschemas/language-v1.0.0.json:849
 msgid "lang_cmc"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:856
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:891
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3367
+#: sonar/common/jsonschemas/language-v1.0.0.json:853
 msgid "lang_cnr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:860
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:895
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3371
+#: sonar/common/jsonschemas/language-v1.0.0.json:857
 msgid "lang_cop"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:864
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:899
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3375
+#: sonar/common/jsonschemas/language-v1.0.0.json:861
 msgid "lang_cor"
 msgstr "kornvala"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:868
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:903
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3379
+#: sonar/common/jsonschemas/language-v1.0.0.json:865
 msgid "lang_cos"
 msgstr "korsika"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:872
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:907
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3383
+#: sonar/common/jsonschemas/language-v1.0.0.json:869
 msgid "lang_cpe"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:876
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:911
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3387
+#: sonar/common/jsonschemas/language-v1.0.0.json:873
 msgid "lang_cpf"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:880
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:915
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3391
+#: sonar/common/jsonschemas/language-v1.0.0.json:877
 msgid "lang_cpp"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:884
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:919
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3395
+#: sonar/common/jsonschemas/language-v1.0.0.json:881
 msgid "lang_cre"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:888
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:923
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3399
+#: sonar/common/jsonschemas/language-v1.0.0.json:885
 msgid "lang_crh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:892
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:927
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3403
+#: sonar/common/jsonschemas/language-v1.0.0.json:889
 msgid "lang_crp"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:896
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:931
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3407
+#: sonar/common/jsonschemas/language-v1.0.0.json:893
 msgid "lang_csb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:900
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:935
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3411
+#: sonar/common/jsonschemas/language-v1.0.0.json:897
 msgid "lang_cus"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:904
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:939
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3415
+#: sonar/common/jsonschemas/language-v1.0.0.json:901
 msgid "lang_cze"
 msgstr "ĉeĥa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:908
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:943
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3419
+#: sonar/common/jsonschemas/language-v1.0.0.json:905
 msgid "lang_dak"
 msgstr "dakota"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:912
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:947
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3423
+#: sonar/common/jsonschemas/language-v1.0.0.json:909
 msgid "lang_dan"
 msgstr "dana"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:916
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:951
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3427
+#: sonar/common/jsonschemas/language-v1.0.0.json:913
 msgid "lang_dar"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:920
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:955
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3431
+#: sonar/common/jsonschemas/language-v1.0.0.json:917
 msgid "lang_day"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:924
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:959
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3435
+#: sonar/common/jsonschemas/language-v1.0.0.json:921
 msgid "lang_del"
 msgstr "delavara"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:928
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:963
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3439
+#: sonar/common/jsonschemas/language-v1.0.0.json:925
 msgid "lang_den"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:932
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:967
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3443
+#: sonar/common/jsonschemas/language-v1.0.0.json:929
 msgid "lang_dgr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:936
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:971
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3447
+#: sonar/common/jsonschemas/language-v1.0.0.json:933
 msgid "lang_din"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:940
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:975
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3451
+#: sonar/common/jsonschemas/language-v1.0.0.json:937
 msgid "lang_div"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:944
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:979
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3455
+#: sonar/common/jsonschemas/language-v1.0.0.json:941
 msgid "lang_doi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:948
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:983
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3459
+#: sonar/common/jsonschemas/language-v1.0.0.json:945
 msgid "lang_dra"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:952
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:987
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3463
+#: sonar/common/jsonschemas/language-v1.0.0.json:949
 msgid "lang_dsb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:956
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:991
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3467
+#: sonar/common/jsonschemas/language-v1.0.0.json:953
 msgid "lang_dua"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:960
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:995
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3471
+#: sonar/common/jsonschemas/language-v1.0.0.json:957
 msgid "lang_dum"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:964
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:999
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3475
+#: sonar/common/jsonschemas/language-v1.0.0.json:961
 msgid "lang_dut"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:968
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1003
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3479
+#: sonar/common/jsonschemas/language-v1.0.0.json:965
 msgid "lang_dyu"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:972
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1007
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3483
+#: sonar/common/jsonschemas/language-v1.0.0.json:969
 msgid "lang_dzo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:976
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1011
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3487
+#: sonar/common/jsonschemas/language-v1.0.0.json:973
 msgid "lang_efi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:980
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1015
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3491
+#: sonar/common/jsonschemas/language-v1.0.0.json:977
 msgid "lang_egy"
 msgstr "antikva egipta"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:984
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1019
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3495
+#: sonar/common/jsonschemas/language-v1.0.0.json:981
 msgid "lang_eka"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:988
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1023
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3499
+#: sonar/common/jsonschemas/language-v1.0.0.json:985
 msgid "lang_elx"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:992
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1027
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3503
+#: sonar/common/jsonschemas/language-v1.0.0.json:989
 msgid "lang_eng"
 msgstr "angla"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:997
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1032
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3508
+#: sonar/common/jsonschemas/language-v1.0.0.json:994
 msgid "lang_enm"
 msgstr "meza angla (1100–1500)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1001
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1036
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3512
+#: sonar/common/jsonschemas/language-v1.0.0.json:998
 msgid "lang_epo"
 msgstr "Esperanto"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1005
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1040
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3516
+#: sonar/common/jsonschemas/language-v1.0.0.json:1002
 msgid "lang_est"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1009
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1044
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3520
+#: sonar/common/jsonschemas/language-v1.0.0.json:1006
 msgid "lang_ewe"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1013
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1048
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3524
+#: sonar/common/jsonschemas/language-v1.0.0.json:1010
 msgid "lang_ewo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1017
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1052
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3528
+#: sonar/common/jsonschemas/language-v1.0.0.json:1014
 msgid "lang_fan"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1021
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1056
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3532
+#: sonar/common/jsonschemas/language-v1.0.0.json:1018
 msgid "lang_fao"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1025
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1060
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3536
+#: sonar/common/jsonschemas/language-v1.0.0.json:1022
 msgid "lang_fat"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1029
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1064
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3540
+#: sonar/common/jsonschemas/language-v1.0.0.json:1026
 msgid "lang_fij"
 msgstr "fiĝia"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1033
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1068
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3544
+#: sonar/common/jsonschemas/language-v1.0.0.json:1030
 msgid "lang_fil"
 msgstr "filipina"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1037
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1072
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3548
+#: sonar/common/jsonschemas/language-v1.0.0.json:1034
 msgid "lang_fin"
 msgstr "finna"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1041
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1076
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3552
+#: sonar/common/jsonschemas/language-v1.0.0.json:1038
 msgid "lang_fiu"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1045
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1080
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3556
+#: sonar/common/jsonschemas/language-v1.0.0.json:1042
 msgid "lang_fon"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1049
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1084
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3560
+#: sonar/common/jsonschemas/language-v1.0.0.json:1046
 msgid "lang_fre"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1054
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1089
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3565
+#: sonar/common/jsonschemas/language-v1.0.0.json:1051
 msgid "lang_frm"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1058
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1093
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3569
+#: sonar/common/jsonschemas/language-v1.0.0.json:1055
 msgid "lang_fro"
 msgstr "antikva franca (842–1300)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1062
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1097
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3573
+#: sonar/common/jsonschemas/language-v1.0.0.json:1059
 msgid "lang_frr"
 msgstr "nordfrisa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1066
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1101
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3577
+#: sonar/common/jsonschemas/language-v1.0.0.json:1063
 msgid "lang_frs"
 msgstr "orientfrisa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1070
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1105
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3581
+#: sonar/common/jsonschemas/language-v1.0.0.json:1067
 msgid "lang_fry"
 msgstr "okcidentfrisa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1074
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1109
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3585
+#: sonar/common/jsonschemas/language-v1.0.0.json:1071
 msgid "lang_ful"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1078
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1113
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3589
+#: sonar/common/jsonschemas/language-v1.0.0.json:1075
 msgid "lang_fur"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1082
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1117
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3593
+#: sonar/common/jsonschemas/language-v1.0.0.json:1079
 msgid "lang_gaa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1086
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1121
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3597
+#: sonar/common/jsonschemas/language-v1.0.0.json:1083
 msgid "lang_gay"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1090
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1125
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3601
+#: sonar/common/jsonschemas/language-v1.0.0.json:1087
 msgid "lang_gba"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1094
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1129
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3605
+#: sonar/common/jsonschemas/language-v1.0.0.json:1091
 msgid "lang_gem"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1098
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1133
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3609
+#: sonar/common/jsonschemas/language-v1.0.0.json:1095
 msgid "lang_geo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1102
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1137
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3613
+#: sonar/common/jsonschemas/language-v1.0.0.json:1099
 msgid "lang_ger"
 msgstr "germana"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1107
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1142
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3618
+#: sonar/common/jsonschemas/language-v1.0.0.json:1104
 msgid "lang_gez"
 msgstr "etiopa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1111
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1146
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3622
+#: sonar/common/jsonschemas/language-v1.0.0.json:1108
 msgid "lang_gil"
 msgstr "kiribata"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1115
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1150
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3626
+#: sonar/common/jsonschemas/language-v1.0.0.json:1112
 msgid "lang_gla"
 msgstr "skotgaela"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1119
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1154
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3630
+#: sonar/common/jsonschemas/language-v1.0.0.json:1116
 msgid "lang_gle"
 msgstr "irlanda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1123
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1158
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3634
+#: sonar/common/jsonschemas/language-v1.0.0.json:1120
 msgid "lang_glg"
 msgstr "galega"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1127
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1162
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3638
+#: sonar/common/jsonschemas/language-v1.0.0.json:1124
 msgid "lang_glv"
 msgstr "manksa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1131
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1166
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3642
+#: sonar/common/jsonschemas/language-v1.0.0.json:1128
 msgid "lang_gmh"
 msgstr "mezaltgermana (1050–1500)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1135
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1170
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3646
+#: sonar/common/jsonschemas/language-v1.0.0.json:1132
 msgid "lang_goh"
 msgstr "antikva altgermana (750–1050)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1139
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1174
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3650
+#: sonar/common/jsonschemas/language-v1.0.0.json:1136
 msgid "lang_gon"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1143
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1178
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3654
+#: sonar/common/jsonschemas/language-v1.0.0.json:1140
 msgid "lang_gor"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1147
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1182
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3658
+#: sonar/common/jsonschemas/language-v1.0.0.json:1144
 msgid "lang_got"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1151
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1186
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3662
+#: sonar/common/jsonschemas/language-v1.0.0.json:1148
 msgid "lang_grb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1155
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1190
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3666
+#: sonar/common/jsonschemas/language-v1.0.0.json:1152
 msgid "lang_grc"
 msgstr "antikva greka (antaŭ 1453)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1159
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1194
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3670
+#: sonar/common/jsonschemas/language-v1.0.0.json:1156
 msgid "lang_gre"
 msgstr "moderna greka (post 1453)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1163
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1198
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3674
+#: sonar/common/jsonschemas/language-v1.0.0.json:1160
 msgid "lang_grn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1167
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1202
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3678
+#: sonar/common/jsonschemas/language-v1.0.0.json:1164
 msgid "lang_gsw"
 msgstr "svisgermana"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1171
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1206
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3682
+#: sonar/common/jsonschemas/language-v1.0.0.json:1168
 msgid "lang_guj"
 msgstr "guĝarata"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1175
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1210
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3686
+#: sonar/common/jsonschemas/language-v1.0.0.json:1172
 msgid "lang_gwi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1179
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1214
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3690
+#: sonar/common/jsonschemas/language-v1.0.0.json:1176
 msgid "lang_hai"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1183
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1218
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3694
+#: sonar/common/jsonschemas/language-v1.0.0.json:1180
 msgid "lang_hat"
 msgstr "haitia kreola"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1187
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1222
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3698
+#: sonar/common/jsonschemas/language-v1.0.0.json:1184
 msgid "lang_hau"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1191
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1226
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3702
+#: sonar/common/jsonschemas/language-v1.0.0.json:1188
 msgid "lang_haw"
 msgstr "havaja"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1195
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1230
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3706
+#: sonar/common/jsonschemas/language-v1.0.0.json:1192
 msgid "lang_heb"
 msgstr "hebrea"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1199
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1234
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3710
+#: sonar/common/jsonschemas/language-v1.0.0.json:1196
 msgid "lang_her"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1203
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1238
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3714
+#: sonar/common/jsonschemas/language-v1.0.0.json:1200
 msgid "lang_hil"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1207
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1242
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3718
+#: sonar/common/jsonschemas/language-v1.0.0.json:1204
 msgid "lang_him"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1211
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1246
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3722
+#: sonar/common/jsonschemas/language-v1.0.0.json:1208
 msgid "lang_hin"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1215
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1250
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3726
+#: sonar/common/jsonschemas/language-v1.0.0.json:1212
 msgid "lang_hit"
 msgstr "hitita"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1219
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1254
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3730
+#: sonar/common/jsonschemas/language-v1.0.0.json:1216
 msgid "lang_hmn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1223
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1258
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3734
+#: sonar/common/jsonschemas/language-v1.0.0.json:1220
 msgid "lang_hmo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1227
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1262
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3738
+#: sonar/common/jsonschemas/language-v1.0.0.json:1224
 msgid "lang_hrv"
 msgstr "kroata"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1231
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1266
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3742
+#: sonar/common/jsonschemas/language-v1.0.0.json:1228
 msgid "lang_hsb"
 msgstr "altsoraba"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1235
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1270
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3746
+#: sonar/common/jsonschemas/language-v1.0.0.json:1232
 msgid "lang_hun"
 msgstr "hungara"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1239
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1274
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3750
+#: sonar/common/jsonschemas/language-v1.0.0.json:1236
 msgid "lang_hup"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1243
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1278
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3754
+#: sonar/common/jsonschemas/language-v1.0.0.json:1240
 msgid "lang_iba"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1247
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1282
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3758
+#: sonar/common/jsonschemas/language-v1.0.0.json:1244
 msgid "lang_ibo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1251
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1286
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3762
+#: sonar/common/jsonschemas/language-v1.0.0.json:1248
 msgid "lang_ice"
 msgstr "islanda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1255
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1290
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3766
+#: sonar/common/jsonschemas/language-v1.0.0.json:1252
 msgid "lang_ido"
 msgstr "Ido"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1259
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1294
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3770
+#: sonar/common/jsonschemas/language-v1.0.0.json:1256
 msgid "lang_iii"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1263
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1298
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3774
+#: sonar/common/jsonschemas/language-v1.0.0.json:1260
 msgid "lang_ijo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1267
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1302
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3778
+#: sonar/common/jsonschemas/language-v1.0.0.json:1264
 msgid "lang_iku"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1271
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1306
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3782
+#: sonar/common/jsonschemas/language-v1.0.0.json:1268
 msgid "lang_ile"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1275
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1310
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3786
+#: sonar/common/jsonschemas/language-v1.0.0.json:1272
 msgid "lang_ilo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1279
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1314
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3790
+#: sonar/common/jsonschemas/language-v1.0.0.json:1276
 msgid "lang_ina"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1283
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1318
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3794
+#: sonar/common/jsonschemas/language-v1.0.0.json:1280
 msgid "lang_inc"
 msgstr "hiindarja (alia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1287
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1322
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3798
+#: sonar/common/jsonschemas/language-v1.0.0.json:1284
 msgid "lang_ind"
 msgstr "indonezia"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1291
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1326
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3802
+#: sonar/common/jsonschemas/language-v1.0.0.json:1288
 msgid "lang_ine"
 msgstr "hindeŭropa (alia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1295
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1330
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3806
+#: sonar/common/jsonschemas/language-v1.0.0.json:1292
 msgid "lang_inh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1299
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1334
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3810
+#: sonar/common/jsonschemas/language-v1.0.0.json:1296
 msgid "lang_ipk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1303
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1338
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3814
+#: sonar/common/jsonschemas/language-v1.0.0.json:1300
 msgid "lang_ira"
 msgstr "irana (alia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1307
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1342
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3818
+#: sonar/common/jsonschemas/language-v1.0.0.json:1304
 msgid "lang_iro"
 msgstr "irokeza (alia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1311
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1346
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3822
+#: sonar/common/jsonschemas/language-v1.0.0.json:1308
 msgid "lang_ita"
 msgstr "itala"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1316
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1351
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3827
+#: sonar/common/jsonschemas/language-v1.0.0.json:1313
 msgid "lang_jav"
 msgstr "java"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1320
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1355
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3831
+#: sonar/common/jsonschemas/language-v1.0.0.json:1317
 msgid "lang_jbo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1324
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1359
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3835
+#: sonar/common/jsonschemas/language-v1.0.0.json:1321
 msgid "lang_jpn"
 msgstr "japana"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1328
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1363
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3839
+#: sonar/common/jsonschemas/language-v1.0.0.json:1325
 msgid "lang_jpr"
 msgstr "judpersa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1332
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1367
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3843
+#: sonar/common/jsonschemas/language-v1.0.0.json:1329
 msgid "lang_jrb"
 msgstr "judaraba"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1336
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1371
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3847
+#: sonar/common/jsonschemas/language-v1.0.0.json:1333
 msgid "lang_kaa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1340
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1375
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3851
+#: sonar/common/jsonschemas/language-v1.0.0.json:1337
 msgid "lang_kab"
 msgstr "kabila"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1344
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1379
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3855
+#: sonar/common/jsonschemas/language-v1.0.0.json:1341
 msgid "lang_kac"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1348
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1383
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3859
+#: sonar/common/jsonschemas/language-v1.0.0.json:1345
 msgid "lang_kal"
 msgstr "gronlanda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1352
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1387
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3863
+#: sonar/common/jsonschemas/language-v1.0.0.json:1349
 msgid "lang_kam"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1356
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1391
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3867
+#: sonar/common/jsonschemas/language-v1.0.0.json:1353
 msgid "lang_kan"
 msgstr "kannada"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1360
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1395
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3871
+#: sonar/common/jsonschemas/language-v1.0.0.json:1357
 msgid "lang_kar"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1364
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1399
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3875
+#: sonar/common/jsonschemas/language-v1.0.0.json:1361
 msgid "lang_kas"
 msgstr "kaŝmira"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1368
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1403
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3879
+#: sonar/common/jsonschemas/language-v1.0.0.json:1365
 msgid "lang_kau"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1372
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1407
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3883
+#: sonar/common/jsonschemas/language-v1.0.0.json:1369
 msgid "lang_kaw"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1376
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1411
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3887
+#: sonar/common/jsonschemas/language-v1.0.0.json:1373
 msgid "lang_kaz"
 msgstr "kazaĥa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1380
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1415
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3891
+#: sonar/common/jsonschemas/language-v1.0.0.json:1377
 msgid "lang_kbd"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1384
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1419
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3895
+#: sonar/common/jsonschemas/language-v1.0.0.json:1381
 msgid "lang_kha"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1388
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1423
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3899
+#: sonar/common/jsonschemas/language-v1.0.0.json:1385
 msgid "lang_khi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1392
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1427
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3903
+#: sonar/common/jsonschemas/language-v1.0.0.json:1389
 msgid "lang_khm"
 msgstr "ĥmera"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1396
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1431
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3907
+#: sonar/common/jsonschemas/language-v1.0.0.json:1393
 msgid "lang_kho"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1400
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1435
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3911
+#: sonar/common/jsonschemas/language-v1.0.0.json:1397
 msgid "lang_kik"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1404
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1439
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3915
+#: sonar/common/jsonschemas/language-v1.0.0.json:1401
 msgid "lang_kin"
 msgstr "ruanda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1408
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1443
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3919
+#: sonar/common/jsonschemas/language-v1.0.0.json:1405
 msgid "lang_kir"
 msgstr "kirgiza"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1412
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1447
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3923
+#: sonar/common/jsonschemas/language-v1.0.0.json:1409
 msgid "lang_kmb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1416
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1451
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3927
+#: sonar/common/jsonschemas/language-v1.0.0.json:1413
 msgid "lang_kok"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1420
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1455
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3931
+#: sonar/common/jsonschemas/language-v1.0.0.json:1417
 msgid "lang_kom"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1424
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1459
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3935
+#: sonar/common/jsonschemas/language-v1.0.0.json:1421
 msgid "lang_kon"
 msgstr "konga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1428
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1463
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3939
+#: sonar/common/jsonschemas/language-v1.0.0.json:1425
 msgid "lang_kor"
 msgstr "korea"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1432
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1467
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3943
+#: sonar/common/jsonschemas/language-v1.0.0.json:1429
 msgid "lang_kos"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1436
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1471
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3947
+#: sonar/common/jsonschemas/language-v1.0.0.json:1433
 msgid "lang_kpe"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1440
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1475
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3951
+#: sonar/common/jsonschemas/language-v1.0.0.json:1437
 msgid "lang_krc"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1444
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1479
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3955
+#: sonar/common/jsonschemas/language-v1.0.0.json:1441
 msgid "lang_krl"
 msgstr "karela"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1448
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1483
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3959
+#: sonar/common/jsonschemas/language-v1.0.0.json:1445
 msgid "lang_kro"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1452
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1487
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3963
+#: sonar/common/jsonschemas/language-v1.0.0.json:1449
 msgid "lang_kru"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1456
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1491
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3967
+#: sonar/common/jsonschemas/language-v1.0.0.json:1453
 msgid "lang_kua"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1460
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1495
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3971
+#: sonar/common/jsonschemas/language-v1.0.0.json:1457
 msgid "lang_kum"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1464
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1499
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3975
+#: sonar/common/jsonschemas/language-v1.0.0.json:1461
 msgid "lang_kur"
 msgstr "kurda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1468
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1503
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3979
+#: sonar/common/jsonschemas/language-v1.0.0.json:1465
 msgid "lang_kut"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1472
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1507
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3983
+#: sonar/common/jsonschemas/language-v1.0.0.json:1469
 msgid "lang_lad"
 msgstr "judhispana"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1476
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1511
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3987
+#: sonar/common/jsonschemas/language-v1.0.0.json:1473
 msgid "lang_lah"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1480
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1515
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3991
+#: sonar/common/jsonschemas/language-v1.0.0.json:1477
 msgid "lang_lam"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1484
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1519
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3995
+#: sonar/common/jsonschemas/language-v1.0.0.json:1481
 msgid "lang_lao"
 msgstr "laosa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1488
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1523
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3999
+#: sonar/common/jsonschemas/language-v1.0.0.json:1485
 msgid "lang_lat"
 msgstr "latino"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1492
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1527
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4003
+#: sonar/common/jsonschemas/language-v1.0.0.json:1489
 msgid "lang_lav"
 msgstr "latva"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1496
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1531
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4007
+#: sonar/common/jsonschemas/language-v1.0.0.json:1493
 msgid "lang_lez"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1500
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1535
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4011
+#: sonar/common/jsonschemas/language-v1.0.0.json:1497
 msgid "lang_lim"
 msgstr "limburga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1504
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1539
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4015
+#: sonar/common/jsonschemas/language-v1.0.0.json:1501
 msgid "lang_lin"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1508
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1543
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4019
+#: sonar/common/jsonschemas/language-v1.0.0.json:1505
 msgid "lang_lit"
 msgstr "litova"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1512
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1547
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4023
+#: sonar/common/jsonschemas/language-v1.0.0.json:1509
 msgid "lang_lol"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1516
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1551
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4027
+#: sonar/common/jsonschemas/language-v1.0.0.json:1513
 msgid "lang_loz"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1520
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1555
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4031
+#: sonar/common/jsonschemas/language-v1.0.0.json:1517
 msgid "lang_ltz"
 msgstr "luksemburga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1524
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1559
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4035
+#: sonar/common/jsonschemas/language-v1.0.0.json:1521
 msgid "lang_lua"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1528
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1563
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4039
+#: sonar/common/jsonschemas/language-v1.0.0.json:1525
 msgid "lang_lub"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1532
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1567
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4043
+#: sonar/common/jsonschemas/language-v1.0.0.json:1529
 msgid "lang_lug"
 msgstr "uganda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1536
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1571
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4047
+#: sonar/common/jsonschemas/language-v1.0.0.json:1533
 msgid "lang_lui"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1540
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1575
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4051
+#: sonar/common/jsonschemas/language-v1.0.0.json:1537
 msgid "lang_lun"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1544
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1579
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4055
+#: sonar/common/jsonschemas/language-v1.0.0.json:1541
 msgid "lang_luo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1548
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1583
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4059
+#: sonar/common/jsonschemas/language-v1.0.0.json:1545
 msgid "lang_lus"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1552
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1587
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4063
+#: sonar/common/jsonschemas/language-v1.0.0.json:1549
 msgid "lang_mac"
 msgstr "makedona"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1556
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1591
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4067
+#: sonar/common/jsonschemas/language-v1.0.0.json:1553
 msgid "lang_mad"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1560
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1595
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4071
+#: sonar/common/jsonschemas/language-v1.0.0.json:1557
 msgid "lang_mag"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1564
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1599
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4075
+#: sonar/common/jsonschemas/language-v1.0.0.json:1561
 msgid "lang_mah"
 msgstr "marŝala"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1568
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1603
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4079
+#: sonar/common/jsonschemas/language-v1.0.0.json:1565
 msgid "lang_mai"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1572
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1607
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4083
+#: sonar/common/jsonschemas/language-v1.0.0.json:1569
 msgid "lang_mak"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1576
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1611
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4087
+#: sonar/common/jsonschemas/language-v1.0.0.json:1573
 msgid "lang_mal"
 msgstr "malajala"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1580
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1615
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4091
+#: sonar/common/jsonschemas/language-v1.0.0.json:1577
 msgid "lang_man"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1584
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1619
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4095
+#: sonar/common/jsonschemas/language-v1.0.0.json:1581
 msgid "lang_mao"
 msgstr "maoria"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1588
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1623
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4099
+#: sonar/common/jsonschemas/language-v1.0.0.json:1585
 msgid "lang_map"
 msgstr "aŭstronezia (alia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1592
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1627
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4103
+#: sonar/common/jsonschemas/language-v1.0.0.json:1589
 msgid "lang_mar"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1596
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1631
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4107
+#: sonar/common/jsonschemas/language-v1.0.0.json:1593
 msgid "lang_mas"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1600
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1635
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4111
+#: sonar/common/jsonschemas/language-v1.0.0.json:1597
 msgid "lang_may"
 msgstr "malaja"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1604
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1639
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4115
+#: sonar/common/jsonschemas/language-v1.0.0.json:1601
 msgid "lang_mdf"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1608
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1643
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4119
+#: sonar/common/jsonschemas/language-v1.0.0.json:1605
 msgid "lang_mdr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1612
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1647
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4123
+#: sonar/common/jsonschemas/language-v1.0.0.json:1609
 msgid "lang_men"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1616
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1651
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4127
+#: sonar/common/jsonschemas/language-v1.0.0.json:1613
 msgid "lang_mga"
 msgstr "mezirlanda (1100–1550)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1620
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1655
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4131
+#: sonar/common/jsonschemas/language-v1.0.0.json:1617
 msgid "lang_mic"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1624
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1659
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4135
+#: sonar/common/jsonschemas/language-v1.0.0.json:1621
 msgid "lang_min"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1628
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1663
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4139
+#: sonar/common/jsonschemas/language-v1.0.0.json:1625
 msgid "lang_mis"
 msgstr "diversaj lingvoj"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1632
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1667
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4143
+#: sonar/common/jsonschemas/language-v1.0.0.json:1629
 msgid "lang_mkh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1636
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1671
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4147
+#: sonar/common/jsonschemas/language-v1.0.0.json:1633
 msgid "lang_mlg"
 msgstr "malagasa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1640
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1675
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4151
+#: sonar/common/jsonschemas/language-v1.0.0.json:1637
 msgid "lang_mlt"
 msgstr "malta"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1644
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1679
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4155
+#: sonar/common/jsonschemas/language-v1.0.0.json:1641
 msgid "lang_mnc"
 msgstr "manĉura"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1648
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1683
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4159
+#: sonar/common/jsonschemas/language-v1.0.0.json:1645
 msgid "lang_mni"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1652
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1687
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4163
+#: sonar/common/jsonschemas/language-v1.0.0.json:1649
 msgid "lang_mno"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1656
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1691
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4167
+#: sonar/common/jsonschemas/language-v1.0.0.json:1653
 msgid "lang_moh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1660
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1695
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4171
+#: sonar/common/jsonschemas/language-v1.0.0.json:1657
 msgid "lang_mon"
 msgstr "mongola"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1664
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1699
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4175
+#: sonar/common/jsonschemas/language-v1.0.0.json:1661
 msgid "lang_mos"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1668
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1703
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4179
+#: sonar/common/jsonschemas/language-v1.0.0.json:1665
 msgid "lang_mul"
 msgstr "pluraj lingvoj"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1672
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1707
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4183
+#: sonar/common/jsonschemas/language-v1.0.0.json:1669
 msgid "lang_mun"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1676
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1711
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4187
+#: sonar/common/jsonschemas/language-v1.0.0.json:1673
 msgid "lang_mus"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1680
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1715
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4191
+#: sonar/common/jsonschemas/language-v1.0.0.json:1677
 msgid "lang_mwl"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1684
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1719
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4195
+#: sonar/common/jsonschemas/language-v1.0.0.json:1681
 msgid "lang_mwr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1688
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1723
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4199
+#: sonar/common/jsonschemas/language-v1.0.0.json:1685
 msgid "lang_myn"
 msgstr "majaa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1692
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1727
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4203
+#: sonar/common/jsonschemas/language-v1.0.0.json:1689
 msgid "lang_myv"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1696
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1731
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4207
+#: sonar/common/jsonschemas/language-v1.0.0.json:1693
 msgid "lang_nah"
 msgstr "azteka"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1700
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1735
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4211
+#: sonar/common/jsonschemas/language-v1.0.0.json:1697
 msgid "lang_nai"
 msgstr "nord-amerika indiana (alia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1704
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1739
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4215
+#: sonar/common/jsonschemas/language-v1.0.0.json:1701
 msgid "lang_nap"
 msgstr "napola"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1708
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1743
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4219
+#: sonar/common/jsonschemas/language-v1.0.0.json:1705
 msgid "lang_nau"
 msgstr "naura"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1712
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1747
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4223
+#: sonar/common/jsonschemas/language-v1.0.0.json:1709
 msgid "lang_nav"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1716
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1751
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4227
+#: sonar/common/jsonschemas/language-v1.0.0.json:1713
 msgid "lang_nbl"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1720
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1755
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4231
+#: sonar/common/jsonschemas/language-v1.0.0.json:1717
 msgid "lang_nde"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1724
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1759
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4235
+#: sonar/common/jsonschemas/language-v1.0.0.json:1721
 msgid "lang_ndo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1728
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1763
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4239
+#: sonar/common/jsonschemas/language-v1.0.0.json:1725
 msgid "lang_nds"
 msgstr "malaltgermana"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1732
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1767
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4243
+#: sonar/common/jsonschemas/language-v1.0.0.json:1729
 msgid "lang_nep"
 msgstr "nepala"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1736
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1771
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4247
+#: sonar/common/jsonschemas/language-v1.0.0.json:1733
 msgid "lang_new"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1740
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1775
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4251
+#: sonar/common/jsonschemas/language-v1.0.0.json:1737
 msgid "lang_nia"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1744
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1779
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4255
+#: sonar/common/jsonschemas/language-v1.0.0.json:1741
 msgid "lang_nic"
 msgstr "niĝer-konga (alia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1748
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1783
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4259
+#: sonar/common/jsonschemas/language-v1.0.0.json:1745
 msgid "lang_niu"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1752
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1787
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4263
+#: sonar/common/jsonschemas/language-v1.0.0.json:1749
 msgid "lang_nno"
 msgstr "novnorvega"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1756
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1791
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4267
+#: sonar/common/jsonschemas/language-v1.0.0.json:1753
 msgid "lang_nob"
 msgstr "dannorvega"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1760
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1795
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4271
+#: sonar/common/jsonschemas/language-v1.0.0.json:1757
 msgid "lang_nog"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1764
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1799
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4275
+#: sonar/common/jsonschemas/language-v1.0.0.json:1761
 msgid "lang_non"
 msgstr "antikva nordia"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1768
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1803
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4279
+#: sonar/common/jsonschemas/language-v1.0.0.json:1765
 msgid "lang_nor"
 msgstr "norvega"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1772
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1807
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4283
+#: sonar/common/jsonschemas/language-v1.0.0.json:1769
 msgid "lang_nqo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1776
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1811
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4287
+#: sonar/common/jsonschemas/language-v1.0.0.json:1773
 msgid "lang_nso"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1780
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1815
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4291
+#: sonar/common/jsonschemas/language-v1.0.0.json:1777
 msgid "lang_nub"
 msgstr "nubia"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1784
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1819
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4295
+#: sonar/common/jsonschemas/language-v1.0.0.json:1781
 msgid "lang_nwc"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1788
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1823
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4299
+#: sonar/common/jsonschemas/language-v1.0.0.json:1785
 msgid "lang_nya"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1792
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1827
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4303
+#: sonar/common/jsonschemas/language-v1.0.0.json:1789
 msgid "lang_nym"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1796
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1831
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4307
+#: sonar/common/jsonschemas/language-v1.0.0.json:1793
 msgid "lang_nyn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1800
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1835
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4311
+#: sonar/common/jsonschemas/language-v1.0.0.json:1797
 msgid "lang_nyo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1804
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1839
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4315
+#: sonar/common/jsonschemas/language-v1.0.0.json:1801
 msgid "lang_nzi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1808
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1843
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4319
+#: sonar/common/jsonschemas/language-v1.0.0.json:1805
 msgid "lang_oci"
 msgstr "okcitana"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1812
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1847
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4323
+#: sonar/common/jsonschemas/language-v1.0.0.json:1809
 msgid "lang_oji"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1816
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1851
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4327
+#: sonar/common/jsonschemas/language-v1.0.0.json:1813
 msgid "lang_ori"
 msgstr "orisa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1820
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1855
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4331
+#: sonar/common/jsonschemas/language-v1.0.0.json:1817
 msgid "lang_orm"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1824
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1859
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4335
+#: sonar/common/jsonschemas/language-v1.0.0.json:1821
 msgid "lang_osa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1828
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1863
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4339
+#: sonar/common/jsonschemas/language-v1.0.0.json:1825
 msgid "lang_oss"
 msgstr "oseta"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1832
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1867
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4343
+#: sonar/common/jsonschemas/language-v1.0.0.json:1829
 msgid "lang_ota"
 msgstr "otomanturka"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1836
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1871
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4347
+#: sonar/common/jsonschemas/language-v1.0.0.json:1833
 msgid "lang_oto"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1840
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1875
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4351
+#: sonar/common/jsonschemas/language-v1.0.0.json:1837
 msgid "lang_paa"
 msgstr "papua (alia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1844
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1879
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4355
+#: sonar/common/jsonschemas/language-v1.0.0.json:1841
 msgid "lang_pag"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1848
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1883
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4359
+#: sonar/common/jsonschemas/language-v1.0.0.json:1845
 msgid "lang_pal"
 msgstr "mezpersa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1852
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1887
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4363
+#: sonar/common/jsonschemas/language-v1.0.0.json:1849
 msgid "lang_pam"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1856
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1891
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4367
+#: sonar/common/jsonschemas/language-v1.0.0.json:1853
 msgid "lang_pan"
 msgstr "panĝaba"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1860
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1895
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4371
+#: sonar/common/jsonschemas/language-v1.0.0.json:1857
 msgid "lang_pap"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1864
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1899
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4375
+#: sonar/common/jsonschemas/language-v1.0.0.json:1861
 msgid "lang_pau"
 msgstr "palaŭa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1868
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1903
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4379
+#: sonar/common/jsonschemas/language-v1.0.0.json:1865
 msgid "lang_peo"
 msgstr "malnovpersa (600–400 a.K.)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1872
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1907
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4383
+#: sonar/common/jsonschemas/language-v1.0.0.json:1869
 msgid "lang_per"
 msgstr "persa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1876
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1911
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4387
+#: sonar/common/jsonschemas/language-v1.0.0.json:1873
 msgid "lang_phi"
 msgstr "filipina (alia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1880
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1915
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4391
+#: sonar/common/jsonschemas/language-v1.0.0.json:1877
 msgid "lang_phn"
 msgstr "fenica"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1884
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1919
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4395
+#: sonar/common/jsonschemas/language-v1.0.0.json:1881
 msgid "lang_pli"
 msgstr "palia"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1888
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1923
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4399
+#: sonar/common/jsonschemas/language-v1.0.0.json:1885
 msgid "lang_pol"
 msgstr "pola"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1892
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1927
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4403
+#: sonar/common/jsonschemas/language-v1.0.0.json:1889
 msgid "lang_pon"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1896
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1931
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4407
+#: sonar/common/jsonschemas/language-v1.0.0.json:1893
 msgid "lang_por"
 msgstr "portugala"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1900
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1935
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4411
+#: sonar/common/jsonschemas/language-v1.0.0.json:1897
 msgid "lang_pra"
 msgstr "prakrito"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1904
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1939
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4415
+#: sonar/common/jsonschemas/language-v1.0.0.json:1901
 msgid "lang_pro"
 msgstr "antikva provenca (antaŭ 1500)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1908
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1943
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4419
+#: sonar/common/jsonschemas/language-v1.0.0.json:1905
 msgid "lang_pus"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1912
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1947
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4423
+#: sonar/common/jsonschemas/language-v1.0.0.json:1909
 msgid "lang_que"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1916
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1951
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4427
+#: sonar/common/jsonschemas/language-v1.0.0.json:1913
 msgid "lang_raj"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1920
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1955
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4431
+#: sonar/common/jsonschemas/language-v1.0.0.json:1917
 msgid "lang_rap"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1924
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1959
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4435
+#: sonar/common/jsonschemas/language-v1.0.0.json:1921
 msgid "lang_rar"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1928
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1963
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4439
+#: sonar/common/jsonschemas/language-v1.0.0.json:1925
 msgid "lang_roa"
 msgstr "latinida (alia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1932
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1967
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4443
+#: sonar/common/jsonschemas/language-v1.0.0.json:1929
 msgid "lang_roh"
 msgstr "romanĉa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1936
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1971
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4447
+#: sonar/common/jsonschemas/language-v1.0.0.json:1933
 msgid "lang_rom"
 msgstr "cigana"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1940
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1975
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4451
+#: sonar/common/jsonschemas/language-v1.0.0.json:1937
 msgid "lang_rum"
 msgstr "rumana"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1944
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1979
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4455
+#: sonar/common/jsonschemas/language-v1.0.0.json:1941
 msgid "lang_run"
 msgstr "burunda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1948
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1983
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4459
+#: sonar/common/jsonschemas/language-v1.0.0.json:1945
 msgid "lang_rup"
 msgstr "arumana"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1952
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1987
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4463
+#: sonar/common/jsonschemas/language-v1.0.0.json:1949
 msgid "lang_rus"
 msgstr "rusa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1956
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1991
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4467
+#: sonar/common/jsonschemas/language-v1.0.0.json:1953
 msgid "lang_sad"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1960
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1995
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4471
+#: sonar/common/jsonschemas/language-v1.0.0.json:1957
 msgid "lang_sag"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1964
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1999
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4475
+#: sonar/common/jsonschemas/language-v1.0.0.json:1961
 msgid "lang_sah"
 msgstr "jakuta"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1968
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2003
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4479
+#: sonar/common/jsonschemas/language-v1.0.0.json:1965
 msgid "lang_sai"
 msgstr "sud-amerika indiana (alia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1972
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2007
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4483
+#: sonar/common/jsonschemas/language-v1.0.0.json:1969
 msgid "lang_sal"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1976
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2011
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4487
+#: sonar/common/jsonschemas/language-v1.0.0.json:1973
 msgid "lang_sam"
 msgstr "samaria aramea"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1980
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2015
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4491
+#: sonar/common/jsonschemas/language-v1.0.0.json:1977
 msgid "lang_san"
 msgstr "sanskrito"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1984
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2019
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4495
+#: sonar/common/jsonschemas/language-v1.0.0.json:1981
 msgid "lang_sas"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1988
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2023
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4499
+#: sonar/common/jsonschemas/language-v1.0.0.json:1985
 msgid "lang_sat"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1992
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2027
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4503
+#: sonar/common/jsonschemas/language-v1.0.0.json:1989
 msgid "lang_scn"
 msgstr "sicilia"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1996
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2031
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4507
+#: sonar/common/jsonschemas/language-v1.0.0.json:1993
 msgid "lang_sco"
 msgstr "skota"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2000
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2035
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4511
+#: sonar/common/jsonschemas/language-v1.0.0.json:1997
 msgid "lang_sel"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2004
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2039
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4515
+#: sonar/common/jsonschemas/language-v1.0.0.json:2001
 msgid "lang_sem"
 msgstr "semida (alia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2008
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2043
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4519
+#: sonar/common/jsonschemas/language-v1.0.0.json:2005
 msgid "lang_sga"
 msgstr "antikva irlanda (antaŭ 1100)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2012
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2047
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4523
+#: sonar/common/jsonschemas/language-v1.0.0.json:2009
 msgid "lang_sgn"
 msgstr "gestolingvo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2016
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2051
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4527
+#: sonar/common/jsonschemas/language-v1.0.0.json:2013
 msgid "lang_shn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2020
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2055
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4531
+#: sonar/common/jsonschemas/language-v1.0.0.json:2017
 msgid "lang_sid"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2024
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2059
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4535
+#: sonar/common/jsonschemas/language-v1.0.0.json:2021
 msgid "lang_sin"
 msgstr "sinhalo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2028
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2063
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4539
+#: sonar/common/jsonschemas/language-v1.0.0.json:2025
 msgid "lang_sio"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2032
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2067
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4543
+#: sonar/common/jsonschemas/language-v1.0.0.json:2029
 msgid "lang_sit"
 msgstr "ĉintibeta (alia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2036
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2071
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4547
+#: sonar/common/jsonschemas/language-v1.0.0.json:2033
 msgid "lang_sla"
 msgstr "slava (alia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2040
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2075
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4551
+#: sonar/common/jsonschemas/language-v1.0.0.json:2037
 msgid "lang_slo"
 msgstr "slovaka"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2044
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2079
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4555
+#: sonar/common/jsonschemas/language-v1.0.0.json:2041
 msgid "lang_slv"
 msgstr "slovena"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2048
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2083
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4559
+#: sonar/common/jsonschemas/language-v1.0.0.json:2045
 msgid "lang_sma"
 msgstr "sudsamea"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2052
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2087
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4563
+#: sonar/common/jsonschemas/language-v1.0.0.json:2049
 msgid "lang_sme"
 msgstr "nordsamea"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2056
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2091
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4567
+#: sonar/common/jsonschemas/language-v1.0.0.json:2053
 msgid "lang_smi"
 msgstr "samea (alia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2060
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2095
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4571
+#: sonar/common/jsonschemas/language-v1.0.0.json:2057
 msgid "lang_smj"
 msgstr "samea de Lule"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2064
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2099
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4575
+#: sonar/common/jsonschemas/language-v1.0.0.json:2061
 msgid "lang_smn"
 msgstr "samea de Inari"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2068
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2103
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4579
+#: sonar/common/jsonschemas/language-v1.0.0.json:2065
 msgid "lang_smo"
 msgstr "samoa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2072
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2107
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4583
+#: sonar/common/jsonschemas/language-v1.0.0.json:2069
 msgid "lang_sms"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2076
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2111
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4587
+#: sonar/common/jsonschemas/language-v1.0.0.json:2073
 msgid "lang_sna"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2080
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2115
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4591
+#: sonar/common/jsonschemas/language-v1.0.0.json:2077
 msgid "lang_snd"
 msgstr "sinda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2084
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2119
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4595
+#: sonar/common/jsonschemas/language-v1.0.0.json:2081
 msgid "lang_snk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2088
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2123
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4599
+#: sonar/common/jsonschemas/language-v1.0.0.json:2085
 msgid "lang_sog"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2092
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2127
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4603
+#: sonar/common/jsonschemas/language-v1.0.0.json:2089
 msgid "lang_som"
 msgstr "somala"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2096
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2131
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4607
+#: sonar/common/jsonschemas/language-v1.0.0.json:2093
 msgid "lang_son"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2100
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2135
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4611
+#: sonar/common/jsonschemas/language-v1.0.0.json:2097
 msgid "lang_sot"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2104
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2139
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4615
+#: sonar/common/jsonschemas/language-v1.0.0.json:2101
 msgid "lang_spa"
 msgstr "hispana"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2108
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2143
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4619
+#: sonar/common/jsonschemas/language-v1.0.0.json:2105
 msgid "lang_srd"
 msgstr "sarda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2112
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2147
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4623
+#: sonar/common/jsonschemas/language-v1.0.0.json:2109
 msgid "lang_srn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2116
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2151
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4627
+#: sonar/common/jsonschemas/language-v1.0.0.json:2113
 msgid "lang_srp"
 msgstr "serba"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2120
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2155
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4631
+#: sonar/common/jsonschemas/language-v1.0.0.json:2117
 msgid "lang_srr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2124
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2159
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4635
+#: sonar/common/jsonschemas/language-v1.0.0.json:2121
 msgid "lang_ssa"
 msgstr "nil-sahara (alia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2128
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2163
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4639
+#: sonar/common/jsonschemas/language-v1.0.0.json:2125
 msgid "lang_ssw"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2132
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2167
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4643
+#: sonar/common/jsonschemas/language-v1.0.0.json:2129
 msgid "lang_suk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2136
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2171
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4647
+#: sonar/common/jsonschemas/language-v1.0.0.json:2133
 msgid "lang_sun"
 msgstr "sunda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2140
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2175
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4651
+#: sonar/common/jsonschemas/language-v1.0.0.json:2137
 msgid "lang_sus"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2144
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2179
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4655
+#: sonar/common/jsonschemas/language-v1.0.0.json:2141
 msgid "lang_sux"
 msgstr "sumera"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2148
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2183
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4659
+#: sonar/common/jsonschemas/language-v1.0.0.json:2145
 msgid "lang_swa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2152
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2187
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4663
+#: sonar/common/jsonschemas/language-v1.0.0.json:2149
 msgid "lang_swe"
 msgstr "sveda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2156
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2191
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4667
+#: sonar/common/jsonschemas/language-v1.0.0.json:2153
 msgid "lang_syc"
 msgstr "klasika siria"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2160
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2195
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4671
+#: sonar/common/jsonschemas/language-v1.0.0.json:2157
 msgid "lang_syr"
 msgstr "moderna siria"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2164
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2199
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4675
+#: sonar/common/jsonschemas/language-v1.0.0.json:2161
 msgid "lang_tah"
 msgstr "tahitia"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2168
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2203
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4679
+#: sonar/common/jsonschemas/language-v1.0.0.json:2165
 msgid "lang_tai"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2172
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2207
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4683
+#: sonar/common/jsonschemas/language-v1.0.0.json:2169
 msgid "lang_tam"
 msgstr "tamula"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2176
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2211
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4687
+#: sonar/common/jsonschemas/language-v1.0.0.json:2173
 msgid "lang_tat"
 msgstr "tatara"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2180
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2215
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4691
+#: sonar/common/jsonschemas/language-v1.0.0.json:2177
 msgid "lang_tel"
 msgstr "telugua"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2184
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2219
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4695
+#: sonar/common/jsonschemas/language-v1.0.0.json:2181
 msgid "lang_tem"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2188
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2223
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4699
+#: sonar/common/jsonschemas/language-v1.0.0.json:2185
 msgid "lang_ter"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2192
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2227
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4703
+#: sonar/common/jsonschemas/language-v1.0.0.json:2189
 msgid "lang_tet"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2196
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2231
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4707
+#: sonar/common/jsonschemas/language-v1.0.0.json:2193
 msgid "lang_tgk"
 msgstr "taĝika"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2200
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2235
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4711
+#: sonar/common/jsonschemas/language-v1.0.0.json:2197
 msgid "lang_tgl"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2204
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2239
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4715
+#: sonar/common/jsonschemas/language-v1.0.0.json:2201
 msgid "lang_tha"
 msgstr "taja"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2208
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2243
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4719
+#: sonar/common/jsonschemas/language-v1.0.0.json:2205
 msgid "lang_tib"
 msgstr "tibeta"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2212
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2247
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4723
+#: sonar/common/jsonschemas/language-v1.0.0.json:2209
 msgid "lang_tig"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2216
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2251
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4727
+#: sonar/common/jsonschemas/language-v1.0.0.json:2213
 msgid "lang_tir"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2220
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2255
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4731
+#: sonar/common/jsonschemas/language-v1.0.0.json:2217
 msgid "lang_tiv"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2224
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2259
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4735
+#: sonar/common/jsonschemas/language-v1.0.0.json:2221
 msgid "lang_tkl"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2228
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2263
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4739
+#: sonar/common/jsonschemas/language-v1.0.0.json:2225
 msgid "lang_tlh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2232
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2267
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4743
+#: sonar/common/jsonschemas/language-v1.0.0.json:2229
 msgid "lang_tli"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2236
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2271
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4747
+#: sonar/common/jsonschemas/language-v1.0.0.json:2233
 msgid "lang_tmh"
 msgstr "tuarega"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2240
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2275
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4751
+#: sonar/common/jsonschemas/language-v1.0.0.json:2237
 msgid "lang_tog"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2244
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2279
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4755
+#: sonar/common/jsonschemas/language-v1.0.0.json:2241
 msgid "lang_ton"
 msgstr "tonga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2248
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2283
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4759
+#: sonar/common/jsonschemas/language-v1.0.0.json:2245
 msgid "lang_tpi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2252
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2287
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4763
+#: sonar/common/jsonschemas/language-v1.0.0.json:2249
 msgid "lang_tsi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2256
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2291
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4767
+#: sonar/common/jsonschemas/language-v1.0.0.json:2253
 msgid "lang_tsn"
 msgstr "bocvana"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2260
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2295
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4771
+#: sonar/common/jsonschemas/language-v1.0.0.json:2257
 msgid "lang_tso"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2264
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2299
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4775
+#: sonar/common/jsonschemas/language-v1.0.0.json:2261
 msgid "lang_tuk"
 msgstr "turkmena"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2268
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2303
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4779
+#: sonar/common/jsonschemas/language-v1.0.0.json:2265
 msgid "lang_tum"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2272
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2307
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4783
+#: sonar/common/jsonschemas/language-v1.0.0.json:2269
 msgid "lang_tup"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2276
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2311
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4787
+#: sonar/common/jsonschemas/language-v1.0.0.json:2273
 msgid "lang_tur"
 msgstr "turka"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2280
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2315
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4791
+#: sonar/common/jsonschemas/language-v1.0.0.json:2277
 msgid "lang_tut"
 msgstr "altaja (alia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2284
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2319
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4795
+#: sonar/common/jsonschemas/language-v1.0.0.json:2281
 msgid "lang_tvl"
 msgstr "tuvala"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2288
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2323
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4799
+#: sonar/common/jsonschemas/language-v1.0.0.json:2285
 msgid "lang_twi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2292
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2327
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4803
+#: sonar/common/jsonschemas/language-v1.0.0.json:2289
 msgid "lang_tyv"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2296
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2331
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4807
+#: sonar/common/jsonschemas/language-v1.0.0.json:2293
 msgid "lang_udm"
 msgstr "udmurta"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2300
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2335
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4811
+#: sonar/common/jsonschemas/language-v1.0.0.json:2297
 msgid "lang_uga"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2304
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2339
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4815
+#: sonar/common/jsonschemas/language-v1.0.0.json:2301
 msgid "lang_uig"
 msgstr "ujgura"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2308
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2343
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4819
+#: sonar/common/jsonschemas/language-v1.0.0.json:2305
 msgid "lang_ukr"
 msgstr "ukraina"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2312
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2347
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4823
+#: sonar/common/jsonschemas/language-v1.0.0.json:2309
 msgid "lang_umb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2316
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2351
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4827
+#: sonar/common/jsonschemas/language-v1.0.0.json:2313
 msgid "lang_und"
 msgstr "Ne determinita lingvo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2320
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2355
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4831
+#: sonar/common/jsonschemas/language-v1.0.0.json:2317
 msgid "lang_urd"
 msgstr "urduo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2324
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2359
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4835
+#: sonar/common/jsonschemas/language-v1.0.0.json:2321
 msgid "lang_uzb"
 msgstr "uzbeka"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2328
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2363
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4839
+#: sonar/common/jsonschemas/language-v1.0.0.json:2325
 msgid "lang_vai"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2332
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2367
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4843
+#: sonar/common/jsonschemas/language-v1.0.0.json:2329
 msgid "lang_ven"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2336
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2371
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4847
+#: sonar/common/jsonschemas/language-v1.0.0.json:2333
 msgid "lang_vie"
 msgstr "vjetnama"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2340
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2375
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4851
+#: sonar/common/jsonschemas/language-v1.0.0.json:2337
 msgid "lang_vol"
 msgstr "Volapuko"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2344
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2379
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4855
+#: sonar/common/jsonschemas/language-v1.0.0.json:2341
 msgid "lang_vot"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2348
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2383
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4859
+#: sonar/common/jsonschemas/language-v1.0.0.json:2345
 msgid "lang_wak"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2352
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2387
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4863
+#: sonar/common/jsonschemas/language-v1.0.0.json:2349
 msgid "lang_wal"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2356
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2391
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4867
+#: sonar/common/jsonschemas/language-v1.0.0.json:2353
 msgid "lang_war"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2360
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2395
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4871
+#: sonar/common/jsonschemas/language-v1.0.0.json:2357
 msgid "lang_was"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2364
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2399
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4875
+#: sonar/common/jsonschemas/language-v1.0.0.json:2361
 msgid "lang_wel"
 msgstr "kimra"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2368
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2403
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4879
+#: sonar/common/jsonschemas/language-v1.0.0.json:2365
 msgid "lang_wen"
 msgstr "soraba (alia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2372
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2407
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4883
+#: sonar/common/jsonschemas/language-v1.0.0.json:2369
 msgid "lang_wln"
 msgstr "valona"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2376
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2411
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4887
+#: sonar/common/jsonschemas/language-v1.0.0.json:2373
 msgid "lang_wol"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2380
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2415
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4891
+#: sonar/common/jsonschemas/language-v1.0.0.json:2377
 msgid "lang_xal"
 msgstr "kalmuka"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2384
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2419
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4895
+#: sonar/common/jsonschemas/language-v1.0.0.json:2381
 msgid "lang_xho"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2388
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2423
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4899
+#: sonar/common/jsonschemas/language-v1.0.0.json:2385
 msgid "lang_yao"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2392
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2427
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4903
+#: sonar/common/jsonschemas/language-v1.0.0.json:2389
 msgid "lang_yap"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2396
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2431
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4907
+#: sonar/common/jsonschemas/language-v1.0.0.json:2393
 msgid "lang_yid"
 msgstr "jido"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2400
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2435
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4911
+#: sonar/common/jsonschemas/language-v1.0.0.json:2397
 msgid "lang_yor"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2404
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2439
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4915
+#: sonar/common/jsonschemas/language-v1.0.0.json:2401
 msgid "lang_ypk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2408
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2443
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4919
+#: sonar/common/jsonschemas/language-v1.0.0.json:2405
 msgid "lang_zap"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2412
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2447
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4923
+#: sonar/common/jsonschemas/language-v1.0.0.json:2409
 msgid "lang_zbl"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2416
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2451
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4927
+#: sonar/common/jsonschemas/language-v1.0.0.json:2413
 msgid "lang_zen"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2420
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2455
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4931
+#: sonar/common/jsonschemas/language-v1.0.0.json:2417
 msgid "lang_zha"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2424
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2459
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4935
+#: sonar/common/jsonschemas/language-v1.0.0.json:2421
 msgid "lang_znd"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2428
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2463
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4939
+#: sonar/common/jsonschemas/language-v1.0.0.json:2425
 msgid "lang_zul"
 msgstr "zulua"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2432
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2467
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4943
+#: sonar/common/jsonschemas/language-v1.0.0.json:2429
 msgid "lang_zun"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2436
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2471
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4947
+#: sonar/common/jsonschemas/language-v1.0.0.json:2433
 msgid "lang_zxx"
 msgstr "neniu lingva enhavao"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2440
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2475
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4951
+#: sonar/common/jsonschemas/language-v1.0.0.json:2437
 msgid "lang_zza"
 msgstr ""
 
@@ -5700,12 +4805,11 @@ msgstr ""
 msgid "mainTeam"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:923
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1743
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1034
 msgid "name"
 msgstr "nomo"
 
-#: sonar/modules/documents/views.py:172
+#: sonar/modules/documents/views.py:178
 msgid "no."
 msgstr "n-ro"
 
@@ -5713,11 +4817,11 @@ msgstr "n-ro"
 msgid "other files"
 msgstr "aliaj dosieroj"
 
-#: sonar/modules/documents/views.py:176
+#: sonar/modules/documents/views.py:182
 msgid "p."
 msgstr "p."
 
-#: sonar/config.py:546
+#: sonar/config.py:570
 msgid "pid"
 msgstr "PID"
 
@@ -5781,7 +4885,7 @@ msgstr ""
 msgid "startDate"
 msgstr ""
 
-#: sonar/config.py:547
+#: sonar/config.py:571
 msgid "status"
 msgstr "stato"
 
@@ -5795,15 +4899,55 @@ msgstr "subtenata de"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:489
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:808
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1615
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1627
 msgid "uri"
 msgstr "URI"
 
-#: sonar/config.py:548
+#: sonar/config.py:572
 msgid "user"
 msgstr "uzanto"
 
-#: sonar/modules/documents/views.py:168
+#: sonar/translations/manual_translations.txt:59
+msgid "validation_action_approve"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:61
+msgid "validation_action_ask_for_changes"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:58
+msgid "validation_action_publish"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:60
+msgid "validation_action_reject"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:57
+msgid "validation_action_save"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:54
+msgid "validation_status_ask_for_changes"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:50
+msgid "validation_status_in_progress"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:53
+msgid "validation_status_rejected"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:51
+msgid "validation_status_to_validate"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:52
+msgid "validation_status_validated"
+msgstr ""
+
+#: sonar/modules/documents/views.py:174
 msgid "vol."
 msgstr "vol."
 
@@ -5816,4 +4960,19 @@ msgstr ""
 
 #~ msgid "\\u200bSwiss National Science Foundation"
 #~ msgstr ""
+
+#~ msgid "Editors"
+#~ msgstr "Redaktoroj"
+
+#~ msgid "In the format \\"
+#~ msgstr ""
+
+#~ msgid "Not OA / Rights reserved"
+#~ msgstr ""
+
+#~ msgid "Other OA / license undefined"
+#~ msgstr ""
+
+#~ msgid "Specific collections"
+#~ msgstr "Specifaj kolektoj"
 

--- a/sonar/translations/fr/LC_MESSAGES/messages.po
+++ b/sonar/translations/fr/LC_MESSAGES/messages.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
 "Report-Msgid-Bugs-To: nicolas.prongue@rero.ch\n"
-"POT-Creation-Date: 2021-06-01 15:56+0200\n"
-"PO-Revision-Date: 2021-05-27 12:34+0000\n"
+"POT-Creation-Date: 2021-06-14 13:34+0200\n"
+"PO-Revision-Date: 2021-06-11 07:32+0000\n"
 "Last-Translator: Nicolas Prongué <n.prongue@outlook.com>\n"
 "Language: fr\n"
 "Language-Team: French "
@@ -23,7 +23,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.1\n"
 
-#: sonar/theme/views.py:65
+#: sonar/theme/views.py:67
 #, python-format
 msgid "%(icon)s Profile"
 msgstr "%(icon)s Mon compte"
@@ -36,13 +36,13 @@ msgstr ""
 msgid "About SONAR"
 msgstr "À propos de SONAR"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:681
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:697
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:795
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:811
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:663
 msgid "Abstract"
 msgstr "Résumé"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:678
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:792
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:659
 msgid "Abstracts"
 msgstr "Résumés"
@@ -60,10 +60,11 @@ msgid "Accompanying material of the resource, i.e. maps."
 msgstr "Matériel d'accompagnement, par ex. plans."
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:844
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1651
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1663
 msgid "Acquisition terms"
 msgstr "Modalité d'acquisition"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:77
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:210
 msgid "Action"
 msgstr "Action"
@@ -76,7 +77,11 @@ msgstr ""
 msgid "Actor involved"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:933
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:704
+msgid "Add a new collection"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1044
 msgid "Add a new project"
 msgstr "Ajouter un nouveau projet"
 
@@ -89,14 +94,13 @@ msgstr "Matériel supplémentaire"
 msgid "Administration"
 msgstr "Administration"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:834
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1009
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1367
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:948
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1383
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:203
 msgid "Affiliation"
 msgstr "Affiliation"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1180
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1196
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:159
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:250
 msgid "Agent"
@@ -134,9 +138,13 @@ msgstr ""
 "Doit contenir au moins 3 caractères (uniquement des minuscules ou des "
 "underscores)."
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1484
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1496
 msgid "Author or editor"
 msgstr "Auteur ou éditeur"
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:612
+msgid "Authors / Editors"
+msgstr ""
 
 #: sonar/modules/documents/templates/documents/record.html:44
 #: sonar/theme/templates/sonar/projects/detail.html:15
@@ -147,7 +155,7 @@ msgstr "Retour"
 msgid "Back to SONAR"
 msgstr "Retour à SONAR"
 
-#: sonar/config.py:584
+#: sonar/config.py:608
 msgid "Best match"
 msgstr "Meilleure correspondance"
 
@@ -163,12 +171,12 @@ msgstr ""
 msgid "Brief description of the report"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1788
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:30
 msgid "Bronze"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4993
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5008
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:110
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:125
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:20
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:34
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:15
@@ -186,35 +194,35 @@ msgstr "Seau UUID pour le stockage des fichiers"
 msgid "CAS or DAS"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:27
+#: sonar/common/jsonschemas/license-v1.0.0.json:28
 msgid "CC BY"
 msgstr "CC BY"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:31
+#: sonar/common/jsonschemas/license-v1.0.0.json:32
 msgid "CC BY-NC"
 msgstr "CC BY-NC"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:35
+#: sonar/common/jsonschemas/license-v1.0.0.json:36
 msgid "CC BY-NC-ND"
 msgstr "CC BY-NC-ND"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:39
+#: sonar/common/jsonschemas/license-v1.0.0.json:40
 msgid "CC BY-NC-SA"
 msgstr "CC BY-NC-SA"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:43
+#: sonar/common/jsonschemas/license-v1.0.0.json:44
 msgid "CC BY-ND"
 msgstr "CC BY-ND"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:47
+#: sonar/common/jsonschemas/license-v1.0.0.json:48
 msgid "CC BY-SA"
 msgstr "CC BY-SA"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:23
+#: sonar/common/jsonschemas/license-v1.0.0.json:24
 msgid "CC0"
 msgstr "CC0"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5033
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:150
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:59
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:58
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:266
@@ -226,16 +234,16 @@ msgid "City"
 msgstr "Ville"
 
 #: sonar/common/jsonschemas/classification-v1.0.0.json:2
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1015
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1031
 #: sonar/modules/documents/templates/documents/record.html:262
 msgid "Classification"
 msgstr "Classification"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1066
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1082
 msgid "Classification portion"
 msgstr "Indice de classification"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1011
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1027
 msgid "Classifications"
 msgstr "Classifications"
 
@@ -247,26 +255,35 @@ msgstr ""
 msgid "Click here to reset your password"
 msgstr "Cliquez ici pour réinitialiser votre mot de passe"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1792
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:34
 msgid "Closed"
-msgstr ""
+msgstr "Fermé"
 
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:18
 msgid "Code"
 msgstr "Code"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:999
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:680
 msgid "Collection"
 msgstr "Collection"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:4
+#: sonar/modules/collections/templates/collections/index.html:21
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:676
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:995
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:999
+#: sonar/modules/documents/templates/documents/record.html:288
 msgid "Collections"
 msgstr "Collections"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:106
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:245
 msgid "Comment"
 msgstr "Commentaire"
+
+#: sonar/common/jsonschemas/validation-v1.0.0.json:107
+msgid "Comment associated with the current action."
+msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:513
 msgid "Company"
@@ -284,37 +301,41 @@ msgstr "Confirmer l'e-mail"
 msgid "Contact"
 msgstr "Contact"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1094
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:540
+msgid "Contained in (journal, book, proceedings)"
+msgstr ""
+
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1110
 msgid "Content note"
 msgstr "Note de contenu"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1090
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1106
 msgid "Content notes"
 msgstr "Notes de contenu"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1175
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1480
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1191
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1492
 msgid "Contribution"
 msgstr "Contribution"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1171
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1187
 msgid "Contributions"
 msgstr "Contributions"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:814
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:928
 msgid "Contributor"
 msgstr "Contributeur"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:808
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:922
 msgid "Contributors"
 msgstr "Contributeurs"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1379
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1395
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:212
 msgid "Controlled affiliation"
 msgstr "Affiliation contrôlée"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1375
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1391
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:208
 msgid "Controlled affiliations"
 msgstr "Affiliations contrôlées"
@@ -324,27 +345,36 @@ msgstr "Affiliations contrôlées"
 msgid "Creativity, transformations and innovations in education"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:78
+msgid "Current action done in the validation process."
+msgstr ""
+
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:173
 msgid "Current cataloguing step."
 msgstr "Étape actuelle de catalogage."
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1799
+#: sonar/common/jsonschemas/validation-v1.0.0.json:65
+msgid "Current status of the record in the validation process."
+msgstr ""
+
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1774
 msgid "Custom field 1"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1819
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1794
 msgid "Custom field 2"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1839
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1814
 msgid "Custom field 3"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:42
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:240
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:777
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:891
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:496
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1123
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1295
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1139
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1311
 msgid "Date"
 msgstr "Date"
 
@@ -356,14 +386,18 @@ msgstr "Date selon le format YYYY-MM-JJ, ex : 1970-01-01"
 msgid "Date of approval by the Team Leader"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1271
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1287
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:34
 msgid "Date of birth"
 msgstr "Date de naissance"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1279
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1295
 msgid "Date of death"
 msgstr "Date de décès"
+
+#: sonar/common/jsonschemas/validation-v1.0.0.json:43
+msgid "Date when the log is created."
+msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:640
 msgid "Dean of a school"
@@ -374,8 +408,8 @@ msgstr ""
 msgid "Dear %(email)s"
 msgstr "Cher/Chère %(email)s"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:762
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1108
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:876
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1124
 msgid "Degree"
 msgstr "Diplôme"
 
@@ -391,20 +425,22 @@ msgstr "Refus du dépôt"
 msgid "Deposit to validate"
 msgstr "Dépôt à valider"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5003
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:120
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:30
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:236
 msgid "Describes the information of a single file in the record."
 msgstr "Décrit l'information d'un seul fichier dans la ressource."
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2497
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:941
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:56
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:740
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1052
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:38
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:55
 msgid "Description"
 msgstr "Description"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2493
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:52
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:736
 msgid "Descriptions"
 msgstr ""
 
@@ -420,8 +456,8 @@ msgstr ""
 msgid "Director, head of establishment"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:757
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1103
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:871
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1119
 msgid "Dissertation"
 msgstr "Thèse"
 
@@ -437,12 +473,12 @@ msgstr ""
 msgid "Doctorate supported by the HEP-VS"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:558
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1117
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:556
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1124
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:3
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:958
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1411
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1445
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1423
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1457
 msgid "Document"
 msgstr "Document"
 
@@ -450,7 +486,7 @@ msgstr "Document"
 msgid "Document ID"
 msgstr "Identifiant du document"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1118
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1125
 msgid "Document created on basis of this deposit."
 msgstr "Document créé sur la base de ce dépôt."
 
@@ -486,10 +522,6 @@ msgstr "E-mail"
 msgid "Edition"
 msgstr "Édition"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:596
-msgid "Editors"
-msgstr "Éditeurs"
-
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:211
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:273
 msgid "Education, childhood and the learning Society 21"
@@ -518,7 +550,7 @@ msgid "Emotions, learning, and well-being at school"
 msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:80
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:959
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1075
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:79
 msgid "End date"
 msgstr "Date de fin"
@@ -546,8 +578,15 @@ msgstr ""
 "Entrez votre adresse e-mail ci-dessous et nous vous enverrons un lien "
 "pour réinitialiser votre mot de passe."
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:886
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1020
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:569
+msgid "Example: 1"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:586
+msgid "Example: 10"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1000
 msgid "Example: 1111-2222-3333-4444"
 msgstr "Exemple : 1111-2222-3333-4444"
 
@@ -556,13 +595,11 @@ msgstr "Exemple : 1111-2222-3333-4444"
 msgid "Example: 2019 or 2019-01-01"
 msgstr "Exemple : 2019 ou 2019-01-01"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:782
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1127
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:896
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1143
 msgid "Example: 2019 or 2019-05-05"
 msgstr "Exemple : 2019 ou 2019-05-05"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:953
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:960
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:153
 msgid "Example: 2019-05-05"
 msgstr "Exemple : 2019-05-05"
@@ -573,6 +610,8 @@ msgstr "Exemple : 2020"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:75
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:88
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1070
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1082
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:74
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:87
 msgid "Example: 2020-12-01"
@@ -586,17 +625,17 @@ msgstr "Exemple : Doe"
 msgid "Example: John"
 msgstr "Exemple : John"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1488
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1500
 msgid "Example: Muller, Hans"
 msgstr "Exemple : Muller, Hans"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:638
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:655
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:977
 msgid "Example: Published version"
 msgstr "Exemple : Version publiée"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:591
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1441
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:602
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1453
 msgid "Examples: 135, 5-27, …"
 msgstr "Exemples : 135, 5-27, …"
 
@@ -604,7 +643,11 @@ msgstr "Exemples : 135, 5-27, …"
 msgid "Except within organisation"
 msgstr "Sauf au sein de l'organisation"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:913
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:685
+msgid "Existing collection"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1024
 msgid "Existing project"
 msgstr "Projet existant"
 
@@ -632,20 +675,20 @@ msgstr ""
 msgid "External partners are involved"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5013
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:130
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:39
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:35
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:246
 msgid "File UUID"
 msgstr "UUID du fichier"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5002
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:119
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:29
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:235
 msgid "File item"
 msgstr "Fichier"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4998
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:115
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:25
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:21
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:231
@@ -696,7 +739,7 @@ msgstr "Format, par ex. dimensions en cm."
 msgid "Formats"
 msgstr "Formats"
 
-#: sonar/config.py:72
+#: sonar/config.py:74
 msgid "French"
 msgstr "Français"
 
@@ -717,12 +760,10 @@ msgstr ""
 msgid "Funding number"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1048
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:245
 msgid "Funding organisation"
 msgstr "Agence de financement"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1045
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:241
 #: sonar/theme/templates/sonar/projects/detail.html:64
 msgid "Funding organisations"
@@ -736,20 +777,20 @@ msgstr ""
 msgid "Funding was granted for the project"
 msgstr ""
 
-#: sonar/config.py:72
+#: sonar/config.py:74
 msgid "German"
 msgstr "Allemand"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1780
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:22
 msgid "Gold"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:772
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1118
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:886
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1134
 msgid "Granting institution"
 msgstr "Institution qui contribue"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1776
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:18
 msgid "Green"
 msgstr ""
 
@@ -777,7 +818,7 @@ msgstr "Le balisage HTML est admis."
 msgid "Harvested"
 msgstr "Moissonné"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:18
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:18
 msgid "Hash key"
 msgstr ""
 
@@ -785,8 +826,8 @@ msgstr ""
 msgid "Help & Documentation"
 msgstr "Aide & documentation"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:559
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1451
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:557
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1463
 msgid ""
 "Host document, for example a journal for an article, or a book for a book"
 " chapter."
@@ -798,7 +839,7 @@ msgstr ""
 msgid "How are research results used in training?"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1784
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:26
 msgid "Hybrid"
 msgstr ""
 
@@ -807,24 +848,22 @@ msgid "IR hosting service"
 msgstr "Service d'hébergement IR"
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:867
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1674
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1686
 msgid "ISBN/ISSN status should be selected in the list below."
 msgstr "Le statut de l'ISBN/ISSN doit être sélectionné dans la liste."
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1220
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1236
 msgid "Identified by"
 msgstr "Identifié par"
 
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:2
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:3
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:9
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:13
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:13
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:15
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:360
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:966
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1058
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:693
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1500
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1512
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:13
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:13
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:9
@@ -835,7 +874,7 @@ msgstr "Identifiant"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:357
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:689
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1496
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1508
 #: sonar/modules/documents/templates/documents/record.html:237
 msgid "Identifiers"
 msgstr "Identifiants"
@@ -851,10 +890,6 @@ msgstr "Si ce champ est utilisé, le fichier pointe vers l'URL spécifiée."
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:316
 msgid "In progress"
 msgstr ""
-
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:597
-msgid "In the format \\"
-msgstr "Au format \"Nom, prénom\""
 
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:118
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:165
@@ -882,12 +917,10 @@ msgstr ""
 msgid "Invenio"
 msgstr "Invenio"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:974
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:154
 msgid "Investigator"
 msgstr "Chercheur"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:971
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:150
 #: sonar/theme/templates/sonar/projects/detail.html:35
 msgid "Investigators"
@@ -901,21 +934,21 @@ msgstr "Est une organisation dédiée"
 msgid "Is shared"
 msgstr "Apparaît dans le portail partagé"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1429
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1441
 msgid "Issue"
 msgstr "Numéro"
 
-#: sonar/config.py:73
+#: sonar/config.py:75
 msgid "Italian"
 msgstr "Italien"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:767
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1113
-#: sonar/modules/documents/views.py:234
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:881
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1129
+#: sonar/modules/documents/views.py:240
 msgid "Jury note"
 msgstr "Note du jury"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5023
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:140
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:49
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:47
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:256
@@ -926,7 +959,12 @@ msgstr "Clé"
 msgid "Key (filename) of the file."
 msgstr "Clé du fichier (nom de fichier)."
 
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:835
+msgid "Keyword"
+msgstr ""
+
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:391
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:832
 msgid "Keywords"
 msgstr ""
 
@@ -934,7 +972,7 @@ msgstr ""
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:69
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:503
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:903
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1154
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1170
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:94
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:141
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:188
@@ -948,8 +986,6 @@ msgid "Labels"
 msgstr ""
 
 #: sonar/common/jsonschemas/language-v1.0.0.json:2
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:37
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2513
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:354
 #: sonar/modules/documents/templates/documents/record.html:221
 msgid "Language"
@@ -972,7 +1008,7 @@ msgstr "Dernière mise à jour OAI-PMH (horodatage formaté selon ISO8601)"
 msgid "Last name"
 msgstr "Nom de famille"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:829
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:943
 msgid "Last name, first name, ex: Doe, John"
 msgstr "Nom, prénom, ex : Dupont, Jean"
 
@@ -981,9 +1017,13 @@ msgid "Lecturer/professor"
 msgstr ""
 
 #: sonar/common/jsonschemas/license-v1.0.0.json:2
-#: sonar/modules/documents/templates/documents/record.html:288
+#: sonar/modules/documents/templates/documents/record.html:306
 msgid "License"
 msgstr "Licence"
+
+#: sonar/common/jsonschemas/license-v1.0.0.json:52
+msgid "License undefined"
+msgstr ""
 
 #: sonar/theme/templates/sonar/projects/detail.html:79
 msgid "Linked documents"
@@ -1001,17 +1041,22 @@ msgstr ""
 "uniquement au sein de l'organisation. Note : les notices bibliographiques"
 " (métadonnées) sont toujours publiques. Entrer une règle par ligne."
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4999
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:116
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:26
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:22
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:232
 msgid "List of files attached to the record."
 msgstr "Liste des fichiers liés à la ressource."
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:21
+msgid "List of logs."
+msgstr ""
+
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:878
 msgid "Locality (Valais)"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:25
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:188
 msgid "Log"
 msgstr "Log"
@@ -1046,11 +1091,12 @@ msgstr ""
 msgid "Logout"
 msgstr "Se déconnecter"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:20
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:184
 msgid "Logs"
 msgstr "Logs"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5034
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:151
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:60
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:59
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:267
@@ -1069,11 +1115,11 @@ msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:291
 msgid "Main title"
-msgstr "Titre propre"
+msgstr "Titre"
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:287
 msgid "Main titles"
-msgstr "Titres propres"
+msgstr "Titres"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:836
 msgid "Mandate"
@@ -1091,38 +1137,38 @@ msgstr ""
 msgid "Mediator"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5028
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:145
 msgid "Mimetype"
 msgstr ""
 
-#: sonar/config.py:578
+#: sonar/config.py:602
 msgid "Most recent"
 msgstr "Plus récent"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:356
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:535
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:898
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:27
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:828
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:936
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:979
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1053
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:27
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:711
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:942
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1047
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:33
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:50
 msgid "Name"
 msgstr "Nom"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:23
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:23
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:707
 msgid "Names"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:55
-msgid "Not OA / Rights reserved"
-msgstr "Pas OA / Droits réservés"
+#: sonar/modules/collections/templates/collections/index.html:32
+msgid "No collection found"
+msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:650
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:828
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1635
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1647
 msgid "Note"
 msgstr "Note"
 
@@ -1139,8 +1185,8 @@ msgid "Notes"
 msgstr "Notes"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:741
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:577
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1303
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:579
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1319
 msgid "Number"
 msgstr "Numéro"
 
@@ -1160,8 +1206,7 @@ msgstr "Sets OAI-PMH."
 msgid "OAI-PMH specific information."
 msgstr "Informations spécifiques à OAI-PMH."
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:880
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1014
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:994
 msgid "ORCID"
 msgstr "ORCID"
 
@@ -1170,18 +1215,17 @@ msgstr "ORCID"
 msgid "Object type"
 msgstr "Type d'objet"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1760
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:2
 msgid "Open access status"
 msgstr "Statut Open Access"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:93
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4969
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4973
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:86
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:90
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:222
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:5
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:84
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:287
-#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:291
 msgid "Organisation"
 msgstr "Organisation"
 
@@ -1204,7 +1248,7 @@ msgstr "Organisations"
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:720
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:890
 msgid "Other"
-msgstr ""
+msgstr "Autre"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:517
 msgid "Other (free field)"
@@ -1222,26 +1266,22 @@ msgstr ""
 "Autres caractéristiques matérielles, par ex. illustrations, noir et "
 "blanc, ou couleurs."
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:51
-msgid "Other OA / license undefined"
-msgstr "Autre OA / licence indéfinie"
-
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:882
 msgid "Other canton (Switzerland)"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:624
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:641
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:953
 #: sonar/modules/documents/templates/documents/record.html:208
 msgid "Other electronic version"
 msgstr "Autre version électronique"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:621
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:638
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:949
 msgid "Other electronic versions"
 msgstr "Autres versions électroniques"
 
-#: sonar/modules/documents/templates/documents/record.html:311
+#: sonar/modules/documents/templates/documents/record.html:329
 msgid "Other files"
 msgstr "Autres fichiers"
 
@@ -1254,8 +1294,8 @@ msgstr ""
 msgid "PID type"
 msgstr "Type de PID"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:585
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1437
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:596
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1449
 msgid "Pages"
 msgstr "Pages"
 
@@ -1263,8 +1303,7 @@ msgstr "Pages"
 msgid "Parents"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:540
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1407
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1419
 msgid "Part of (host document)"
 msgstr "Contenu dans (document hôte)"
 
@@ -1276,7 +1315,7 @@ msgstr ""
 msgid "Period"
 msgstr "Période"
 
-#: sonar/modules/documents/templates/documents/record.html:301
+#: sonar/modules/documents/templates/documents/record.html:319
 msgid "Permalink"
 msgstr "Permalien"
 
@@ -1293,7 +1332,7 @@ msgstr "Numéro de téléphone"
 msgid "Phone number with the international prefix, without spaces."
 msgstr "Numéro de téléphone avec l'indicatif international, sans espaces."
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1287
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1303
 msgid "Place"
 msgstr "Lieu"
 
@@ -1304,6 +1343,15 @@ msgstr ""
 #: sonar/templates/security/email/welcome.html:5
 msgid "Please confirm your e-mail by clicking here"
 msgstr "Veuillez confirmer votre e-mail en cliquant ici"
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:573
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:590
+msgid "Please enter a valid number."
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:606
+msgid "Please enter a valid pages range, example: 135, 5-27."
+msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:85
 msgid "Position"
@@ -1334,13 +1382,13 @@ msgstr ""
 msgid "Practitioner-trainer"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1210
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1226
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:164
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:255
 msgid "Preferred name"
 msgstr "Nom privilégié"
 
-#: sonar/modules/documents/templates/documents/record.html:329
+#: sonar/modules/documents/templates/documents/record.html:347
 #: sonar/theme/templates/sonar/preview/base.html:23
 msgid "Preview"
 msgstr "Aperçu"
@@ -1360,11 +1408,11 @@ msgstr ""
 
 #: sonar/theme/templates/sonar/partial/dropdown_user.html:21
 #: sonar/theme/templates/sonar/partial/dropdown_user.html:24
-#: sonar/theme/views.py:66
+#: sonar/theme/views.py:68
 msgid "Profile"
 msgstr "Profil"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:916
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1027
 msgid "Project"
 msgstr "Projet"
 
@@ -1404,12 +1452,12 @@ msgstr "Accès public depuis"
 msgid "Public foundation"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:633
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:650
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:973
 msgid "Public note"
 msgstr "Note publique"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1456
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1468
 msgid "Publication"
 msgstr "Publication"
 
@@ -1422,12 +1470,12 @@ msgid "Published in"
 msgstr "Publié dans"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:332
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:606
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:623
 msgid "Publisher"
 msgstr "Éditeur"
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:836
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1643
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1655
 msgid "Qualifier"
 msgstr "Qualificatif"
 
@@ -1435,15 +1483,19 @@ msgstr "Qualificatif"
 msgid "Realization framework"
 msgstr ""
 
+#: sonar/modules/validation/api.py:216
+msgid "Record validation"
+msgstr ""
+
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:4
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:908
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1732
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1019
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1744
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:4
 msgid "Research project"
 msgstr "Projet de recherche"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:901
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1728
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1015
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1740
 #: sonar/modules/documents/templates/documents/record.html:183
 msgid "Research projects"
 msgstr "Projets de recherche"
@@ -1459,15 +1511,18 @@ msgstr "Réinitialiser le mot de passe"
 msgid "Responsibility"
 msgstr "Mention de responsabilité"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:839
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:984
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1330
+#: sonar/common/jsonschemas/license-v1.0.0.json:56
+msgid "Rights reserved"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:953
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1346
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:99
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:181
 msgid "Role"
 msgstr "Rôle"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1326
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1342
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:177
 msgid "Roles"
 msgstr "Rôles"
@@ -1490,6 +1545,10 @@ msgstr "Logo de SONAR"
 msgid "Schema"
 msgstr "Schéma"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:3
+msgid "Schema representing a validation workflow."
+msgstr ""
+
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:9
 msgid "Schema to validate document against."
 msgstr "Schéma de validation des notices bibliographiques."
@@ -1504,6 +1563,10 @@ msgstr ""
 #: sonar/theme/templates/sonar/partial/organisation.html:21
 msgid "Search"
 msgstr "Recherche"
+
+#: sonar/modules/collections/templates/collections/item.html:48
+msgid "Search in collection"
+msgstr ""
 
 #: sonar/theme/templates/sonar/frontpage.html:57
 msgid "Search publications, authors, projects..."
@@ -1562,14 +1625,14 @@ msgstr "S'inscrire avec %(type)s"
 msgid "Sign-up with SWITCHaai"
 msgstr "S'inscrire avec SWITCHaai"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5039
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:156
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:65
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:64
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:272
 msgid "Size"
 msgstr "Taille"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5040
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:157
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:66
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:65
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:273
@@ -1584,8 +1647,8 @@ msgstr ""
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:510
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:849
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:926
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1245
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1656
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1261
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1668
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:117
 msgid "Source"
 msgstr "Source"
@@ -1598,13 +1661,9 @@ msgstr "Code source sur"
 msgid "Special education teacher"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:659
-msgid "Specific collections"
-msgstr "Collections spécifiques"
-
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:67
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:952
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1461
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1063
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1473
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:66
 msgid "Start date"
 msgstr "Date de début"
@@ -1630,7 +1689,7 @@ msgid "State of Valais, parastatal institution"
 msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:474
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1466
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1478
 msgid "Statement"
 msgstr "Mention"
 
@@ -1638,10 +1697,11 @@ msgstr "Mention"
 msgid "Statements"
 msgstr "Mentions"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:64
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:39
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:136
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:860
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1667
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1679
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:39
 msgid "Status"
 msgstr "Statut"
@@ -1670,14 +1730,11 @@ msgstr ""
 msgid "Student in training"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:721
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:898
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:915
 msgid "Subject"
 msgstr "Sujet"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:718
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:737
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:894
 msgid "Subjects"
 msgstr "Sujets"
@@ -1699,7 +1756,7 @@ msgstr "Super administration"
 msgid "Suspended"
 msgstr ""
 
-#: sonar/config.py:94 sonar/config.py:98
+#: sonar/config.py:96 sonar/config.py:100
 msgid "Swiss Open Access Repository"
 msgstr "Swiss Open Access Repository"
 
@@ -1735,7 +1792,7 @@ msgstr ""
 "scientifiques. Elle recueille et promeut les publications en libre accès "
 "de personnes affiliées aux institutions publiques suisses de recherche."
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:660
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:677
 msgid ""
 "The names of the organisation's specific/patrimonial collections to which"
 " this document belongs"
@@ -1766,7 +1823,7 @@ msgstr ""
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:304
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:264
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:627
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1450
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1462
 msgid "Title"
 msgstr "Titre"
 
@@ -1810,11 +1867,11 @@ msgstr ""
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:449
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:478
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:698
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1022
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1052
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1185
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1225
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1505
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1038
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1068
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1201
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1241
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1517
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:97
 msgid "Type"
 msgstr "Type"
@@ -1827,7 +1884,7 @@ msgstr ""
 msgid "Type of the file"
 msgstr "Type du fichier"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:643
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:660
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:963
 msgid "URL"
 msgstr "URL"
@@ -1844,10 +1901,12 @@ msgstr "UUID de l’objet ObjectVersion."
 msgid "UUID of the bucket the tile is assigned to."
 msgstr "UUID du bucket à laquelle est assignée la tuile."
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1146
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1162
 msgid "Usage and access policy"
-msgstr "Politique d'utilisation et d'accès"
+msgstr "Politique d'usage et d'accès"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:90
+#: sonar/common/jsonschemas/validation-v1.0.0.json:96
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:116
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:121
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:120
@@ -1855,15 +1914,25 @@ msgstr "Politique d'utilisation et d'accès"
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:198
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:202
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:5
-#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:311
-#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:316
+#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:310
+#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:315
 msgid "User"
 msgstr "utilisateur"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:91
+msgid "User which created the record."
+msgstr ""
+
+#: sonar/common/jsonschemas/validation-v1.0.0.json:2
+msgid "Validation"
+msgstr ""
+
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:39
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:32
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2502
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:32
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:61
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:505
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:716
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:745
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:296
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:320
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:405
@@ -1872,8 +1941,8 @@ msgstr "utilisateur"
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:668
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:823
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:911
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1256
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1630
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1272
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1642
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:99
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:146
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:193
@@ -1881,7 +1950,11 @@ msgstr "utilisateur"
 msgid "Value"
 msgstr "Valeur"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5018
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:851
+msgid "Values"
+msgstr ""
+
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:135
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:44
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:41
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:251
@@ -1892,8 +1965,8 @@ msgstr "UUID de la version"
 msgid "Vice-rector HE"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:569
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1421
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:562
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1433
 msgid "Volume"
 msgstr "Volume"
 
@@ -1901,7 +1974,7 @@ msgstr "Volume"
 msgid "Welcome to SONAR"
 msgstr "Bienvenue sur SONAR"
 
-#: sonar/config.py:125
+#: sonar/config.py:127
 msgid "Welcome to SONAR, the Swiss Open Access Repository!"
 msgstr "Bienvenue à SONAR, le Swiss Open Access Repository !"
 
@@ -1933,8 +2006,7 @@ msgstr ""
 msgid "Why?"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:564
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1416
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1428
 msgid "Year"
 msgstr "Année"
 
@@ -1956,78 +2028,78 @@ msgstr "agent"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:417
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:728
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1535
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1547
 msgid "bf:AudioIssueNumber"
 msgstr "Référence de l'éditeur (documents audio)"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1049
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1065
 msgid "bf:ClassificationDdc"
 msgstr "Classification CDD"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1019
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1035
 msgid "bf:ClassificationUdc"
 msgstr "Classification CDU"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:402
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:732
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1539
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1551
 msgid "bf:Doi"
 msgstr "DOI"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:421
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:736
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1543
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1555
 msgid "bf:Ean"
 msgstr "EAN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:425
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:740
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1547
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1559
 msgid "bf:Gtin14Number"
 msgstr "GTIN-14"
 
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:17
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:429
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:744
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1234
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1551
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1250
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1563
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:106
 msgid "bf:Identifier"
 msgstr "Identifiant"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:433
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:748
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1555
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1567
 msgid "bf:Isan"
 msgstr "ISAN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:412
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:752
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1559
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1571
 msgid "bf:Isbn"
 msgstr "ISBN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:437
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:756
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1563
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1575
 msgid "bf:Ismn"
 msgstr "ISMN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:441
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:760
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1567
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1579
 msgid "bf:Isrc"
 msgstr "ISRC"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:445
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:764
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1571
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1583
 msgid "bf:Issn"
 msgstr "ISSN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:449
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:768
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1575
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1587
 msgid "bf:IssnL"
 msgstr "ISSN-L"
 
@@ -2038,8 +2110,8 @@ msgstr "langue"
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:21
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:453
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:772
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1238
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1579
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1254
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1591
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:110
 msgid "bf:Local"
 msgstr "Identifiant local"
@@ -2050,37 +2122,37 @@ msgstr "Fabrication"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:457
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:776
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1583
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1595
 msgid "bf:MatrixNumber"
 msgstr "Numéro de matrice (sons)"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1203
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1219
 msgid "bf:Meeting"
 msgstr "Conférence"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:461
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:780
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1587
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1599
 msgid "bf:MusicDistributorNumber"
 msgstr "Référence du distributeur (musique)"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:465
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:784
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1591
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1603
 msgid "bf:MusicPlate"
 msgstr "Cotage (partitions)"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:469
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:788
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1595
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1607
 msgid "bf:MusicPublisherNumber"
 msgstr "Autre référence de l'éditeur (musique)"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1199
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1215
 msgid "bf:Organization"
 msgstr "Collectivité"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1195
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1211
 msgid "bf:Person"
 msgstr "Personne"
 
@@ -2094,41 +2166,41 @@ msgstr "Publication"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:473
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:792
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1599
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1611
 msgid "bf:PublisherNumber"
 msgstr "Numéro de l'éditeur"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:493
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:812
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1619
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1631
 msgid "bf:ReportNumber"
 msgstr "Numéro de rapport"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:497
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:816
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1623
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1635
 msgid "bf:Strn"
 msgstr "STRN"
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:280
 msgid "bf:Title"
-msgstr "titre"
+msgstr "titre propre"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:477
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:796
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1603
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1615
 msgid "bf:Upc"
 msgstr "UPC"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:481
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:800
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1607
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1619
 msgid "bf:Urn"
 msgstr "URN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:485
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:804
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1611
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1623
 msgid "bf:VideoRecordingNumber"
 msgstr "Numéro d'enregistrement vidéo"
 
@@ -2492,41 +2564,40 @@ msgstr "Libre accès"
 msgid "coar:c_f1cf"
 msgstr "Sous embargo"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1002
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:195
 msgid "coinvestigator"
 msgstr "co-chercheur"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:857
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1351
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:971
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1367
 msgid "contribution_role_cre"
 msgstr "Auteur / créateur"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:861
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1359
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:975
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1375
 msgid "contribution_role_ctb"
 msgstr "Contributeur"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:869
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1343
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:983
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1359
 msgid "contribution_role_dgs"
 msgstr "Superviseur académique"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:865
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1355
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:979
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1371
 msgid "contribution_role_edt"
 msgstr "Éditeur intellectuel"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:873
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1347
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:987
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1363
 msgid "contribution_role_prt"
 msgstr "Imprimeur"
 
-#: sonar/modules/documents/views.py:266
+#: sonar/modules/documents/views.py:272
 msgid "contribution_role_{role}"
 msgstr "contribution_role_{role}"
 
-#: sonar/config.py:549
+#: sonar/config.py:573
 msgid "contributor"
 msgstr "Contributeur"
 
@@ -2810,7 +2881,6 @@ msgstr ""
 msgid "innerSearcher"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:998
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:191
 msgid "investigator"
 msgstr "chercheur"
@@ -2819,2913 +2889,1948 @@ msgstr "chercheur"
 msgid "keywords"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:500
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:535
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3011
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:694
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1010
+msgid "label"
+msgstr ""
+
+#: sonar/common/jsonschemas/language-v1.0.0.json:497
 msgid "lang_aar"
 msgstr "afar"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:504
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:539
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3015
+#: sonar/common/jsonschemas/language-v1.0.0.json:501
 msgid "lang_abk"
 msgstr "abkhaze"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:508
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:543
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3019
+#: sonar/common/jsonschemas/language-v1.0.0.json:505
 msgid "lang_ace"
 msgstr "aceh"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:512
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:547
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3023
+#: sonar/common/jsonschemas/language-v1.0.0.json:509
 msgid "lang_ach"
 msgstr "acoli"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:516
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:551
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3027
+#: sonar/common/jsonschemas/language-v1.0.0.json:513
 msgid "lang_ada"
 msgstr "adangme"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:520
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:555
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3031
+#: sonar/common/jsonschemas/language-v1.0.0.json:517
 msgid "lang_ady"
 msgstr "adyguéen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:524
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:559
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3035
+#: sonar/common/jsonschemas/language-v1.0.0.json:521
 msgid "lang_afa"
 msgstr "afro-asiatiques, autres langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:528
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:563
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3039
+#: sonar/common/jsonschemas/language-v1.0.0.json:525
 msgid "lang_afh"
 msgstr "afrihili"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:532
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:567
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3043
+#: sonar/common/jsonschemas/language-v1.0.0.json:529
 msgid "lang_afr"
 msgstr "afrikaans"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:536
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:571
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3047
+#: sonar/common/jsonschemas/language-v1.0.0.json:533
 msgid "lang_ain"
 msgstr "aïnou"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:540
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:575
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3051
+#: sonar/common/jsonschemas/language-v1.0.0.json:537
 msgid "lang_aka"
 msgstr "akan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:544
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:579
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3055
+#: sonar/common/jsonschemas/language-v1.0.0.json:541
 msgid "lang_akk"
 msgstr "akkadien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:548
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:583
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3059
+#: sonar/common/jsonschemas/language-v1.0.0.json:545
 msgid "lang_alb"
 msgstr "albanais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:552
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:587
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3063
+#: sonar/common/jsonschemas/language-v1.0.0.json:549
 msgid "lang_ale"
 msgstr "aléoute"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:556
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:591
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3067
+#: sonar/common/jsonschemas/language-v1.0.0.json:553
 msgid "lang_alg"
 msgstr "algonquines, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:560
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:595
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3071
+#: sonar/common/jsonschemas/language-v1.0.0.json:557
 msgid "lang_alt"
 msgstr "altaï du Sud"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:564
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:599
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3075
+#: sonar/common/jsonschemas/language-v1.0.0.json:561
 msgid "lang_amh"
 msgstr "amharique"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:568
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:603
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3079
+#: sonar/common/jsonschemas/language-v1.0.0.json:565
 msgid "lang_ang"
 msgstr "ancien anglais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:572
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:607
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3083
+#: sonar/common/jsonschemas/language-v1.0.0.json:569
 msgid "lang_anp"
 msgstr "angika"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:576
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:611
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3087
+#: sonar/common/jsonschemas/language-v1.0.0.json:573
 msgid "lang_apa"
 msgstr "apaches, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:580
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:615
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3091
+#: sonar/common/jsonschemas/language-v1.0.0.json:577
 msgid "lang_ara"
 msgstr "arabe"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:584
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:619
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3095
+#: sonar/common/jsonschemas/language-v1.0.0.json:581
 msgid "lang_arc"
 msgstr "araméen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:588
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:623
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3099
+#: sonar/common/jsonschemas/language-v1.0.0.json:585
 msgid "lang_arg"
 msgstr "aragonais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:592
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:627
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3103
+#: sonar/common/jsonschemas/language-v1.0.0.json:589
 msgid "lang_arm"
 msgstr "arménien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:596
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:631
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3107
+#: sonar/common/jsonschemas/language-v1.0.0.json:593
 msgid "lang_arn"
 msgstr "mapuche"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:600
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:635
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3111
+#: sonar/common/jsonschemas/language-v1.0.0.json:597
 msgid "lang_arp"
 msgstr "arapaho"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:604
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:639
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3115
+#: sonar/common/jsonschemas/language-v1.0.0.json:601
 msgid "lang_art"
 msgstr "artificielles, autres langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:608
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:643
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3119
+#: sonar/common/jsonschemas/language-v1.0.0.json:605
 msgid "lang_arw"
 msgstr "arawak"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:612
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:647
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3123
+#: sonar/common/jsonschemas/language-v1.0.0.json:609
 msgid "lang_asm"
 msgstr "assamais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:616
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:651
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3127
+#: sonar/common/jsonschemas/language-v1.0.0.json:613
 msgid "lang_ast"
 msgstr "asturien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:620
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:655
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3131
+#: sonar/common/jsonschemas/language-v1.0.0.json:617
 msgid "lang_ath"
 msgstr "athapascanes, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:624
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:659
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3135
+#: sonar/common/jsonschemas/language-v1.0.0.json:621
 msgid "lang_aus"
 msgstr "australiennes, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:628
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:663
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3139
+#: sonar/common/jsonschemas/language-v1.0.0.json:625
 msgid "lang_ava"
 msgstr "avar"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:632
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:667
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3143
+#: sonar/common/jsonschemas/language-v1.0.0.json:629
 msgid "lang_ave"
 msgstr "avestique"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:636
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:671
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3147
+#: sonar/common/jsonschemas/language-v1.0.0.json:633
 msgid "lang_awa"
 msgstr "awadhi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:640
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:675
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3151
+#: sonar/common/jsonschemas/language-v1.0.0.json:637
 msgid "lang_aym"
 msgstr "aymara"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:644
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:679
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3155
+#: sonar/common/jsonschemas/language-v1.0.0.json:641
 msgid "lang_aze"
 msgstr "azéri"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:648
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:683
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3159
+#: sonar/common/jsonschemas/language-v1.0.0.json:645
 msgid "lang_bad"
 msgstr "banda, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:652
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:687
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3163
+#: sonar/common/jsonschemas/language-v1.0.0.json:649
 msgid "lang_bai"
 msgstr "bamilékés, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:656
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:691
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3167
+#: sonar/common/jsonschemas/language-v1.0.0.json:653
 msgid "lang_bak"
 msgstr "bachkir"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:660
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:695
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3171
+#: sonar/common/jsonschemas/language-v1.0.0.json:657
 msgid "lang_bal"
 msgstr "baloutchi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:664
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:699
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3175
+#: sonar/common/jsonschemas/language-v1.0.0.json:661
 msgid "lang_bam"
 msgstr "bambara"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:668
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:703
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3179
+#: sonar/common/jsonschemas/language-v1.0.0.json:665
 msgid "lang_ban"
 msgstr "balinais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:672
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:707
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3183
+#: sonar/common/jsonschemas/language-v1.0.0.json:669
 msgid "lang_baq"
 msgstr "basque"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:676
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:711
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3187
+#: sonar/common/jsonschemas/language-v1.0.0.json:673
 msgid "lang_bas"
 msgstr "bassa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:680
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:715
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3191
+#: sonar/common/jsonschemas/language-v1.0.0.json:677
 msgid "lang_bat"
 msgstr "baltes, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:684
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:719
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3195
+#: sonar/common/jsonschemas/language-v1.0.0.json:681
 msgid "lang_bej"
 msgstr "bedja"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:688
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:723
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3199
+#: sonar/common/jsonschemas/language-v1.0.0.json:685
 msgid "lang_bel"
 msgstr "biélorusse"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:692
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:727
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3203
+#: sonar/common/jsonschemas/language-v1.0.0.json:689
 msgid "lang_bem"
 msgstr "bemba"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:696
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:731
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3207
+#: sonar/common/jsonschemas/language-v1.0.0.json:693
 msgid "lang_ben"
 msgstr "bengali"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:700
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:735
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3211
+#: sonar/common/jsonschemas/language-v1.0.0.json:697
 msgid "lang_ber"
 msgstr "berbères, autres langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:704
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:739
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3215
+#: sonar/common/jsonschemas/language-v1.0.0.json:701
 msgid "lang_bho"
 msgstr "bhodjpouri"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:708
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:743
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3219
+#: sonar/common/jsonschemas/language-v1.0.0.json:705
 msgid "lang_bih"
 msgstr "bihari"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:712
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:747
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3223
+#: sonar/common/jsonschemas/language-v1.0.0.json:709
 msgid "lang_bik"
 msgstr "bikol"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:716
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:751
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3227
+#: sonar/common/jsonschemas/language-v1.0.0.json:713
 msgid "lang_bin"
 msgstr "bini"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:720
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:755
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3231
+#: sonar/common/jsonschemas/language-v1.0.0.json:717
 msgid "lang_bis"
 msgstr "bichelamar"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:724
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:759
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3235
+#: sonar/common/jsonschemas/language-v1.0.0.json:721
 msgid "lang_bla"
 msgstr "siksika"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:728
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:763
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3239
+#: sonar/common/jsonschemas/language-v1.0.0.json:725
 msgid "lang_bnt"
 msgstr "bantoues, autres langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:732
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:767
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3243
+#: sonar/common/jsonschemas/language-v1.0.0.json:729
 msgid "lang_bos"
 msgstr "bosniaque"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:736
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:771
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3247
+#: sonar/common/jsonschemas/language-v1.0.0.json:733
 msgid "lang_bra"
 msgstr "braj"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:740
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:775
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3251
+#: sonar/common/jsonschemas/language-v1.0.0.json:737
 msgid "lang_bre"
 msgstr "breton"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:744
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:779
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3255
+#: sonar/common/jsonschemas/language-v1.0.0.json:741
 msgid "lang_btk"
 msgstr "batak, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:748
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:783
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3259
+#: sonar/common/jsonschemas/language-v1.0.0.json:745
 msgid "lang_bua"
 msgstr "bouriate"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:752
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:787
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3263
+#: sonar/common/jsonschemas/language-v1.0.0.json:749
 msgid "lang_bug"
 msgstr "bugi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:756
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:791
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3267
+#: sonar/common/jsonschemas/language-v1.0.0.json:753
 msgid "lang_bul"
 msgstr "bulgare"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:760
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:795
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3271
+#: sonar/common/jsonschemas/language-v1.0.0.json:757
 msgid "lang_bur"
 msgstr "birman"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:764
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:799
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3275
+#: sonar/common/jsonschemas/language-v1.0.0.json:761
 msgid "lang_byn"
 msgstr "blin"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:768
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:803
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3279
+#: sonar/common/jsonschemas/language-v1.0.0.json:765
 msgid "lang_cad"
 msgstr "caddo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:772
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:807
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3283
+#: sonar/common/jsonschemas/language-v1.0.0.json:769
 msgid "lang_cai"
 msgstr "indiennes d'Amérique centrale, autres langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:776
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:811
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3287
+#: sonar/common/jsonschemas/language-v1.0.0.json:773
 msgid "lang_car"
 msgstr "caribe"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:780
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:815
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3291
+#: sonar/common/jsonschemas/language-v1.0.0.json:777
 msgid "lang_cat"
 msgstr "catalan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:784
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:819
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3295
+#: sonar/common/jsonschemas/language-v1.0.0.json:781
 msgid "lang_cau"
 msgstr "caucasiens, autres langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:788
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:823
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3299
+#: sonar/common/jsonschemas/language-v1.0.0.json:785
 msgid "lang_ceb"
 msgstr "cebuano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:792
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:827
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3303
+#: sonar/common/jsonschemas/language-v1.0.0.json:789
 msgid "lang_cel"
 msgstr "celtique, autres langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:796
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:831
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3307
+#: sonar/common/jsonschemas/language-v1.0.0.json:793
 msgid "lang_cha"
 msgstr "chamorro"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:800
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:835
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3311
+#: sonar/common/jsonschemas/language-v1.0.0.json:797
 msgid "lang_chb"
 msgstr "chibcha"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:804
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:839
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3315
+#: sonar/common/jsonschemas/language-v1.0.0.json:801
 msgid "lang_che"
 msgstr "tchétchène"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:808
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:843
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3319
+#: sonar/common/jsonschemas/language-v1.0.0.json:805
 msgid "lang_chg"
 msgstr "tchaghataï"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:812
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:847
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3323
+#: sonar/common/jsonschemas/language-v1.0.0.json:809
 msgid "lang_chi"
 msgstr "chinois"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:816
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:851
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3327
+#: sonar/common/jsonschemas/language-v1.0.0.json:813
 msgid "lang_chk"
 msgstr "chuuk"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:820
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:855
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3331
+#: sonar/common/jsonschemas/language-v1.0.0.json:817
 msgid "lang_chm"
 msgstr "mari"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:824
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:859
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3335
+#: sonar/common/jsonschemas/language-v1.0.0.json:821
 msgid "lang_chn"
 msgstr "jargon chinook"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:828
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:863
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3339
+#: sonar/common/jsonschemas/language-v1.0.0.json:825
 msgid "lang_cho"
 msgstr "choctaw"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:832
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:867
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3343
+#: sonar/common/jsonschemas/language-v1.0.0.json:829
 msgid "lang_chp"
 msgstr "chipewyan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:836
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:871
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3347
+#: sonar/common/jsonschemas/language-v1.0.0.json:833
 msgid "lang_chr"
 msgstr "cherokee"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:840
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:875
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3351
+#: sonar/common/jsonschemas/language-v1.0.0.json:837
 msgid "lang_chu"
 msgstr "slavon d’église"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:844
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:879
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3355
+#: sonar/common/jsonschemas/language-v1.0.0.json:841
 msgid "lang_chv"
 msgstr "tchouvache"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:848
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:883
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3359
+#: sonar/common/jsonschemas/language-v1.0.0.json:845
 msgid "lang_chy"
 msgstr "cheyenne"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:852
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:887
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3363
+#: sonar/common/jsonschemas/language-v1.0.0.json:849
 msgid "lang_cmc"
 msgstr "chamic"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:856
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:891
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3367
+#: sonar/common/jsonschemas/language-v1.0.0.json:853
 msgid "lang_cnr"
 msgstr "monténégrin"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:860
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:895
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3371
+#: sonar/common/jsonschemas/language-v1.0.0.json:857
 msgid "lang_cop"
 msgstr "copte"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:864
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:899
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3375
+#: sonar/common/jsonschemas/language-v1.0.0.json:861
 msgid "lang_cor"
 msgstr "cornique"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:868
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:903
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3379
+#: sonar/common/jsonschemas/language-v1.0.0.json:865
 msgid "lang_cos"
 msgstr "corse"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:872
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:907
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3383
+#: sonar/common/jsonschemas/language-v1.0.0.json:869
 msgid "lang_cpe"
 msgstr "créoles et pidgins anglais, autres"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:876
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:911
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3387
+#: sonar/common/jsonschemas/language-v1.0.0.json:873
 msgid "lang_cpf"
 msgstr "créoles et pidgins français, autres"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:880
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:915
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3391
+#: sonar/common/jsonschemas/language-v1.0.0.json:877
 msgid "lang_cpp"
 msgstr "créoles et pidgins portugais, autres"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:884
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:919
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3395
+#: sonar/common/jsonschemas/language-v1.0.0.json:881
 msgid "lang_cre"
 msgstr "cree"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:888
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:923
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3399
+#: sonar/common/jsonschemas/language-v1.0.0.json:885
 msgid "lang_crh"
 msgstr "turc de Crimée"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:892
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:927
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3403
+#: sonar/common/jsonschemas/language-v1.0.0.json:889
 msgid "lang_crp"
 msgstr "créoles et pidgins divers"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:896
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:931
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3407
+#: sonar/common/jsonschemas/language-v1.0.0.json:893
 msgid "lang_csb"
 msgstr "kachoube"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:900
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:935
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3411
+#: sonar/common/jsonschemas/language-v1.0.0.json:897
 msgid "lang_cus"
 msgstr "couchitiques, autres langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:904
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:939
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3415
+#: sonar/common/jsonschemas/language-v1.0.0.json:901
 msgid "lang_cze"
 msgstr "tchèque"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:908
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:943
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3419
+#: sonar/common/jsonschemas/language-v1.0.0.json:905
 msgid "lang_dak"
 msgstr "dakota"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:912
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:947
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3423
+#: sonar/common/jsonschemas/language-v1.0.0.json:909
 msgid "lang_dan"
 msgstr "danois"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:916
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:951
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3427
+#: sonar/common/jsonschemas/language-v1.0.0.json:913
 msgid "lang_dar"
 msgstr "dargwa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:920
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:955
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3431
+#: sonar/common/jsonschemas/language-v1.0.0.json:917
 msgid "lang_day"
 msgstr "Land Dayak, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:924
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:959
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3435
+#: sonar/common/jsonschemas/language-v1.0.0.json:921
 msgid "lang_del"
 msgstr "delaware"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:928
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:963
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3439
+#: sonar/common/jsonschemas/language-v1.0.0.json:925
 msgid "lang_den"
 msgstr "esclave"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:932
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:967
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3443
+#: sonar/common/jsonschemas/language-v1.0.0.json:929
 msgid "lang_dgr"
 msgstr "dogrib"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:936
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:971
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3447
+#: sonar/common/jsonschemas/language-v1.0.0.json:933
 msgid "lang_din"
 msgstr "dinka"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:940
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:975
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3451
+#: sonar/common/jsonschemas/language-v1.0.0.json:937
 msgid "lang_div"
 msgstr "maldivien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:944
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:979
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3455
+#: sonar/common/jsonschemas/language-v1.0.0.json:941
 msgid "lang_doi"
 msgstr "dogri"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:948
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:983
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3459
+#: sonar/common/jsonschemas/language-v1.0.0.json:945
 msgid "lang_dra"
 msgstr "dravidiennes, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:952
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:987
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3463
+#: sonar/common/jsonschemas/language-v1.0.0.json:949
 msgid "lang_dsb"
 msgstr "bas-sorabe"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:956
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:991
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3467
+#: sonar/common/jsonschemas/language-v1.0.0.json:953
 msgid "lang_dua"
 msgstr "douala"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:960
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:995
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3471
+#: sonar/common/jsonschemas/language-v1.0.0.json:957
 msgid "lang_dum"
 msgstr "moyen néerlandais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:964
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:999
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3475
+#: sonar/common/jsonschemas/language-v1.0.0.json:961
 msgid "lang_dut"
 msgstr "néerlandais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:968
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1003
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3479
+#: sonar/common/jsonschemas/language-v1.0.0.json:965
 msgid "lang_dyu"
 msgstr "dioula"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:972
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1007
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3483
+#: sonar/common/jsonschemas/language-v1.0.0.json:969
 msgid "lang_dzo"
 msgstr "dzongkha"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:976
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1011
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3487
+#: sonar/common/jsonschemas/language-v1.0.0.json:973
 msgid "lang_efi"
 msgstr "éfik"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:980
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1015
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3491
+#: sonar/common/jsonschemas/language-v1.0.0.json:977
 msgid "lang_egy"
 msgstr "égyptien ancien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:984
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1019
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3495
+#: sonar/common/jsonschemas/language-v1.0.0.json:981
 msgid "lang_eka"
 msgstr "ékadjouk"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:988
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1023
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3499
+#: sonar/common/jsonschemas/language-v1.0.0.json:985
 msgid "lang_elx"
 msgstr "élamite"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:992
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1027
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3503
+#: sonar/common/jsonschemas/language-v1.0.0.json:989
 msgid "lang_eng"
 msgstr "anglais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:997
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1032
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3508
+#: sonar/common/jsonschemas/language-v1.0.0.json:994
 msgid "lang_enm"
 msgstr "moyen anglais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1001
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1036
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3512
+#: sonar/common/jsonschemas/language-v1.0.0.json:998
 msgid "lang_epo"
 msgstr "espéranto"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1005
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1040
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3516
+#: sonar/common/jsonschemas/language-v1.0.0.json:1002
 msgid "lang_est"
 msgstr "estonien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1009
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1044
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3520
+#: sonar/common/jsonschemas/language-v1.0.0.json:1006
 msgid "lang_ewe"
 msgstr "éwé"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1013
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1048
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3524
+#: sonar/common/jsonschemas/language-v1.0.0.json:1010
 msgid "lang_ewo"
 msgstr "éwondo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1017
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1052
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3528
+#: sonar/common/jsonschemas/language-v1.0.0.json:1014
 msgid "lang_fan"
 msgstr "fang"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1021
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1056
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3532
+#: sonar/common/jsonschemas/language-v1.0.0.json:1018
 msgid "lang_fao"
 msgstr "féroïen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1025
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1060
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3536
+#: sonar/common/jsonschemas/language-v1.0.0.json:1022
 msgid "lang_fat"
 msgstr "fanti"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1029
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1064
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3540
+#: sonar/common/jsonschemas/language-v1.0.0.json:1026
 msgid "lang_fij"
 msgstr "fidjien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1033
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1068
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3544
+#: sonar/common/jsonschemas/language-v1.0.0.json:1030
 msgid "lang_fil"
 msgstr "filipino"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1037
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1072
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3548
+#: sonar/common/jsonschemas/language-v1.0.0.json:1034
 msgid "lang_fin"
 msgstr "finnois"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1041
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1076
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3552
+#: sonar/common/jsonschemas/language-v1.0.0.json:1038
 msgid "lang_fiu"
 msgstr "finno-ougriennnes, autres langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1045
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1080
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3556
+#: sonar/common/jsonschemas/language-v1.0.0.json:1042
 msgid "lang_fon"
 msgstr "fon"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1049
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1084
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3560
+#: sonar/common/jsonschemas/language-v1.0.0.json:1046
 msgid "lang_fre"
 msgstr "français"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1054
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1089
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3565
+#: sonar/common/jsonschemas/language-v1.0.0.json:1051
 msgid "lang_frm"
 msgstr "moyen français"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1058
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1093
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3569
+#: sonar/common/jsonschemas/language-v1.0.0.json:1055
 msgid "lang_fro"
 msgstr "ancien français"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1062
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1097
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3573
+#: sonar/common/jsonschemas/language-v1.0.0.json:1059
 msgid "lang_frr"
 msgstr "frison du Nord"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1066
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1101
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3577
+#: sonar/common/jsonschemas/language-v1.0.0.json:1063
 msgid "lang_frs"
 msgstr "frison oriental"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1070
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1105
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3581
+#: sonar/common/jsonschemas/language-v1.0.0.json:1067
 msgid "lang_fry"
 msgstr "frison occidental"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1074
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1109
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3585
+#: sonar/common/jsonschemas/language-v1.0.0.json:1071
 msgid "lang_ful"
 msgstr "peul"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1078
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1113
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3589
+#: sonar/common/jsonschemas/language-v1.0.0.json:1075
 msgid "lang_fur"
 msgstr "frioulan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1082
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1117
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3593
+#: sonar/common/jsonschemas/language-v1.0.0.json:1079
 msgid "lang_gaa"
 msgstr "ga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1086
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1121
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3597
+#: sonar/common/jsonschemas/language-v1.0.0.json:1083
 msgid "lang_gay"
 msgstr "gayo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1090
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1125
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3601
+#: sonar/common/jsonschemas/language-v1.0.0.json:1087
 msgid "lang_gba"
 msgstr "gbaya"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1094
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1129
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3605
+#: sonar/common/jsonschemas/language-v1.0.0.json:1091
 msgid "lang_gem"
 msgstr "germaniques, autres langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1098
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1133
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3609
+#: sonar/common/jsonschemas/language-v1.0.0.json:1095
 msgid "lang_geo"
 msgstr "géorgien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1102
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1137
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3613
+#: sonar/common/jsonschemas/language-v1.0.0.json:1099
 msgid "lang_ger"
 msgstr "allemand"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1107
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1142
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3618
+#: sonar/common/jsonschemas/language-v1.0.0.json:1104
 msgid "lang_gez"
 msgstr "guèze"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1111
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1146
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3622
+#: sonar/common/jsonschemas/language-v1.0.0.json:1108
 msgid "lang_gil"
 msgstr "gilbertin"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1115
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1150
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3626
+#: sonar/common/jsonschemas/language-v1.0.0.json:1112
 msgid "lang_gla"
 msgstr "gaélique écossais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1119
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1154
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3630
+#: sonar/common/jsonschemas/language-v1.0.0.json:1116
 msgid "lang_gle"
 msgstr "irlandais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1123
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1158
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3634
+#: sonar/common/jsonschemas/language-v1.0.0.json:1120
 msgid "lang_glg"
 msgstr "galicien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1127
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1162
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3638
+#: sonar/common/jsonschemas/language-v1.0.0.json:1124
 msgid "lang_glv"
 msgstr "mannois"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1131
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1166
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3642
+#: sonar/common/jsonschemas/language-v1.0.0.json:1128
 msgid "lang_gmh"
 msgstr "moyen haut-allemand"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1135
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1170
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3646
+#: sonar/common/jsonschemas/language-v1.0.0.json:1132
 msgid "lang_goh"
 msgstr "ancien haut allemand"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1139
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1174
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3650
+#: sonar/common/jsonschemas/language-v1.0.0.json:1136
 msgid "lang_gon"
 msgstr "gondi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1143
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1178
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3654
+#: sonar/common/jsonschemas/language-v1.0.0.json:1140
 msgid "lang_gor"
 msgstr "gorontalo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1147
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1182
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3658
+#: sonar/common/jsonschemas/language-v1.0.0.json:1144
 msgid "lang_got"
 msgstr "gotique"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1151
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1186
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3662
+#: sonar/common/jsonschemas/language-v1.0.0.json:1148
 msgid "lang_grb"
 msgstr "grebo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1155
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1190
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3666
+#: sonar/common/jsonschemas/language-v1.0.0.json:1152
 msgid "lang_grc"
 msgstr "grec ancien (jusqu'à 1453)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1159
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1194
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3670
+#: sonar/common/jsonschemas/language-v1.0.0.json:1156
 msgid "lang_gre"
 msgstr "grec moderne (après 1453)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1163
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1198
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3674
+#: sonar/common/jsonschemas/language-v1.0.0.json:1160
 msgid "lang_grn"
 msgstr "guarani"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1167
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1202
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3678
+#: sonar/common/jsonschemas/language-v1.0.0.json:1164
 msgid "lang_gsw"
 msgstr "suisse allemand"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1171
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1206
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3682
+#: sonar/common/jsonschemas/language-v1.0.0.json:1168
 msgid "lang_guj"
 msgstr "goudjerati"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1175
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1210
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3686
+#: sonar/common/jsonschemas/language-v1.0.0.json:1172
 msgid "lang_gwi"
 msgstr "gwichʼin"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1179
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1214
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3690
+#: sonar/common/jsonschemas/language-v1.0.0.json:1176
 msgid "lang_hai"
 msgstr "haida"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1183
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1218
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3694
+#: sonar/common/jsonschemas/language-v1.0.0.json:1180
 msgid "lang_hat"
 msgstr "créole haïtien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1187
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1222
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3698
+#: sonar/common/jsonschemas/language-v1.0.0.json:1184
 msgid "lang_hau"
 msgstr "haoussa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1191
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1226
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3702
+#: sonar/common/jsonschemas/language-v1.0.0.json:1188
 msgid "lang_haw"
 msgstr "hawaïen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1195
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1230
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3706
+#: sonar/common/jsonschemas/language-v1.0.0.json:1192
 msgid "lang_heb"
 msgstr "hébreu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1199
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1234
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3710
+#: sonar/common/jsonschemas/language-v1.0.0.json:1196
 msgid "lang_her"
 msgstr "héréro"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1203
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1238
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3714
+#: sonar/common/jsonschemas/language-v1.0.0.json:1200
 msgid "lang_hil"
 msgstr "hiligaynon"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1207
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1242
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3718
+#: sonar/common/jsonschemas/language-v1.0.0.json:1204
 msgid "lang_him"
 msgstr "himachali"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1211
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1246
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3722
+#: sonar/common/jsonschemas/language-v1.0.0.json:1208
 msgid "lang_hin"
 msgstr "hindi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1215
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1250
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3726
+#: sonar/common/jsonschemas/language-v1.0.0.json:1212
 msgid "lang_hit"
 msgstr "hittite"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1219
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1254
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3730
+#: sonar/common/jsonschemas/language-v1.0.0.json:1216
 msgid "lang_hmn"
 msgstr "hmong"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1223
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1258
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3734
+#: sonar/common/jsonschemas/language-v1.0.0.json:1220
 msgid "lang_hmo"
 msgstr "hiri motu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1227
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1262
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3738
+#: sonar/common/jsonschemas/language-v1.0.0.json:1224
 msgid "lang_hrv"
 msgstr "croate"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1231
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1266
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3742
+#: sonar/common/jsonschemas/language-v1.0.0.json:1228
 msgid "lang_hsb"
 msgstr "haut-sorabe"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1235
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1270
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3746
+#: sonar/common/jsonschemas/language-v1.0.0.json:1232
 msgid "lang_hun"
 msgstr "hongrois"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1239
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1274
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3750
+#: sonar/common/jsonschemas/language-v1.0.0.json:1236
 msgid "lang_hup"
 msgstr "hupa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1243
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1278
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3754
+#: sonar/common/jsonschemas/language-v1.0.0.json:1240
 msgid "lang_iba"
 msgstr "iban"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1247
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1282
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3758
+#: sonar/common/jsonschemas/language-v1.0.0.json:1244
 msgid "lang_ibo"
 msgstr "igbo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1251
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1286
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3762
+#: sonar/common/jsonschemas/language-v1.0.0.json:1248
 msgid "lang_ice"
 msgstr "islandais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1255
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1290
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3766
+#: sonar/common/jsonschemas/language-v1.0.0.json:1252
 msgid "lang_ido"
 msgstr "ido"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1259
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1294
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3770
+#: sonar/common/jsonschemas/language-v1.0.0.json:1256
 msgid "lang_iii"
 msgstr "yi du Sichuan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1263
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1298
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3774
+#: sonar/common/jsonschemas/language-v1.0.0.json:1260
 msgid "lang_ijo"
 msgstr "ijo, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1267
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1302
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3778
+#: sonar/common/jsonschemas/language-v1.0.0.json:1264
 msgid "lang_iku"
 msgstr "inuktitut"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1271
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1306
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3782
+#: sonar/common/jsonschemas/language-v1.0.0.json:1268
 msgid "lang_ile"
 msgstr "interlingue"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1275
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1310
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3786
+#: sonar/common/jsonschemas/language-v1.0.0.json:1272
 msgid "lang_ilo"
 msgstr "ilocano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1279
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1314
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3790
+#: sonar/common/jsonschemas/language-v1.0.0.json:1276
 msgid "lang_ina"
 msgstr "interlingua"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1283
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1318
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3794
+#: sonar/common/jsonschemas/language-v1.0.0.json:1280
 msgid "lang_inc"
 msgstr "indo-aryennes, autres langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1287
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1322
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3798
+#: sonar/common/jsonschemas/language-v1.0.0.json:1284
 msgid "lang_ind"
 msgstr "indonésien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1291
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1326
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3802
+#: sonar/common/jsonschemas/language-v1.0.0.json:1288
 msgid "lang_ine"
 msgstr "indo-européennes, autres langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1295
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1330
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3806
+#: sonar/common/jsonschemas/language-v1.0.0.json:1292
 msgid "lang_inh"
 msgstr "ingouche"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1299
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1334
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3810
+#: sonar/common/jsonschemas/language-v1.0.0.json:1296
 msgid "lang_ipk"
 msgstr "inupiaq"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1303
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1338
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3814
+#: sonar/common/jsonschemas/language-v1.0.0.json:1300
 msgid "lang_ira"
 msgstr "iraniennes, autres langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1307
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1342
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3818
+#: sonar/common/jsonschemas/language-v1.0.0.json:1304
 msgid "lang_iro"
 msgstr "iroquois, langues (famille)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1311
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1346
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3822
+#: sonar/common/jsonschemas/language-v1.0.0.json:1308
 msgid "lang_ita"
 msgstr "italien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1316
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1351
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3827
+#: sonar/common/jsonschemas/language-v1.0.0.json:1313
 msgid "lang_jav"
 msgstr "javanais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1320
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1355
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3831
+#: sonar/common/jsonschemas/language-v1.0.0.json:1317
 msgid "lang_jbo"
 msgstr "lojban"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1324
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1359
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3835
+#: sonar/common/jsonschemas/language-v1.0.0.json:1321
 msgid "lang_jpn"
 msgstr "japonais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1328
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1363
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3839
+#: sonar/common/jsonschemas/language-v1.0.0.json:1325
 msgid "lang_jpr"
 msgstr "judéo-persan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1332
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1367
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3843
+#: sonar/common/jsonschemas/language-v1.0.0.json:1329
 msgid "lang_jrb"
 msgstr "judéo-arabe"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1336
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1371
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3847
+#: sonar/common/jsonschemas/language-v1.0.0.json:1333
 msgid "lang_kaa"
 msgstr "karakalpak"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1340
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1375
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3851
+#: sonar/common/jsonschemas/language-v1.0.0.json:1337
 msgid "lang_kab"
 msgstr "kabyle"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1344
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1379
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3855
+#: sonar/common/jsonschemas/language-v1.0.0.json:1341
 msgid "lang_kac"
 msgstr "kachin"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1348
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1383
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3859
+#: sonar/common/jsonschemas/language-v1.0.0.json:1345
 msgid "lang_kal"
 msgstr "groenlandais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1352
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1387
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3863
+#: sonar/common/jsonschemas/language-v1.0.0.json:1349
 msgid "lang_kam"
 msgstr "kamba"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1356
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1391
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3867
+#: sonar/common/jsonschemas/language-v1.0.0.json:1353
 msgid "lang_kan"
 msgstr "kannada"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1360
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1395
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3871
+#: sonar/common/jsonschemas/language-v1.0.0.json:1357
 msgid "lang_kar"
 msgstr "karen, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1364
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1399
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3875
+#: sonar/common/jsonschemas/language-v1.0.0.json:1361
 msgid "lang_kas"
 msgstr "cachemiri"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1368
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1403
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3879
+#: sonar/common/jsonschemas/language-v1.0.0.json:1365
 msgid "lang_kau"
 msgstr "kanouri"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1372
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1407
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3883
+#: sonar/common/jsonschemas/language-v1.0.0.json:1369
 msgid "lang_kaw"
 msgstr "kawi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1376
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1411
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3887
+#: sonar/common/jsonschemas/language-v1.0.0.json:1373
 msgid "lang_kaz"
 msgstr "kazakh"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1380
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1415
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3891
+#: sonar/common/jsonschemas/language-v1.0.0.json:1377
 msgid "lang_kbd"
 msgstr "kabarde"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1384
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1419
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3895
+#: sonar/common/jsonschemas/language-v1.0.0.json:1381
 msgid "lang_kha"
 msgstr "khasi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1388
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1423
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3899
+#: sonar/common/jsonschemas/language-v1.0.0.json:1385
 msgid "lang_khi"
 msgstr "khoisan, autres langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1392
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1427
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3903
+#: sonar/common/jsonschemas/language-v1.0.0.json:1389
 msgid "lang_khm"
 msgstr "khmer"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1396
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1431
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3907
+#: sonar/common/jsonschemas/language-v1.0.0.json:1393
 msgid "lang_kho"
 msgstr "khotanais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1400
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1435
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3911
+#: sonar/common/jsonschemas/language-v1.0.0.json:1397
 msgid "lang_kik"
 msgstr "kikuyu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1404
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1439
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3915
+#: sonar/common/jsonschemas/language-v1.0.0.json:1401
 msgid "lang_kin"
 msgstr "kinyarwanda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1408
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1443
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3919
+#: sonar/common/jsonschemas/language-v1.0.0.json:1405
 msgid "lang_kir"
 msgstr "kirghize"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1412
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1447
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3923
+#: sonar/common/jsonschemas/language-v1.0.0.json:1409
 msgid "lang_kmb"
 msgstr "kimboundou"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1416
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1451
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3927
+#: sonar/common/jsonschemas/language-v1.0.0.json:1413
 msgid "lang_kok"
 msgstr "konkani"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1420
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1455
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3931
+#: sonar/common/jsonschemas/language-v1.0.0.json:1417
 msgid "lang_kom"
 msgstr "komi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1424
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1459
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3935
+#: sonar/common/jsonschemas/language-v1.0.0.json:1421
 msgid "lang_kon"
 msgstr "kikongo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1428
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1463
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3939
+#: sonar/common/jsonschemas/language-v1.0.0.json:1425
 msgid "lang_kor"
 msgstr "coréen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1432
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1467
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3943
+#: sonar/common/jsonschemas/language-v1.0.0.json:1429
 msgid "lang_kos"
 msgstr "kosraéen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1436
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1471
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3947
+#: sonar/common/jsonschemas/language-v1.0.0.json:1433
 msgid "lang_kpe"
 msgstr "kpellé"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1440
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1475
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3951
+#: sonar/common/jsonschemas/language-v1.0.0.json:1437
 msgid "lang_krc"
 msgstr "karatchaï balkar"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1444
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1479
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3955
+#: sonar/common/jsonschemas/language-v1.0.0.json:1441
 msgid "lang_krl"
 msgstr "carélien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1448
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1483
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3959
+#: sonar/common/jsonschemas/language-v1.0.0.json:1445
 msgid "lang_kro"
 msgstr "krou, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1452
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1487
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3963
+#: sonar/common/jsonschemas/language-v1.0.0.json:1449
 msgid "lang_kru"
 msgstr "kouroukh"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1456
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1491
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3967
+#: sonar/common/jsonschemas/language-v1.0.0.json:1453
 msgid "lang_kua"
 msgstr "kuanyama"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1460
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1495
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3971
+#: sonar/common/jsonschemas/language-v1.0.0.json:1457
 msgid "lang_kum"
 msgstr "koumyk"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1464
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1499
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3975
+#: sonar/common/jsonschemas/language-v1.0.0.json:1461
 msgid "lang_kur"
 msgstr "kurde"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1468
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1503
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3979
+#: sonar/common/jsonschemas/language-v1.0.0.json:1465
 msgid "lang_kut"
 msgstr "kutenai"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1472
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1507
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3983
+#: sonar/common/jsonschemas/language-v1.0.0.json:1469
 msgid "lang_lad"
 msgstr "ladino"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1476
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1511
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3987
+#: sonar/common/jsonschemas/language-v1.0.0.json:1473
 msgid "lang_lah"
 msgstr "lahnda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1480
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1515
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3991
+#: sonar/common/jsonschemas/language-v1.0.0.json:1477
 msgid "lang_lam"
 msgstr "lamba"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1484
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1519
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3995
+#: sonar/common/jsonschemas/language-v1.0.0.json:1481
 msgid "lang_lao"
 msgstr "lao"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1488
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1523
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3999
+#: sonar/common/jsonschemas/language-v1.0.0.json:1485
 msgid "lang_lat"
 msgstr "latin"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1492
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1527
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4003
+#: sonar/common/jsonschemas/language-v1.0.0.json:1489
 msgid "lang_lav"
 msgstr "letton"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1496
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1531
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4007
+#: sonar/common/jsonschemas/language-v1.0.0.json:1493
 msgid "lang_lez"
 msgstr "lezghien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1500
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1535
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4011
+#: sonar/common/jsonschemas/language-v1.0.0.json:1497
 msgid "lang_lim"
 msgstr "limbourgeois"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1504
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1539
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4015
+#: sonar/common/jsonschemas/language-v1.0.0.json:1501
 msgid "lang_lin"
 msgstr "lingala"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1508
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1543
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4019
+#: sonar/common/jsonschemas/language-v1.0.0.json:1505
 msgid "lang_lit"
 msgstr "lituanien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1512
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1547
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4023
+#: sonar/common/jsonschemas/language-v1.0.0.json:1509
 msgid "lang_lol"
 msgstr "mongo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1516
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1551
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4027
+#: sonar/common/jsonschemas/language-v1.0.0.json:1513
 msgid "lang_loz"
 msgstr "lozi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1520
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1555
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4031
+#: sonar/common/jsonschemas/language-v1.0.0.json:1517
 msgid "lang_ltz"
 msgstr "luxembourgeois"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1524
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1559
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4035
+#: sonar/common/jsonschemas/language-v1.0.0.json:1521
 msgid "lang_lua"
 msgstr "luba-kasaï (ciluba)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1528
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1563
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4039
+#: sonar/common/jsonschemas/language-v1.0.0.json:1525
 msgid "lang_lub"
 msgstr "luba-katanga (kiluba)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1532
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1567
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4043
+#: sonar/common/jsonschemas/language-v1.0.0.json:1529
 msgid "lang_lug"
 msgstr "ganda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1536
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1571
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4047
+#: sonar/common/jsonschemas/language-v1.0.0.json:1533
 msgid "lang_lui"
 msgstr "luiseño"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1540
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1575
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4051
+#: sonar/common/jsonschemas/language-v1.0.0.json:1537
 msgid "lang_lun"
 msgstr "lunda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1544
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1579
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4055
+#: sonar/common/jsonschemas/language-v1.0.0.json:1541
 msgid "lang_luo"
 msgstr "luo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1548
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1583
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4059
+#: sonar/common/jsonschemas/language-v1.0.0.json:1545
 msgid "lang_lus"
 msgstr "lushaï"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1552
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1587
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4063
+#: sonar/common/jsonschemas/language-v1.0.0.json:1549
 msgid "lang_mac"
 msgstr "macédonien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1556
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1591
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4067
+#: sonar/common/jsonschemas/language-v1.0.0.json:1553
 msgid "lang_mad"
 msgstr "madurais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1560
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1595
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4071
+#: sonar/common/jsonschemas/language-v1.0.0.json:1557
 msgid "lang_mag"
 msgstr "magahi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1564
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1599
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4075
+#: sonar/common/jsonschemas/language-v1.0.0.json:1561
 msgid "lang_mah"
 msgstr "marshallais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1568
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1603
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4079
+#: sonar/common/jsonschemas/language-v1.0.0.json:1565
 msgid "lang_mai"
 msgstr "maïthili"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1572
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1607
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4083
+#: sonar/common/jsonschemas/language-v1.0.0.json:1569
 msgid "lang_mak"
 msgstr "makassar"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1576
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1611
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4087
+#: sonar/common/jsonschemas/language-v1.0.0.json:1573
 msgid "lang_mal"
 msgstr "malayalam"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1580
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1615
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4091
+#: sonar/common/jsonschemas/language-v1.0.0.json:1577
 msgid "lang_man"
 msgstr "mandingue"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1584
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1619
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4095
+#: sonar/common/jsonschemas/language-v1.0.0.json:1581
 msgid "lang_mao"
 msgstr "maori"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1588
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1623
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4099
+#: sonar/common/jsonschemas/language-v1.0.0.json:1585
 msgid "lang_map"
 msgstr "malayo-polynésiennes, autres langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1592
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1627
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4103
+#: sonar/common/jsonschemas/language-v1.0.0.json:1589
 msgid "lang_mar"
 msgstr "marathi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1596
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1631
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4107
+#: sonar/common/jsonschemas/language-v1.0.0.json:1593
 msgid "lang_mas"
 msgstr "maasaï"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1600
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1635
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4111
+#: sonar/common/jsonschemas/language-v1.0.0.json:1597
 msgid "lang_may"
 msgstr "malais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1604
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1639
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4115
+#: sonar/common/jsonschemas/language-v1.0.0.json:1601
 msgid "lang_mdf"
 msgstr "mokcha"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1608
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1643
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4119
+#: sonar/common/jsonschemas/language-v1.0.0.json:1605
 msgid "lang_mdr"
 msgstr "mandar"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1612
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1647
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4123
+#: sonar/common/jsonschemas/language-v1.0.0.json:1609
 msgid "lang_men"
 msgstr "mendé"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1616
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1651
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4127
+#: sonar/common/jsonschemas/language-v1.0.0.json:1613
 msgid "lang_mga"
 msgstr "moyen irlandais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1620
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1655
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4131
+#: sonar/common/jsonschemas/language-v1.0.0.json:1617
 msgid "lang_mic"
 msgstr "micmac"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1624
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1659
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4135
+#: sonar/common/jsonschemas/language-v1.0.0.json:1621
 msgid "lang_min"
 msgstr "minangkabau"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1628
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1663
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4139
+#: sonar/common/jsonschemas/language-v1.0.0.json:1625
 msgid "lang_mis"
 msgstr "diverses, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1632
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1667
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4143
+#: sonar/common/jsonschemas/language-v1.0.0.json:1629
 msgid "lang_mkh"
 msgstr "môn-khmer, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1636
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1671
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4147
+#: sonar/common/jsonschemas/language-v1.0.0.json:1633
 msgid "lang_mlg"
 msgstr "malgache"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1640
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1675
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4151
+#: sonar/common/jsonschemas/language-v1.0.0.json:1637
 msgid "lang_mlt"
 msgstr "maltais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1644
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1679
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4155
+#: sonar/common/jsonschemas/language-v1.0.0.json:1641
 msgid "lang_mnc"
 msgstr "mandchou"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1648
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1683
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4159
+#: sonar/common/jsonschemas/language-v1.0.0.json:1645
 msgid "lang_mni"
 msgstr "manipuri"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1652
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1687
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4163
+#: sonar/common/jsonschemas/language-v1.0.0.json:1649
 msgid "lang_mno"
 msgstr "manobo, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1656
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1691
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4167
+#: sonar/common/jsonschemas/language-v1.0.0.json:1653
 msgid "lang_moh"
 msgstr "mohawk"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1660
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1695
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4171
+#: sonar/common/jsonschemas/language-v1.0.0.json:1657
 msgid "lang_mon"
 msgstr "mongol"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1664
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1699
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4175
+#: sonar/common/jsonschemas/language-v1.0.0.json:1661
 msgid "lang_mos"
 msgstr "moré"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1668
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1703
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4179
+#: sonar/common/jsonschemas/language-v1.0.0.json:1665
 msgid "lang_mul"
 msgstr "multilingue"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1672
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1707
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4183
+#: sonar/common/jsonschemas/language-v1.0.0.json:1669
 msgid "lang_mun"
 msgstr "mounda, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1676
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1711
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4187
+#: sonar/common/jsonschemas/language-v1.0.0.json:1673
 msgid "lang_mus"
 msgstr "muskogee"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1680
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1715
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4191
+#: sonar/common/jsonschemas/language-v1.0.0.json:1677
 msgid "lang_mwl"
 msgstr "mirandais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1684
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1719
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4195
+#: sonar/common/jsonschemas/language-v1.0.0.json:1681
 msgid "lang_mwr"
 msgstr "marwarî"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1688
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1723
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4199
+#: sonar/common/jsonschemas/language-v1.0.0.json:1685
 msgid "lang_myn"
 msgstr "maya, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1692
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1727
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4203
+#: sonar/common/jsonschemas/language-v1.0.0.json:1689
 msgid "lang_myv"
 msgstr "erzya"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1696
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1731
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4207
+#: sonar/common/jsonschemas/language-v1.0.0.json:1693
 msgid "lang_nah"
 msgstr "nahuatl, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1700
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1735
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4211
+#: sonar/common/jsonschemas/language-v1.0.0.json:1697
 msgid "lang_nai"
 msgstr "indiennes d'Amérique du Nord, autres langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1704
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1739
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4215
+#: sonar/common/jsonschemas/language-v1.0.0.json:1701
 msgid "lang_nap"
 msgstr "napolitain"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1708
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1743
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4219
+#: sonar/common/jsonschemas/language-v1.0.0.json:1705
 msgid "lang_nau"
 msgstr "nauruan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1712
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1747
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4223
+#: sonar/common/jsonschemas/language-v1.0.0.json:1709
 msgid "lang_nav"
 msgstr "navajo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1716
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1751
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4227
+#: sonar/common/jsonschemas/language-v1.0.0.json:1713
 msgid "lang_nbl"
 msgstr "ndébélé du Sud"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1720
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1755
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4231
+#: sonar/common/jsonschemas/language-v1.0.0.json:1717
 msgid "lang_nde"
 msgstr "ndébélé du Nord"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1724
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1759
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4235
+#: sonar/common/jsonschemas/language-v1.0.0.json:1721
 msgid "lang_ndo"
 msgstr "ndonga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1728
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1763
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4239
+#: sonar/common/jsonschemas/language-v1.0.0.json:1725
 msgid "lang_nds"
 msgstr "bas-allemand"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1732
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1767
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4243
+#: sonar/common/jsonschemas/language-v1.0.0.json:1729
 msgid "lang_nep"
 msgstr "népalais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1736
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1771
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4247
+#: sonar/common/jsonschemas/language-v1.0.0.json:1733
 msgid "lang_new"
 msgstr "newari"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1740
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1775
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4251
+#: sonar/common/jsonschemas/language-v1.0.0.json:1737
 msgid "lang_nia"
 msgstr "niha"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1744
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1779
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4255
+#: sonar/common/jsonschemas/language-v1.0.0.json:1741
 msgid "lang_nic"
 msgstr "nigéro-congolaises,langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1748
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1783
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4259
+#: sonar/common/jsonschemas/language-v1.0.0.json:1745
 msgid "lang_niu"
 msgstr "niuéen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1752
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1787
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4263
+#: sonar/common/jsonschemas/language-v1.0.0.json:1749
 msgid "lang_nno"
 msgstr "norvégien nynorsk"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1756
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1791
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4267
+#: sonar/common/jsonschemas/language-v1.0.0.json:1753
 msgid "lang_nob"
 msgstr "norvégien bokmål"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1760
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1795
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4271
+#: sonar/common/jsonschemas/language-v1.0.0.json:1757
 msgid "lang_nog"
 msgstr "nogaï"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1764
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1799
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4275
+#: sonar/common/jsonschemas/language-v1.0.0.json:1761
 msgid "lang_non"
 msgstr "vieux norrois"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1768
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1803
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4279
+#: sonar/common/jsonschemas/language-v1.0.0.json:1765
 msgid "lang_nor"
 msgstr "norvégien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1772
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1807
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4283
+#: sonar/common/jsonschemas/language-v1.0.0.json:1769
 msgid "lang_nqo"
 msgstr "n’ko"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1776
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1811
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4287
+#: sonar/common/jsonschemas/language-v1.0.0.json:1773
 msgid "lang_nso"
 msgstr "sotho du Nord"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1780
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1815
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4291
+#: sonar/common/jsonschemas/language-v1.0.0.json:1777
 msgid "lang_nub"
 msgstr "nubiennes, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1784
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1819
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4295
+#: sonar/common/jsonschemas/language-v1.0.0.json:1781
 msgid "lang_nwc"
 msgstr "newarî classique"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1788
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1823
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4299
+#: sonar/common/jsonschemas/language-v1.0.0.json:1785
 msgid "lang_nya"
 msgstr "chewa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1792
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1827
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4303
+#: sonar/common/jsonschemas/language-v1.0.0.json:1789
 msgid "lang_nym"
 msgstr "nyamwezi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1796
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1831
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4307
+#: sonar/common/jsonschemas/language-v1.0.0.json:1793
 msgid "lang_nyn"
 msgstr "nyankolé"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1800
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1835
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4311
+#: sonar/common/jsonschemas/language-v1.0.0.json:1797
 msgid "lang_nyo"
 msgstr "nyoro"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1804
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1839
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4315
+#: sonar/common/jsonschemas/language-v1.0.0.json:1801
 msgid "lang_nzi"
 msgstr "nzema"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1808
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1843
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4319
+#: sonar/common/jsonschemas/language-v1.0.0.json:1805
 msgid "lang_oci"
 msgstr "occitan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1812
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1847
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4323
+#: sonar/common/jsonschemas/language-v1.0.0.json:1809
 msgid "lang_oji"
 msgstr "ojibwa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1816
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1851
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4327
+#: sonar/common/jsonschemas/language-v1.0.0.json:1813
 msgid "lang_ori"
 msgstr "odia"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1820
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1855
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4331
+#: sonar/common/jsonschemas/language-v1.0.0.json:1817
 msgid "lang_orm"
 msgstr "oromo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1824
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1859
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4335
+#: sonar/common/jsonschemas/language-v1.0.0.json:1821
 msgid "lang_osa"
 msgstr "osage"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1828
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1863
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4339
+#: sonar/common/jsonschemas/language-v1.0.0.json:1825
 msgid "lang_oss"
 msgstr "ossète"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1832
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1867
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4343
+#: sonar/common/jsonschemas/language-v1.0.0.json:1829
 msgid "lang_ota"
 msgstr "turc ottoman"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1836
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1871
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4347
+#: sonar/common/jsonschemas/language-v1.0.0.json:1833
 msgid "lang_oto"
 msgstr "otomi, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1840
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1875
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4351
+#: sonar/common/jsonschemas/language-v1.0.0.json:1837
 msgid "lang_paa"
 msgstr "papoues, autres langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1844
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1879
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4355
+#: sonar/common/jsonschemas/language-v1.0.0.json:1841
 msgid "lang_pag"
 msgstr "pangasinan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1848
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1883
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4359
+#: sonar/common/jsonschemas/language-v1.0.0.json:1845
 msgid "lang_pal"
 msgstr "pahlavi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1852
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1887
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4363
+#: sonar/common/jsonschemas/language-v1.0.0.json:1849
 msgid "lang_pam"
 msgstr "pampangan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1856
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1891
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4367
+#: sonar/common/jsonschemas/language-v1.0.0.json:1853
 msgid "lang_pan"
 msgstr "pendjabi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1860
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1895
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4371
+#: sonar/common/jsonschemas/language-v1.0.0.json:1857
 msgid "lang_pap"
 msgstr "papiamento"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1864
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1899
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4375
+#: sonar/common/jsonschemas/language-v1.0.0.json:1861
 msgid "lang_pau"
 msgstr "paluan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1868
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1903
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4379
+#: sonar/common/jsonschemas/language-v1.0.0.json:1865
 msgid "lang_peo"
 msgstr "persan ancien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1872
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1907
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4383
+#: sonar/common/jsonschemas/language-v1.0.0.json:1869
 msgid "lang_per"
 msgstr "persan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1876
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1911
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4387
+#: sonar/common/jsonschemas/language-v1.0.0.json:1873
 msgid "lang_phi"
 msgstr "philippin, autres langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1880
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1915
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4391
+#: sonar/common/jsonschemas/language-v1.0.0.json:1877
 msgid "lang_phn"
 msgstr "phénicien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1884
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1919
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4395
+#: sonar/common/jsonschemas/language-v1.0.0.json:1881
 msgid "lang_pli"
 msgstr "pali"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1888
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1923
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4399
+#: sonar/common/jsonschemas/language-v1.0.0.json:1885
 msgid "lang_pol"
 msgstr "polonais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1892
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1927
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4403
+#: sonar/common/jsonschemas/language-v1.0.0.json:1889
 msgid "lang_pon"
 msgstr "pohnpei"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1896
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1931
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4407
+#: sonar/common/jsonschemas/language-v1.0.0.json:1893
 msgid "lang_por"
 msgstr "portugais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1900
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1935
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4411
+#: sonar/common/jsonschemas/language-v1.0.0.json:1897
 msgid "lang_pra"
 msgstr "prâkrit"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1904
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1939
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4415
+#: sonar/common/jsonschemas/language-v1.0.0.json:1901
 msgid "lang_pro"
 msgstr "provençal ancien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1908
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1943
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4419
+#: sonar/common/jsonschemas/language-v1.0.0.json:1905
 msgid "lang_pus"
 msgstr "pachto"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1912
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1947
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4423
+#: sonar/common/jsonschemas/language-v1.0.0.json:1909
 msgid "lang_que"
 msgstr "quechua"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1916
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1951
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4427
+#: sonar/common/jsonschemas/language-v1.0.0.json:1913
 msgid "lang_raj"
 msgstr "rajasthani"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1920
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1955
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4431
+#: sonar/common/jsonschemas/language-v1.0.0.json:1917
 msgid "lang_rap"
 msgstr "rapanui"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1924
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1959
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4435
+#: sonar/common/jsonschemas/language-v1.0.0.json:1921
 msgid "lang_rar"
 msgstr "rarotongien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1928
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1963
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4439
+#: sonar/common/jsonschemas/language-v1.0.0.json:1925
 msgid "lang_roa"
 msgstr "romanes, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1932
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1967
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4443
+#: sonar/common/jsonschemas/language-v1.0.0.json:1929
 msgid "lang_roh"
 msgstr "romanche"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1936
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1971
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4447
+#: sonar/common/jsonschemas/language-v1.0.0.json:1933
 msgid "lang_rom"
 msgstr "romani"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1940
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1975
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4451
+#: sonar/common/jsonschemas/language-v1.0.0.json:1937
 msgid "lang_rum"
 msgstr "roumain"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1944
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1979
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4455
+#: sonar/common/jsonschemas/language-v1.0.0.json:1941
 msgid "lang_run"
 msgstr "roundi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1948
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1983
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4459
+#: sonar/common/jsonschemas/language-v1.0.0.json:1945
 msgid "lang_rup"
 msgstr "aroumain"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1952
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1987
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4463
+#: sonar/common/jsonschemas/language-v1.0.0.json:1949
 msgid "lang_rus"
 msgstr "russe"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1956
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1991
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4467
+#: sonar/common/jsonschemas/language-v1.0.0.json:1953
 msgid "lang_sad"
 msgstr "sandawe"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1960
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1995
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4471
+#: sonar/common/jsonschemas/language-v1.0.0.json:1957
 msgid "lang_sag"
 msgstr "sango"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1964
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1999
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4475
+#: sonar/common/jsonschemas/language-v1.0.0.json:1961
 msgid "lang_sah"
 msgstr "iakoute"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1968
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2003
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4479
+#: sonar/common/jsonschemas/language-v1.0.0.json:1965
 msgid "lang_sai"
 msgstr "indiennes d'Amérique du Sud, autres langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1972
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2007
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4483
+#: sonar/common/jsonschemas/language-v1.0.0.json:1969
 msgid "lang_sal"
 msgstr "salish, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1976
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2011
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4487
+#: sonar/common/jsonschemas/language-v1.0.0.json:1973
 msgid "lang_sam"
 msgstr "araméen samaritain"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1980
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2015
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4491
+#: sonar/common/jsonschemas/language-v1.0.0.json:1977
 msgid "lang_san"
 msgstr "sanskrit"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1984
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2019
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4495
+#: sonar/common/jsonschemas/language-v1.0.0.json:1981
 msgid "lang_sas"
 msgstr "sasak"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1988
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2023
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4499
+#: sonar/common/jsonschemas/language-v1.0.0.json:1985
 msgid "lang_sat"
 msgstr "santali"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1992
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2027
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4503
+#: sonar/common/jsonschemas/language-v1.0.0.json:1989
 msgid "lang_scn"
 msgstr "sicilien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1996
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2031
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4507
+#: sonar/common/jsonschemas/language-v1.0.0.json:1993
 msgid "lang_sco"
 msgstr "écossais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2000
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2035
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4511
+#: sonar/common/jsonschemas/language-v1.0.0.json:1997
 msgid "lang_sel"
 msgstr "selkoupe"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2004
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2039
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4515
+#: sonar/common/jsonschemas/language-v1.0.0.json:2001
 msgid "lang_sem"
 msgstr "sémitiques, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2008
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2043
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4519
+#: sonar/common/jsonschemas/language-v1.0.0.json:2005
 msgid "lang_sga"
 msgstr "ancien irlandais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2012
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2047
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4523
+#: sonar/common/jsonschemas/language-v1.0.0.json:2009
 msgid "lang_sgn"
 msgstr "langue des signes"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2016
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2051
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4527
+#: sonar/common/jsonschemas/language-v1.0.0.json:2013
 msgid "lang_shn"
 msgstr "shan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2020
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2055
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4531
+#: sonar/common/jsonschemas/language-v1.0.0.json:2017
 msgid "lang_sid"
 msgstr "sidamo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2024
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2059
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4535
+#: sonar/common/jsonschemas/language-v1.0.0.json:2021
 msgid "lang_sin"
 msgstr "cingalais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2028
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2063
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4539
+#: sonar/common/jsonschemas/language-v1.0.0.json:2025
 msgid "lang_sio"
 msgstr "sioux, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2032
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2067
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4543
+#: sonar/common/jsonschemas/language-v1.0.0.json:2029
 msgid "lang_sit"
 msgstr "sino-tibétaines, autres langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2036
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2071
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4547
+#: sonar/common/jsonschemas/language-v1.0.0.json:2033
 msgid "lang_sla"
 msgstr "slaves, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2040
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2075
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4551
+#: sonar/common/jsonschemas/language-v1.0.0.json:2037
 msgid "lang_slo"
 msgstr "slovaque"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2044
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2079
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4555
+#: sonar/common/jsonschemas/language-v1.0.0.json:2041
 msgid "lang_slv"
 msgstr "slovène"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2048
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2083
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4559
+#: sonar/common/jsonschemas/language-v1.0.0.json:2045
 msgid "lang_sma"
 msgstr "same du Sud"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2052
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2087
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4563
+#: sonar/common/jsonschemas/language-v1.0.0.json:2049
 msgid "lang_sme"
 msgstr "same du Nord"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2056
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2091
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4567
+#: sonar/common/jsonschemas/language-v1.0.0.json:2053
 msgid "lang_smi"
 msgstr "sâmes, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2060
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2095
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4571
+#: sonar/common/jsonschemas/language-v1.0.0.json:2057
 msgid "lang_smj"
 msgstr "same de Lule"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2064
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2099
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4575
+#: sonar/common/jsonschemas/language-v1.0.0.json:2061
 msgid "lang_smn"
 msgstr "same d’Inari"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2068
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2103
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4579
+#: sonar/common/jsonschemas/language-v1.0.0.json:2065
 msgid "lang_smo"
 msgstr "samoan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2072
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2107
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4583
+#: sonar/common/jsonschemas/language-v1.0.0.json:2069
 msgid "lang_sms"
 msgstr "same skolt"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2076
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2111
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4587
+#: sonar/common/jsonschemas/language-v1.0.0.json:2073
 msgid "lang_sna"
 msgstr "shona"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2080
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2115
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4591
+#: sonar/common/jsonschemas/language-v1.0.0.json:2077
 msgid "lang_snd"
 msgstr "sindhi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2084
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2119
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4595
+#: sonar/common/jsonschemas/language-v1.0.0.json:2081
 msgid "lang_snk"
 msgstr "soninké"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2088
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2123
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4599
+#: sonar/common/jsonschemas/language-v1.0.0.json:2085
 msgid "lang_sog"
 msgstr "sogdien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2092
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2127
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4603
+#: sonar/common/jsonschemas/language-v1.0.0.json:2089
 msgid "lang_som"
 msgstr "somali"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2096
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2131
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4607
+#: sonar/common/jsonschemas/language-v1.0.0.json:2093
 msgid "lang_son"
 msgstr "songhai"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2100
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2135
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4611
+#: sonar/common/jsonschemas/language-v1.0.0.json:2097
 msgid "lang_sot"
 msgstr "sotho du Sud"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2104
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2139
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4615
+#: sonar/common/jsonschemas/language-v1.0.0.json:2101
 msgid "lang_spa"
 msgstr "espagnol"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2108
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2143
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4619
+#: sonar/common/jsonschemas/language-v1.0.0.json:2105
 msgid "lang_srd"
 msgstr "sarde"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2112
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2147
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4623
+#: sonar/common/jsonschemas/language-v1.0.0.json:2109
 msgid "lang_srn"
 msgstr "sranan tongo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2116
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2151
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4627
+#: sonar/common/jsonschemas/language-v1.0.0.json:2113
 msgid "lang_srp"
 msgstr "serbe"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2120
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2155
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4631
+#: sonar/common/jsonschemas/language-v1.0.0.json:2117
 msgid "lang_srr"
 msgstr "sérère"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2124
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2159
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4635
+#: sonar/common/jsonschemas/language-v1.0.0.json:2121
 msgid "lang_ssa"
 msgstr "nilo-sahariennes, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2128
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2163
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4639
+#: sonar/common/jsonschemas/language-v1.0.0.json:2125
 msgid "lang_ssw"
 msgstr "swati"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2132
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2167
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4643
+#: sonar/common/jsonschemas/language-v1.0.0.json:2129
 msgid "lang_suk"
 msgstr "soukouma"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2136
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2171
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4647
+#: sonar/common/jsonschemas/language-v1.0.0.json:2133
 msgid "lang_sun"
 msgstr "soundanais"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2140
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2175
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4651
+#: sonar/common/jsonschemas/language-v1.0.0.json:2137
 msgid "lang_sus"
 msgstr "soussou"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2144
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2179
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4655
+#: sonar/common/jsonschemas/language-v1.0.0.json:2141
 msgid "lang_sux"
 msgstr "sumérien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2148
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2183
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4659
+#: sonar/common/jsonschemas/language-v1.0.0.json:2145
 msgid "lang_swa"
 msgstr "swahili"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2152
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2187
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4663
+#: sonar/common/jsonschemas/language-v1.0.0.json:2149
 msgid "lang_swe"
 msgstr "suédois"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2156
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2191
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4667
+#: sonar/common/jsonschemas/language-v1.0.0.json:2153
 msgid "lang_syc"
 msgstr "syriaque classique"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2160
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2195
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4671
+#: sonar/common/jsonschemas/language-v1.0.0.json:2157
 msgid "lang_syr"
 msgstr "syriaque"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2164
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2199
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4675
+#: sonar/common/jsonschemas/language-v1.0.0.json:2161
 msgid "lang_tah"
 msgstr "tahitien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2168
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2203
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4679
+#: sonar/common/jsonschemas/language-v1.0.0.json:2165
 msgid "lang_tai"
 msgstr "tai, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2172
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2207
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4683
+#: sonar/common/jsonschemas/language-v1.0.0.json:2169
 msgid "lang_tam"
 msgstr "tamoul"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2176
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2211
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4687
+#: sonar/common/jsonschemas/language-v1.0.0.json:2173
 msgid "lang_tat"
 msgstr "tatar"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2180
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2215
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4691
+#: sonar/common/jsonschemas/language-v1.0.0.json:2177
 msgid "lang_tel"
 msgstr "télougou"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2184
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2219
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4695
+#: sonar/common/jsonschemas/language-v1.0.0.json:2181
 msgid "lang_tem"
 msgstr "timné"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2188
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2223
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4699
+#: sonar/common/jsonschemas/language-v1.0.0.json:2185
 msgid "lang_ter"
 msgstr "tereno"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2192
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2227
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4703
+#: sonar/common/jsonschemas/language-v1.0.0.json:2189
 msgid "lang_tet"
 msgstr "tétoum"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2196
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2231
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4707
+#: sonar/common/jsonschemas/language-v1.0.0.json:2193
 msgid "lang_tgk"
 msgstr "tadjik"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2200
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2235
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4711
+#: sonar/common/jsonschemas/language-v1.0.0.json:2197
 msgid "lang_tgl"
 msgstr "tagalog"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2204
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2239
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4715
+#: sonar/common/jsonschemas/language-v1.0.0.json:2201
 msgid "lang_tha"
 msgstr "thaï"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2208
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2243
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4719
+#: sonar/common/jsonschemas/language-v1.0.0.json:2205
 msgid "lang_tib"
 msgstr "tibétain"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2212
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2247
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4723
+#: sonar/common/jsonschemas/language-v1.0.0.json:2209
 msgid "lang_tig"
 msgstr "tigré"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2216
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2251
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4727
+#: sonar/common/jsonschemas/language-v1.0.0.json:2213
 msgid "lang_tir"
 msgstr "tigrigna"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2220
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2255
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4731
+#: sonar/common/jsonschemas/language-v1.0.0.json:2217
 msgid "lang_tiv"
 msgstr "tiv"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2224
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2259
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4735
+#: sonar/common/jsonschemas/language-v1.0.0.json:2221
 msgid "lang_tkl"
 msgstr "tokelau"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2228
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2263
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4739
+#: sonar/common/jsonschemas/language-v1.0.0.json:2225
 msgid "lang_tlh"
 msgstr "klingon"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2232
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2267
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4743
+#: sonar/common/jsonschemas/language-v1.0.0.json:2229
 msgid "lang_tli"
 msgstr "tlingit"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2236
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2271
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4747
+#: sonar/common/jsonschemas/language-v1.0.0.json:2233
 msgid "lang_tmh"
 msgstr "tamacheq"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2240
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2275
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4751
+#: sonar/common/jsonschemas/language-v1.0.0.json:2237
 msgid "lang_tog"
 msgstr "tonga nyasa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2244
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2279
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4755
+#: sonar/common/jsonschemas/language-v1.0.0.json:2241
 msgid "lang_ton"
 msgstr "tongien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2248
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2283
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4759
+#: sonar/common/jsonschemas/language-v1.0.0.json:2245
 msgid "lang_tpi"
 msgstr "tok pisin"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2252
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2287
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4763
+#: sonar/common/jsonschemas/language-v1.0.0.json:2249
 msgid "lang_tsi"
 msgstr "tsimshian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2256
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2291
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4767
+#: sonar/common/jsonschemas/language-v1.0.0.json:2253
 msgid "lang_tsn"
 msgstr "tswana"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2260
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2295
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4771
+#: sonar/common/jsonschemas/language-v1.0.0.json:2257
 msgid "lang_tso"
 msgstr "tsonga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2264
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2299
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4775
+#: sonar/common/jsonschemas/language-v1.0.0.json:2261
 msgid "lang_tuk"
 msgstr "turkmène"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2268
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2303
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4779
+#: sonar/common/jsonschemas/language-v1.0.0.json:2265
 msgid "lang_tum"
 msgstr "tumbuka"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2272
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2307
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4783
+#: sonar/common/jsonschemas/language-v1.0.0.json:2269
 msgid "lang_tup"
 msgstr "tupi, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2276
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2311
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4787
+#: sonar/common/jsonschemas/language-v1.0.0.json:2273
 msgid "lang_tur"
 msgstr "turc"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2280
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2315
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4791
+#: sonar/common/jsonschemas/language-v1.0.0.json:2277
 msgid "lang_tut"
 msgstr "altaïques, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2284
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2319
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4795
+#: sonar/common/jsonschemas/language-v1.0.0.json:2281
 msgid "lang_tvl"
 msgstr "tuvalu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2288
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2323
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4799
+#: sonar/common/jsonschemas/language-v1.0.0.json:2285
 msgid "lang_twi"
 msgstr "twi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2292
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2327
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4803
+#: sonar/common/jsonschemas/language-v1.0.0.json:2289
 msgid "lang_tyv"
 msgstr "touvain"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2296
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2331
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4807
+#: sonar/common/jsonschemas/language-v1.0.0.json:2293
 msgid "lang_udm"
 msgstr "oudmourte"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2300
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2335
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4811
+#: sonar/common/jsonschemas/language-v1.0.0.json:2297
 msgid "lang_uga"
 msgstr "ougaritique"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2304
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2339
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4815
+#: sonar/common/jsonschemas/language-v1.0.0.json:2301
 msgid "lang_uig"
 msgstr "ouïghour"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2308
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2343
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4819
+#: sonar/common/jsonschemas/language-v1.0.0.json:2305
 msgid "lang_ukr"
 msgstr "ukrainien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2312
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2347
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4823
+#: sonar/common/jsonschemas/language-v1.0.0.json:2309
 msgid "lang_umb"
 msgstr "umbundu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2316
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2351
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4827
+#: sonar/common/jsonschemas/language-v1.0.0.json:2313
 msgid "lang_und"
 msgstr "langue indéterminée"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2320
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2355
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4831
+#: sonar/common/jsonschemas/language-v1.0.0.json:2317
 msgid "lang_urd"
 msgstr "ourdou"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2324
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2359
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4835
+#: sonar/common/jsonschemas/language-v1.0.0.json:2321
 msgid "lang_uzb"
 msgstr "ouzbek"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2328
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2363
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4839
+#: sonar/common/jsonschemas/language-v1.0.0.json:2325
 msgid "lang_vai"
 msgstr "vaï"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2332
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2367
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4843
+#: sonar/common/jsonschemas/language-v1.0.0.json:2329
 msgid "lang_ven"
 msgstr "venda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2336
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2371
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4847
+#: sonar/common/jsonschemas/language-v1.0.0.json:2333
 msgid "lang_vie"
 msgstr "vietnamien"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2340
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2375
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4851
+#: sonar/common/jsonschemas/language-v1.0.0.json:2337
 msgid "lang_vol"
 msgstr "volapük"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2344
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2379
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4855
+#: sonar/common/jsonschemas/language-v1.0.0.json:2341
 msgid "lang_vot"
 msgstr "vote"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2348
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2383
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4859
+#: sonar/common/jsonschemas/language-v1.0.0.json:2345
 msgid "lang_wak"
 msgstr "wakashennes, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2352
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2387
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4863
+#: sonar/common/jsonschemas/language-v1.0.0.json:2349
 msgid "lang_wal"
 msgstr "walamo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2356
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2391
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4867
+#: sonar/common/jsonschemas/language-v1.0.0.json:2353
 msgid "lang_war"
 msgstr "waray"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2360
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2395
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4871
+#: sonar/common/jsonschemas/language-v1.0.0.json:2357
 msgid "lang_was"
 msgstr "washo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2364
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2399
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4875
+#: sonar/common/jsonschemas/language-v1.0.0.json:2361
 msgid "lang_wel"
 msgstr "gallois"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2368
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2403
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4879
+#: sonar/common/jsonschemas/language-v1.0.0.json:2365
 msgid "lang_wen"
 msgstr "sorabes, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2372
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2407
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4883
+#: sonar/common/jsonschemas/language-v1.0.0.json:2369
 msgid "lang_wln"
 msgstr "wallon"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2376
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2411
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4887
+#: sonar/common/jsonschemas/language-v1.0.0.json:2373
 msgid "lang_wol"
 msgstr "wolof"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2380
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2415
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4891
+#: sonar/common/jsonschemas/language-v1.0.0.json:2377
 msgid "lang_xal"
 msgstr "kalmouk"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2384
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2419
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4895
+#: sonar/common/jsonschemas/language-v1.0.0.json:2381
 msgid "lang_xho"
 msgstr "xhosa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2388
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2423
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4899
+#: sonar/common/jsonschemas/language-v1.0.0.json:2385
 msgid "lang_yao"
 msgstr "yao"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2392
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2427
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4903
+#: sonar/common/jsonschemas/language-v1.0.0.json:2389
 msgid "lang_yap"
 msgstr "yapois"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2396
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2431
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4907
+#: sonar/common/jsonschemas/language-v1.0.0.json:2393
 msgid "lang_yid"
 msgstr "yiddish"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2400
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2435
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4911
+#: sonar/common/jsonschemas/language-v1.0.0.json:2397
 msgid "lang_yor"
 msgstr "yoruba"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2404
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2439
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4915
+#: sonar/common/jsonschemas/language-v1.0.0.json:2401
 msgid "lang_ypk"
 msgstr "yupik, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2408
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2443
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4919
+#: sonar/common/jsonschemas/language-v1.0.0.json:2405
 msgid "lang_zap"
 msgstr "zapotèque"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2412
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2447
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4923
+#: sonar/common/jsonschemas/language-v1.0.0.json:2409
 msgid "lang_zbl"
 msgstr "symboles Bliss"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2416
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2451
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4927
+#: sonar/common/jsonschemas/language-v1.0.0.json:2413
 msgid "lang_zen"
 msgstr "zenaga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2420
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2455
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4931
+#: sonar/common/jsonschemas/language-v1.0.0.json:2417
 msgid "lang_zha"
 msgstr "zhuang"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2424
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2459
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4935
+#: sonar/common/jsonschemas/language-v1.0.0.json:2421
 msgid "lang_znd"
 msgstr "zandé, langues"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2428
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2463
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4939
+#: sonar/common/jsonschemas/language-v1.0.0.json:2425
 msgid "lang_zul"
 msgstr "zoulou"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2432
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2467
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4943
+#: sonar/common/jsonschemas/language-v1.0.0.json:2429
 msgid "lang_zun"
 msgstr "zuñi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2436
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2471
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4947
+#: sonar/common/jsonschemas/language-v1.0.0.json:2433
 msgid "lang_zxx"
 msgstr "sans contenu linguistique"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2440
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2475
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4951
+#: sonar/common/jsonschemas/language-v1.0.0.json:2437
 msgid "lang_zza"
 msgstr "zazaki"
 
@@ -5733,12 +4838,11 @@ msgstr "zazaki"
 msgid "mainTeam"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:923
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1743
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1034
 msgid "name"
 msgstr "nom"
 
-#: sonar/modules/documents/views.py:172
+#: sonar/modules/documents/views.py:178
 msgid "no."
 msgstr "no."
 
@@ -5746,11 +4850,11 @@ msgstr "no."
 msgid "other files"
 msgstr "autres fichiers"
 
-#: sonar/modules/documents/views.py:176
+#: sonar/modules/documents/views.py:182
 msgid "p."
 msgstr "p."
 
-#: sonar/config.py:546
+#: sonar/config.py:570
 msgid "pid"
 msgstr "pid"
 
@@ -5814,7 +4918,7 @@ msgstr ""
 msgid "startDate"
 msgstr ""
 
-#: sonar/config.py:547
+#: sonar/config.py:571
 msgid "status"
 msgstr "statut"
 
@@ -5828,15 +4932,55 @@ msgstr "avec le soutien de"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:489
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:808
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1615
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1627
 msgid "uri"
 msgstr "URI"
 
-#: sonar/config.py:548
+#: sonar/config.py:572
 msgid "user"
 msgstr "utilisateur"
 
-#: sonar/modules/documents/views.py:168
+#: sonar/translations/manual_translations.txt:59
+msgid "validation_action_approve"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:61
+msgid "validation_action_ask_for_changes"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:58
+msgid "validation_action_publish"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:60
+msgid "validation_action_reject"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:57
+msgid "validation_action_save"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:54
+msgid "validation_status_ask_for_changes"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:50
+msgid "validation_status_in_progress"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:53
+msgid "validation_status_rejected"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:51
+msgid "validation_status_to_validate"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:52
+msgid "validation_status_validated"
+msgstr ""
+
+#: sonar/modules/documents/views.py:174
 msgid "vol."
 msgstr "vol."
 
@@ -5904,4 +5048,19 @@ msgstr ""
 
 #~ msgid "\\u200bSwiss National Science Foundation"
 #~ msgstr ""
+
+#~ msgid "Editors"
+#~ msgstr "Éditeurs"
+
+#~ msgid "In the format \\"
+#~ msgstr "Au format \"Nom, prénom\""
+
+#~ msgid "Not OA / Rights reserved"
+#~ msgstr "Pas OA / Droits réservés"
+
+#~ msgid "Other OA / license undefined"
+#~ msgstr "Autre OA / licence indéfinie"
+
+#~ msgid "Specific collections"
+#~ msgstr "Collections spécifiques"
 

--- a/sonar/translations/it/LC_MESSAGES/messages.po
+++ b/sonar/translations/it/LC_MESSAGES/messages.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
 "Report-Msgid-Bugs-To: nicolas.prongue@rero.ch\n"
-"POT-Creation-Date: 2021-06-01 15:56+0200\n"
-"PO-Revision-Date: 2021-05-27 12:34+0000\n"
+"POT-Creation-Date: 2021-06-14 13:34+0200\n"
+"PO-Revision-Date: 2021-06-11 07:32+0000\n"
 "Last-Translator: Nicolas Prongué <n.prongue@outlook.com>\n"
 "Language: it\n"
 "Language-Team: Italian "
@@ -22,7 +22,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.1\n"
 
-#: sonar/theme/views.py:65
+#: sonar/theme/views.py:67
 #, python-format
 msgid "%(icon)s Profile"
 msgstr "%(icon)s Il mio account"
@@ -35,13 +35,13 @@ msgstr ""
 msgid "About SONAR"
 msgstr "A proposito di SONAR"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:681
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:697
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:795
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:811
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:663
 msgid "Abstract"
 msgstr "Riassunto"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:678
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:792
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:659
 msgid "Abstracts"
 msgstr "Riassunti"
@@ -59,10 +59,11 @@ msgid "Accompanying material of the resource, i.e. maps."
 msgstr "Materiale allegato alla risorsa, per esempio carte."
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:844
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1651
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1663
 msgid "Acquisition terms"
 msgstr "Condizioni di disponibilità"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:77
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:210
 msgid "Action"
 msgstr "Azione"
@@ -75,7 +76,11 @@ msgstr ""
 msgid "Actor involved"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:933
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:704
+msgid "Add a new collection"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1044
 msgid "Add a new project"
 msgstr "Il progetto"
 
@@ -88,14 +93,13 @@ msgstr "Materiali supplementari"
 msgid "Administration"
 msgstr "Amministrazione"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:834
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1009
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1367
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:948
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1383
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:203
 msgid "Affiliation"
 msgstr "Affiliazione"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1180
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1196
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:159
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:250
 msgid "Agent"
@@ -131,9 +135,13 @@ msgid ""
 "underscores."
 msgstr "Deve contenere almeno 3 caratteri (unicamente minuscole o trattini bassi)."
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1484
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1496
 msgid "Author or editor"
 msgstr "Autore o editore"
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:612
+msgid "Authors / Editors"
+msgstr ""
 
 #: sonar/modules/documents/templates/documents/record.html:44
 #: sonar/theme/templates/sonar/projects/detail.html:15
@@ -144,7 +152,7 @@ msgstr "Ritorno"
 msgid "Back to SONAR"
 msgstr "Ritorno a SONAR"
 
-#: sonar/config.py:584
+#: sonar/config.py:608
 msgid "Best match"
 msgstr "Migliore corrispondenza"
 
@@ -160,12 +168,12 @@ msgstr ""
 msgid "Brief description of the report"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1788
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:30
 msgid "Bronze"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4993
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5008
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:110
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:125
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:20
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:34
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:15
@@ -183,35 +191,35 @@ msgstr "Bucket UUID utilizzato per archiviare i file"
 msgid "CAS or DAS"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:27
+#: sonar/common/jsonschemas/license-v1.0.0.json:28
 msgid "CC BY"
 msgstr "CC BY"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:31
+#: sonar/common/jsonschemas/license-v1.0.0.json:32
 msgid "CC BY-NC"
 msgstr "CC BY-NC"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:35
+#: sonar/common/jsonschemas/license-v1.0.0.json:36
 msgid "CC BY-NC-ND"
 msgstr "CC BY-NC-ND"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:39
+#: sonar/common/jsonschemas/license-v1.0.0.json:40
 msgid "CC BY-NC-SA"
 msgstr "CC BY-NC-SA"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:43
+#: sonar/common/jsonschemas/license-v1.0.0.json:44
 msgid "CC BY-ND"
 msgstr "CC BY-ND"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:47
+#: sonar/common/jsonschemas/license-v1.0.0.json:48
 msgid "CC BY-SA"
 msgstr "CC BY-SA"
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:23
+#: sonar/common/jsonschemas/license-v1.0.0.json:24
 msgid "CC0"
 msgstr "CC0"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5033
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:150
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:59
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:58
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:266
@@ -223,16 +231,16 @@ msgid "City"
 msgstr "Città"
 
 #: sonar/common/jsonschemas/classification-v1.0.0.json:2
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1015
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1031
 #: sonar/modules/documents/templates/documents/record.html:262
 msgid "Classification"
 msgstr "Classificazione"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1066
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1082
 msgid "Classification portion"
 msgstr "Indice di classificazione"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1011
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1027
 msgid "Classifications"
 msgstr "Classificazioni"
 
@@ -244,7 +252,7 @@ msgstr ""
 msgid "Click here to reset your password"
 msgstr "Cliccare qui per ripristinare la parola d'ordine"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1792
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:34
 msgid "Closed"
 msgstr ""
 
@@ -252,18 +260,27 @@ msgstr ""
 msgid "Code"
 msgstr "Codice"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:999
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:680
 msgid "Collection"
 msgstr "Collezione"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:4
+#: sonar/modules/collections/templates/collections/index.html:21
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:676
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:995
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:999
+#: sonar/modules/documents/templates/documents/record.html:288
 msgid "Collections"
 msgstr "Collezioni"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:106
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:245
 msgid "Comment"
 msgstr "Commento"
+
+#: sonar/common/jsonschemas/validation-v1.0.0.json:107
+msgid "Comment associated with the current action."
+msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:513
 msgid "Company"
@@ -281,37 +298,41 @@ msgstr "Confermare E-mail"
 msgid "Contact"
 msgstr "Contatto"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1094
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:540
+msgid "Contained in (journal, book, proceedings)"
+msgstr ""
+
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1110
 msgid "Content note"
 msgstr "Nota di contenuto"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1090
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1106
 msgid "Content notes"
 msgstr "Note di contenuto"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1175
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1480
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1191
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1492
 msgid "Contribution"
 msgstr "Contributo"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1171
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1187
 msgid "Contributions"
 msgstr "Contributi"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:814
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:928
 msgid "Contributor"
 msgstr "Contributore"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:808
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:922
 msgid "Contributors"
 msgstr "Contributori"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1379
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1395
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:212
 msgid "Controlled affiliation"
 msgstr "Affiliazione controllata"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1375
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1391
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:208
 msgid "Controlled affiliations"
 msgstr "Affiliazioni controllate"
@@ -321,27 +342,36 @@ msgstr "Affiliazioni controllate"
 msgid "Creativity, transformations and innovations in education"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:78
+msgid "Current action done in the validation process."
+msgstr ""
+
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:173
 msgid "Current cataloguing step."
 msgstr "Tappa attuale di catalogazione."
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1799
+#: sonar/common/jsonschemas/validation-v1.0.0.json:65
+msgid "Current status of the record in the validation process."
+msgstr ""
+
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1774
 msgid "Custom field 1"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1819
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1794
 msgid "Custom field 2"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1839
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1814
 msgid "Custom field 3"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:42
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:240
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:777
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:891
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:496
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1123
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1295
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1139
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1311
 msgid "Date"
 msgstr "Data"
 
@@ -353,14 +383,18 @@ msgstr "Data secondo il formato YYYY-MM-JJ, es: 1970-01-01"
 msgid "Date of approval by the Team Leader"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1271
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1287
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:34
 msgid "Date of birth"
 msgstr "Data di nascita"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1279
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1295
 msgid "Date of death"
 msgstr "Data di morte"
+
+#: sonar/common/jsonschemas/validation-v1.0.0.json:43
+msgid "Date when the log is created."
+msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:640
 msgid "Dean of a school"
@@ -371,8 +405,8 @@ msgstr ""
 msgid "Dear %(email)s"
 msgstr "Gentile %(email)s"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:762
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1108
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:876
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1124
 msgid "Degree"
 msgstr "Diploma"
 
@@ -388,20 +422,22 @@ msgstr "Rifiuto del deposito"
 msgid "Deposit to validate"
 msgstr "Deposito da convalidare"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5003
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:120
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:30
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:236
 msgid "Describes the information of a single file in the record."
 msgstr "Descrive l'informazione di un singolo file nella risorsa."
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2497
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:941
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:56
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:740
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1052
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:38
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:55
 msgid "Description"
 msgstr "Descrizione"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2493
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:52
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:736
 msgid "Descriptions"
 msgstr ""
 
@@ -417,8 +453,8 @@ msgstr ""
 msgid "Director, head of establishment"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:757
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1103
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:871
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1119
 msgid "Dissertation"
 msgstr "Dissertazione"
 
@@ -434,12 +470,12 @@ msgstr ""
 msgid "Doctorate supported by the HEP-VS"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:558
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1117
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:556
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1124
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:3
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:958
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1411
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1445
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1423
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1457
 msgid "Document"
 msgstr "Documento"
 
@@ -447,7 +483,7 @@ msgstr "Documento"
 msgid "Document ID"
 msgstr "Identificativo del documento"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1118
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1125
 msgid "Document created on basis of this deposit."
 msgstr "Documento creato sulla base di questo deposito."
 
@@ -485,10 +521,6 @@ msgstr "E-mail"
 msgid "Edition"
 msgstr "Edizione"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:596
-msgid "Editors"
-msgstr "Editori"
-
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:211
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:273
 msgid "Education, childhood and the learning Society 21"
@@ -517,7 +549,7 @@ msgid "Emotions, learning, and well-being at school"
 msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:80
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:959
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1075
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:79
 msgid "End date"
 msgstr "Data di fine"
@@ -545,8 +577,15 @@ msgstr ""
 "Inserisca il suo e-mail qui sotto e le invieremo un collegamento per "
 "ripristinare la sua parola d'ordine."
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:886
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1020
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:569
+msgid "Example: 1"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:586
+msgid "Example: 10"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1000
 msgid "Example: 1111-2222-3333-4444"
 msgstr "Esempio: 1111-2222-3333-4444"
 
@@ -555,13 +594,11 @@ msgstr "Esempio: 1111-2222-3333-4444"
 msgid "Example: 2019 or 2019-01-01"
 msgstr "Esempio: 2019 o 2019-01-01"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:782
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1127
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:896
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1143
 msgid "Example: 2019 or 2019-05-05"
 msgstr "Esempio: 2019 o 2019-05-05"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:953
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:960
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:153
 msgid "Example: 2019-05-05"
 msgstr "Esempio: 2019-05-05"
@@ -572,6 +609,8 @@ msgstr "Esempio: 2020"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:75
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:88
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1070
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1082
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:74
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:87
 msgid "Example: 2020-12-01"
@@ -585,17 +624,17 @@ msgstr "Esempio: Doe"
 msgid "Example: John"
 msgstr "Esempio: John"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1488
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1500
 msgid "Example: Muller, Hans"
 msgstr "Esempio: Bernasconi, Mario"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:638
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:655
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:977
 msgid "Example: Published version"
 msgstr "Esempio: Versione pubblicata"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:591
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1441
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:602
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1453
 msgid "Examples: 135, 5-27, …"
 msgstr "Esempi: 135, 5-27, …"
 
@@ -603,7 +642,11 @@ msgstr "Esempi: 135, 5-27, …"
 msgid "Except within organisation"
 msgstr "Eccetto all'interno dell'organizzazione"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:913
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:685
+msgid "Existing collection"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1024
 msgid "Existing project"
 msgstr "Progetto esistente"
 
@@ -631,20 +674,20 @@ msgstr ""
 msgid "External partners are involved"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5013
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:130
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:39
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:35
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:246
 msgid "File UUID"
 msgstr "UUID del file"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5002
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:119
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:29
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:235
 msgid "File item"
 msgstr "File item"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4998
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:115
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:25
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:21
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:231
@@ -695,7 +738,7 @@ msgstr "Formato, per esempio dimensioni in cm."
 msgid "Formats"
 msgstr "Formati"
 
-#: sonar/config.py:72
+#: sonar/config.py:74
 msgid "French"
 msgstr "Francese"
 
@@ -716,12 +759,10 @@ msgstr ""
 msgid "Funding number"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1048
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:245
 msgid "Funding organisation"
 msgstr "Agenzia di finanziamento"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1045
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:241
 #: sonar/theme/templates/sonar/projects/detail.html:64
 msgid "Funding organisations"
@@ -735,20 +776,20 @@ msgstr ""
 msgid "Funding was granted for the project"
 msgstr ""
 
-#: sonar/config.py:72
+#: sonar/config.py:74
 msgid "German"
 msgstr "Tedesco"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1780
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:22
 msgid "Gold"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:772
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1118
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:886
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1134
 msgid "Granting institution"
 msgstr "Istituzione che eroga il contributo"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1776
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:18
 msgid "Green"
 msgstr ""
 
@@ -776,7 +817,7 @@ msgstr "Markup HTML ammesso."
 msgid "Harvested"
 msgstr "Raccolto"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:18
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:18
 msgid "Hash key"
 msgstr ""
 
@@ -784,8 +825,8 @@ msgstr ""
 msgid "Help & Documentation"
 msgstr "Aiuto & documentazione"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:559
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1451
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:557
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1463
 msgid ""
 "Host document, for example a journal for an article, or a book for a book"
 " chapter."
@@ -797,7 +838,7 @@ msgstr ""
 msgid "How are research results used in training?"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1784
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:26
 msgid "Hybrid"
 msgstr ""
 
@@ -806,24 +847,22 @@ msgid "IR hosting service"
 msgstr "Servizio di hosting IR"
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:867
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1674
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1686
 msgid "ISBN/ISSN status should be selected in the list below."
 msgstr "ISBN/ISSN statuto deve essere selezionato nell'elenco sottostante."
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1220
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1236
 msgid "Identified by"
 msgstr "Identificato da"
 
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:2
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:3
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:9
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:13
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:13
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:15
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:360
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:966
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1058
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:693
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1500
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1512
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:13
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:13
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:9
@@ -834,7 +873,7 @@ msgstr "identificatore"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:357
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:689
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1496
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1508
 #: sonar/modules/documents/templates/documents/record.html:237
 msgid "Identifiers"
 msgstr "Identificatori"
@@ -850,10 +889,6 @@ msgstr "Se questo campo è compilato, il file punta all'URL specificato."
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:316
 msgid "In progress"
 msgstr ""
-
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:597
-msgid "In the format \\"
-msgstr "In formato \"Cognome, nome\""
 
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:118
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:165
@@ -881,12 +916,10 @@ msgstr ""
 msgid "Invenio"
 msgstr "Invenio"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:974
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:154
 msgid "Investigator"
 msgstr "Ricercatore"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:971
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:150
 #: sonar/theme/templates/sonar/projects/detail.html:35
 msgid "Investigators"
@@ -900,21 +933,21 @@ msgstr "È un'organizzazione dedicata"
 msgid "Is shared"
 msgstr "Appare nel portale condiviso"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1429
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1441
 msgid "Issue"
 msgstr "Numero"
 
-#: sonar/config.py:73
+#: sonar/config.py:75
 msgid "Italian"
 msgstr "Italiano"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:767
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1113
-#: sonar/modules/documents/views.py:234
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:881
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1129
+#: sonar/modules/documents/views.py:240
 msgid "Jury note"
 msgstr "Nota della giuria"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5023
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:140
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:49
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:47
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:256
@@ -925,7 +958,12 @@ msgstr "Chiave"
 msgid "Key (filename) of the file."
 msgstr "Chiave (nome) del file."
 
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:835
+msgid "Keyword"
+msgstr ""
+
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:391
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:832
 msgid "Keywords"
 msgstr ""
 
@@ -933,7 +971,7 @@ msgstr ""
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:69
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:503
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:903
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1154
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1170
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:94
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:141
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:188
@@ -947,8 +985,6 @@ msgid "Labels"
 msgstr ""
 
 #: sonar/common/jsonschemas/language-v1.0.0.json:2
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:37
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2513
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:354
 #: sonar/modules/documents/templates/documents/record.html:221
 msgid "Language"
@@ -971,7 +1007,7 @@ msgstr "Ultimo aggiornamento del set OAI-PMH (timestamp formattato ISO8601)"
 msgid "Last name"
 msgstr "Cognome"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:829
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:943
 msgid "Last name, first name, ex: Doe, John"
 msgstr "Cognome, nome, es: Bernasconi, Mario"
 
@@ -980,9 +1016,13 @@ msgid "Lecturer/professor"
 msgstr ""
 
 #: sonar/common/jsonschemas/license-v1.0.0.json:2
-#: sonar/modules/documents/templates/documents/record.html:288
+#: sonar/modules/documents/templates/documents/record.html:306
 msgid "License"
 msgstr "Licenza"
+
+#: sonar/common/jsonschemas/license-v1.0.0.json:52
+msgid "License undefined"
+msgstr ""
 
 #: sonar/theme/templates/sonar/projects/detail.html:79
 msgid "Linked documents"
@@ -1000,17 +1040,22 @@ msgstr ""
 "all'interno dell'organizzazione. Nota: il record bibliografico (metadati)"
 " è sempre pubblico. Inserire una regola per riga."
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4999
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:116
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:26
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:22
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:232
 msgid "List of files attached to the record."
 msgstr "Lista dei files legati alla risorsa."
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:21
+msgid "List of logs."
+msgstr ""
+
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:878
 msgid "Locality (Valais)"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:25
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:188
 msgid "Log"
 msgstr "Log"
@@ -1045,11 +1090,12 @@ msgstr ""
 msgid "Logout"
 msgstr "Disconnettersi"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:20
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:184
 msgid "Logs"
 msgstr "Logs"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5034
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:151
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:60
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:59
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:267
@@ -1068,11 +1114,11 @@ msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:291
 msgid "Main title"
-msgstr "Titolo principale"
+msgstr "Titolo"
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:287
 msgid "Main titles"
-msgstr "Titoli principali"
+msgstr "Titoli"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:836
 msgid "Mandate"
@@ -1090,38 +1136,38 @@ msgstr ""
 msgid "Mediator"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5028
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:145
 msgid "Mimetype"
 msgstr ""
 
-#: sonar/config.py:578
+#: sonar/config.py:602
 msgid "Most recent"
 msgstr "Più recente"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:356
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:535
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:898
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:27
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:828
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:936
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:979
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1053
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:27
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:711
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:942
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1047
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:33
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:50
 msgid "Name"
 msgstr "Nome"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:23
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:23
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:707
 msgid "Names"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:55
-msgid "Not OA / Rights reserved"
-msgstr "Non OA / Diritti riservati"
+#: sonar/modules/collections/templates/collections/index.html:32
+msgid "No collection found"
+msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:650
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:828
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1635
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1647
 msgid "Note"
 msgstr "Nota"
 
@@ -1139,8 +1185,8 @@ msgid "Notes"
 msgstr "Note"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:741
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:577
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1303
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:579
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1319
 msgid "Number"
 msgstr "Numero"
 
@@ -1160,8 +1206,7 @@ msgstr "Set OAI-PMH per i record."
 msgid "OAI-PMH specific information."
 msgstr "Informazione specifica OAI-PMH."
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:880
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1014
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:994
 msgid "ORCID"
 msgstr "ORCID"
 
@@ -1170,18 +1215,17 @@ msgstr "ORCID"
 msgid "Object type"
 msgstr "Tipo di oggetto"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1760
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:2
 msgid "Open access status"
 msgstr "Statuto Open Access"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:93
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4969
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4973
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:86
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:90
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:222
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:5
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:84
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:287
-#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:291
 msgid "Organisation"
 msgstr "Organizzazione"
 
@@ -1222,26 +1266,22 @@ msgstr ""
 "Altre caratteristiche materiali, per esempio illustrazioni, bianco e "
 "nero, o colori."
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:51
-msgid "Other OA / license undefined"
-msgstr "Altro OA / licenza indefinita"
-
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:882
 msgid "Other canton (Switzerland)"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:624
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:641
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:953
 #: sonar/modules/documents/templates/documents/record.html:208
 msgid "Other electronic version"
 msgstr "Altra versione elettronica"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:621
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:638
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:949
 msgid "Other electronic versions"
 msgstr "Altre versioni elettroniche"
 
-#: sonar/modules/documents/templates/documents/record.html:311
+#: sonar/modules/documents/templates/documents/record.html:329
 msgid "Other files"
 msgstr "Altri files"
 
@@ -1254,8 +1294,8 @@ msgstr ""
 msgid "PID type"
 msgstr "Tipo di PID"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:585
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1437
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:596
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1449
 msgid "Pages"
 msgstr "Pagine"
 
@@ -1263,8 +1303,7 @@ msgstr "Pagine"
 msgid "Parents"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:540
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1407
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1419
 msgid "Part of (host document)"
 msgstr "Contenuto in (documento ospitante)"
 
@@ -1276,7 +1315,7 @@ msgstr ""
 msgid "Period"
 msgstr "Periodo"
 
-#: sonar/modules/documents/templates/documents/record.html:301
+#: sonar/modules/documents/templates/documents/record.html:319
 msgid "Permalink"
 msgstr "Permalink"
 
@@ -1293,7 +1332,7 @@ msgstr "Numero di telefono"
 msgid "Phone number with the international prefix, without spaces."
 msgstr "Numero di telefono con il prefisso internazionale, senza spazi."
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1287
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1303
 msgid "Place"
 msgstr "Luogo"
 
@@ -1304,6 +1343,15 @@ msgstr ""
 #: sonar/templates/security/email/welcome.html:5
 msgid "Please confirm your e-mail by clicking here"
 msgstr "Confermare l'indirizzo E-mail cliccando qui"
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:573
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:590
+msgid "Please enter a valid number."
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:606
+msgid "Please enter a valid pages range, example: 135, 5-27."
+msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:85
 msgid "Position"
@@ -1334,13 +1382,13 @@ msgstr ""
 msgid "Practitioner-trainer"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1210
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1226
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:164
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:255
 msgid "Preferred name"
 msgstr "Nome preferito"
 
-#: sonar/modules/documents/templates/documents/record.html:329
+#: sonar/modules/documents/templates/documents/record.html:347
 #: sonar/theme/templates/sonar/preview/base.html:23
 msgid "Preview"
 msgstr "Anteprima"
@@ -1360,11 +1408,11 @@ msgstr ""
 
 #: sonar/theme/templates/sonar/partial/dropdown_user.html:21
 #: sonar/theme/templates/sonar/partial/dropdown_user.html:24
-#: sonar/theme/views.py:66
+#: sonar/theme/views.py:68
 msgid "Profile"
 msgstr "Profilo"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:916
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1027
 msgid "Project"
 msgstr "Progetto"
 
@@ -1404,12 +1452,12 @@ msgstr "Accesso pubblico dal"
 msgid "Public foundation"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:633
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:650
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:973
 msgid "Public note"
 msgstr "Nota pubblica"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1456
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1468
 msgid "Publication"
 msgstr "Pubblicazione"
 
@@ -1422,12 +1470,12 @@ msgid "Published in"
 msgstr "Pubblicato in"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:332
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:606
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:623
 msgid "Publisher"
 msgstr "Editore"
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:836
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1643
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1655
 msgid "Qualifier"
 msgstr "Qualificazione"
 
@@ -1435,15 +1483,19 @@ msgstr "Qualificazione"
 msgid "Realization framework"
 msgstr ""
 
+#: sonar/modules/validation/api.py:216
+msgid "Record validation"
+msgstr ""
+
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:4
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:908
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1732
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1019
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1744
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:4
 msgid "Research project"
 msgstr "Progetto di ricerca"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:901
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1728
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1015
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1740
 #: sonar/modules/documents/templates/documents/record.html:183
 msgid "Research projects"
 msgstr "Progetto di ricerca"
@@ -1459,15 +1511,18 @@ msgstr "Reimpostare la parola d'ordine"
 msgid "Responsibility"
 msgstr "Responsabilità"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:839
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:984
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1330
+#: sonar/common/jsonschemas/license-v1.0.0.json:56
+msgid "Rights reserved"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:953
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1346
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:99
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:181
 msgid "Role"
 msgstr "Ruolo"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1326
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1342
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:177
 msgid "Roles"
 msgstr "Ruoli"
@@ -1490,6 +1545,10 @@ msgstr "Logo di SONAR"
 msgid "Schema"
 msgstr "Schema"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:3
+msgid "Schema representing a validation workflow."
+msgstr ""
+
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:9
 msgid "Schema to validate document against."
 msgstr "Schema di validazione delle notizie bibliografiche."
@@ -1504,6 +1563,10 @@ msgstr ""
 #: sonar/theme/templates/sonar/partial/organisation.html:21
 msgid "Search"
 msgstr "Ricerca"
+
+#: sonar/modules/collections/templates/collections/item.html:48
+msgid "Search in collection"
+msgstr ""
 
 #: sonar/theme/templates/sonar/frontpage.html:57
 msgid "Search publications, authors, projects..."
@@ -1562,14 +1625,14 @@ msgstr "Iscriversi con %(type)s"
 msgid "Sign-up with SWITCHaai"
 msgstr "Iscriversi con SWITCHaai"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5039
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:156
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:65
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:64
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:272
 msgid "Size"
 msgstr "Dimensione"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5040
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:157
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:66
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:65
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:273
@@ -1584,8 +1647,8 @@ msgstr ""
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:510
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:849
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:926
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1245
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1656
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1261
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1668
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:117
 msgid "Source"
 msgstr "Fonte"
@@ -1598,13 +1661,9 @@ msgstr "Codice sorgente su"
 msgid "Special education teacher"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:659
-msgid "Specific collections"
-msgstr "Collezioni specifiche"
-
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:67
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:952
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1461
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1063
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1473
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:66
 msgid "Start date"
 msgstr "Data di inizio"
@@ -1630,7 +1689,7 @@ msgid "State of Valais, parastatal institution"
 msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:474
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1466
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1478
 msgid "Statement"
 msgstr "Formulazione"
 
@@ -1638,10 +1697,11 @@ msgstr "Formulazione"
 msgid "Statements"
 msgstr "Formulazioni"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:64
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:39
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:136
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:860
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1667
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1679
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:39
 msgid "Status"
 msgstr "Statuto"
@@ -1670,14 +1730,11 @@ msgstr ""
 msgid "Student in training"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:721
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:898
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:915
 msgid "Subject"
 msgstr "Soggetto"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:718
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:737
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:894
 msgid "Subjects"
 msgstr "Soggetti"
@@ -1699,7 +1756,7 @@ msgstr "Super amministrazione"
 msgid "Suspended"
 msgstr ""
 
-#: sonar/config.py:94 sonar/config.py:98
+#: sonar/config.py:96 sonar/config.py:100
 msgid "Swiss Open Access Repository"
 msgstr "Swiss Open Access Repository"
 
@@ -1735,7 +1792,7 @@ msgstr ""
 "scientifiche. Colleziona e promuove le pubblicazioni ad accesso aperto di"
 " persone affiliate a istituzioni svizzere di ricerca pubbliche."
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:660
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:677
 msgid ""
 "The names of the organisation's specific/patrimonial collections to which"
 " this document belongs"
@@ -1766,7 +1823,7 @@ msgstr ""
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:304
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:264
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:627
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1450
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1462
 msgid "Title"
 msgstr "Titolo"
 
@@ -1809,11 +1866,11 @@ msgstr ""
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:449
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:478
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:698
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1022
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1052
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1185
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1225
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1505
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1038
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1068
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1201
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1241
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1517
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:97
 msgid "Type"
 msgstr "Tipo"
@@ -1826,7 +1883,7 @@ msgstr ""
 msgid "Type of the file"
 msgstr "Tipo di file"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:643
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:660
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:963
 msgid "URL"
 msgstr "URL"
@@ -1843,10 +1900,12 @@ msgstr "UUID of the ObjectVersion object."
 msgid "UUID of the bucket the tile is assigned to."
 msgstr "UUID del bucket a cui è assegnato il tile."
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1146
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1162
 msgid "Usage and access policy"
 msgstr "Politica di utilizzo e accesso"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:90
+#: sonar/common/jsonschemas/validation-v1.0.0.json:96
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:116
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:121
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:120
@@ -1854,15 +1913,25 @@ msgstr "Politica di utilizzo e accesso"
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:198
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:202
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:5
-#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:311
-#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:316
+#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:310
+#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:315
 msgid "User"
 msgstr "Utente"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:91
+msgid "User which created the record."
+msgstr ""
+
+#: sonar/common/jsonschemas/validation-v1.0.0.json:2
+msgid "Validation"
+msgstr ""
+
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:39
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:32
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2502
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:32
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:61
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:505
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:716
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:745
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:296
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:320
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:405
@@ -1871,8 +1940,8 @@ msgstr "Utente"
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:668
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:823
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:911
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1256
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1630
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1272
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1642
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:99
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:146
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:193
@@ -1880,7 +1949,11 @@ msgstr "Utente"
 msgid "Value"
 msgstr "Valore"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5018
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:851
+msgid "Values"
+msgstr ""
+
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:135
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:44
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:41
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:251
@@ -1891,8 +1964,8 @@ msgstr "UUID della versione"
 msgid "Vice-rector HE"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:569
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1421
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:562
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1433
 msgid "Volume"
 msgstr "Volume"
 
@@ -1900,7 +1973,7 @@ msgstr "Volume"
 msgid "Welcome to SONAR"
 msgstr "Benvenuti su SONAR"
 
-#: sonar/config.py:125
+#: sonar/config.py:127
 msgid "Welcome to SONAR, the Swiss Open Access Repository!"
 msgstr "Benvenuti su SONAR, lo Swiss Open Access Repository!"
 
@@ -1932,8 +2005,7 @@ msgstr ""
 msgid "Why?"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:564
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1416
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1428
 msgid "Year"
 msgstr "Anno"
 
@@ -1955,78 +2027,78 @@ msgstr "agente"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:417
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:728
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1535
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1547
 msgid "bf:AudioIssueNumber"
 msgstr "Riferimento dell'editore (documenti audio)"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1049
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1065
 msgid "bf:ClassificationDdc"
 msgstr "Classificazione decimale Dewey (DDC)"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1019
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1035
 msgid "bf:ClassificationUdc"
 msgstr "Classificazione decimale universale"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:402
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:732
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1539
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1551
 msgid "bf:Doi"
 msgstr "DOI"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:421
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:736
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1543
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1555
 msgid "bf:Ean"
 msgstr "EAN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:425
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:740
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1547
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1559
 msgid "bf:Gtin14Number"
 msgstr "GTIN-14"
 
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:17
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:429
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:744
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1234
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1551
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1250
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1563
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:106
 msgid "bf:Identifier"
 msgstr "Identificatore"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:433
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:748
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1555
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1567
 msgid "bf:Isan"
 msgstr "ISAN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:412
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:752
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1559
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1571
 msgid "bf:Isbn"
 msgstr "ISBN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:437
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:756
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1563
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1575
 msgid "bf:Ismn"
 msgstr "ISMN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:441
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:760
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1567
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1579
 msgid "bf:Isrc"
 msgstr "ISRC"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:445
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:764
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1571
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1583
 msgid "bf:Issn"
 msgstr "ISSN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:449
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:768
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1575
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1587
 msgid "bf:IssnL"
 msgstr "ISSN-L"
 
@@ -2037,8 +2109,8 @@ msgstr "lingua"
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:21
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:453
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:772
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1238
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1579
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1254
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1591
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:110
 msgid "bf:Local"
 msgstr "Identificativo locale"
@@ -2049,37 +2121,37 @@ msgstr "Manifattura"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:457
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:776
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1583
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1595
 msgid "bf:MatrixNumber"
 msgstr "Numero di matrice (suoni)"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1203
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1219
 msgid "bf:Meeting"
 msgstr "Conferenza"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:461
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:780
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1587
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1599
 msgid "bf:MusicDistributorNumber"
 msgstr "Numero di distribuzione (musica)"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:465
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:784
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1591
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1603
 msgid "bf:MusicPlate"
 msgstr "Numero di lastra (musica a stampa)"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:469
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:788
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1595
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1607
 msgid "bf:MusicPublisherNumber"
 msgstr "Numero dell'editore (musica)"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1199
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1215
 msgid "bf:Organization"
 msgstr "Ente"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1195
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1211
 msgid "bf:Person"
 msgstr "Persona"
 
@@ -2093,41 +2165,41 @@ msgstr "Pubblicazione"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:473
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:792
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1599
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1611
 msgid "bf:PublisherNumber"
 msgstr "Numero dell'editore"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:493
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:812
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1619
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1631
 msgid "bf:ReportNumber"
 msgstr "Numero di rapporto"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:497
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:816
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1623
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1635
 msgid "bf:Strn"
 msgstr "STRN"
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:280
 msgid "bf:Title"
-msgstr "titolo"
+msgstr "titolo proprio"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:477
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:796
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1603
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1615
 msgid "bf:Upc"
 msgstr "UPC"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:481
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:800
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1607
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1619
 msgid "bf:Urn"
 msgstr "URN"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:485
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:804
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1611
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1623
 msgid "bf:VideoRecordingNumber"
 msgstr "Numero di videoregistrazione"
 
@@ -2491,41 +2563,40 @@ msgstr "Accesso aperto"
 msgid "coar:c_f1cf"
 msgstr "Sottoposto a embargo"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1002
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:195
 msgid "coinvestigator"
 msgstr "co-ricercatore"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:857
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1351
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:971
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1367
 msgid "contribution_role_cre"
 msgstr "Autore / creatore"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:861
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1359
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:975
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1375
 msgid "contribution_role_ctb"
 msgstr "Contributore"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:869
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1343
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:983
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1359
 msgid "contribution_role_dgs"
 msgstr "Supervisore accademico"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:865
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1355
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:979
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1371
 msgid "contribution_role_edt"
 msgstr "Curatore"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:873
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1347
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:987
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1363
 msgid "contribution_role_prt"
 msgstr "Stampatore"
 
-#: sonar/modules/documents/views.py:266
+#: sonar/modules/documents/views.py:272
 msgid "contribution_role_{role}"
 msgstr "contribution_role_{role}"
 
-#: sonar/config.py:549
+#: sonar/config.py:573
 msgid "contributor"
 msgstr "Contributore"
 
@@ -2809,7 +2880,6 @@ msgstr ""
 msgid "innerSearcher"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:998
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:191
 msgid "investigator"
 msgstr "ricercatore"
@@ -2818,2913 +2888,1948 @@ msgstr "ricercatore"
 msgid "keywords"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:500
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:535
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3011
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:694
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1010
+msgid "label"
+msgstr ""
+
+#: sonar/common/jsonschemas/language-v1.0.0.json:497
 msgid "lang_aar"
 msgstr "afar"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:504
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:539
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3015
+#: sonar/common/jsonschemas/language-v1.0.0.json:501
 msgid "lang_abk"
 msgstr "abcaso"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:508
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:543
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3019
+#: sonar/common/jsonschemas/language-v1.0.0.json:505
 msgid "lang_ace"
 msgstr "accinese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:512
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:547
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3023
+#: sonar/common/jsonschemas/language-v1.0.0.json:509
 msgid "lang_ach"
 msgstr "acioli"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:516
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:551
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3027
+#: sonar/common/jsonschemas/language-v1.0.0.json:513
 msgid "lang_ada"
 msgstr "adangme"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:520
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:555
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3031
+#: sonar/common/jsonschemas/language-v1.0.0.json:517
 msgid "lang_ady"
 msgstr "adyghe"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:524
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:559
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3035
+#: sonar/common/jsonschemas/language-v1.0.0.json:521
 msgid "lang_afa"
 msgstr "afroasiatiche (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:528
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:563
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3039
+#: sonar/common/jsonschemas/language-v1.0.0.json:525
 msgid "lang_afh"
 msgstr "afrihili"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:532
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:567
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3043
+#: sonar/common/jsonschemas/language-v1.0.0.json:529
 msgid "lang_afr"
 msgstr "afrikaans"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:536
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:571
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3047
+#: sonar/common/jsonschemas/language-v1.0.0.json:533
 msgid "lang_ain"
 msgstr "ainu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:540
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:575
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3051
+#: sonar/common/jsonschemas/language-v1.0.0.json:537
 msgid "lang_aka"
 msgstr "akan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:544
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:579
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3055
+#: sonar/common/jsonschemas/language-v1.0.0.json:541
 msgid "lang_akk"
 msgstr "accado"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:548
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:583
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3059
+#: sonar/common/jsonschemas/language-v1.0.0.json:545
 msgid "lang_alb"
 msgstr "albanese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:552
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:587
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3063
+#: sonar/common/jsonschemas/language-v1.0.0.json:549
 msgid "lang_ale"
 msgstr "aleuto"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:556
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:591
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3067
+#: sonar/common/jsonschemas/language-v1.0.0.json:553
 msgid "lang_alg"
 msgstr "lingue algonchine"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:560
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:595
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3071
+#: sonar/common/jsonschemas/language-v1.0.0.json:557
 msgid "lang_alt"
 msgstr "altai meridionale"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:564
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:599
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3075
+#: sonar/common/jsonschemas/language-v1.0.0.json:561
 msgid "lang_amh"
 msgstr "amarico"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:568
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:603
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3079
+#: sonar/common/jsonschemas/language-v1.0.0.json:565
 msgid "lang_ang"
 msgstr "inglese antico"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:572
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:607
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3083
+#: sonar/common/jsonschemas/language-v1.0.0.json:569
 msgid "lang_anp"
 msgstr "angika"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:576
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:611
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3087
+#: sonar/common/jsonschemas/language-v1.0.0.json:573
 msgid "lang_apa"
 msgstr "lingue apache"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:580
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:615
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3091
+#: sonar/common/jsonschemas/language-v1.0.0.json:577
 msgid "lang_ara"
 msgstr "arabo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:584
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:619
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3095
+#: sonar/common/jsonschemas/language-v1.0.0.json:581
 msgid "lang_arc"
 msgstr "aramaico"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:588
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:623
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3099
+#: sonar/common/jsonschemas/language-v1.0.0.json:585
 msgid "lang_arg"
 msgstr "aragonese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:592
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:627
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3103
+#: sonar/common/jsonschemas/language-v1.0.0.json:589
 msgid "lang_arm"
 msgstr "armeno"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:596
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:631
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3107
+#: sonar/common/jsonschemas/language-v1.0.0.json:593
 msgid "lang_arn"
 msgstr "mapudungun"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:600
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:635
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3111
+#: sonar/common/jsonschemas/language-v1.0.0.json:597
 msgid "lang_arp"
 msgstr "arapaho"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:604
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:639
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3115
+#: sonar/common/jsonschemas/language-v1.0.0.json:601
 msgid "lang_art"
 msgstr "lingua artificiale (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:608
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:643
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3119
+#: sonar/common/jsonschemas/language-v1.0.0.json:605
 msgid "lang_arw"
 msgstr "aruaco"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:612
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:647
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3123
+#: sonar/common/jsonschemas/language-v1.0.0.json:609
 msgid "lang_asm"
 msgstr "assamese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:616
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:651
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3127
+#: sonar/common/jsonschemas/language-v1.0.0.json:613
 msgid "lang_ast"
 msgstr "asturiano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:620
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:655
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3131
+#: sonar/common/jsonschemas/language-v1.0.0.json:617
 msgid "lang_ath"
 msgstr "lingue athabaska"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:624
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:659
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3135
+#: sonar/common/jsonschemas/language-v1.0.0.json:621
 msgid "lang_aus"
 msgstr "lingue australiane aborigene"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:628
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:663
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3139
+#: sonar/common/jsonschemas/language-v1.0.0.json:625
 msgid "lang_ava"
 msgstr "avaro"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:632
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:667
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3143
+#: sonar/common/jsonschemas/language-v1.0.0.json:629
 msgid "lang_ave"
 msgstr "avestan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:636
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:671
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3147
+#: sonar/common/jsonschemas/language-v1.0.0.json:633
 msgid "lang_awa"
 msgstr "awadhi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:640
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:675
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3151
+#: sonar/common/jsonschemas/language-v1.0.0.json:637
 msgid "lang_aym"
 msgstr "aymara"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:644
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:679
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3155
+#: sonar/common/jsonschemas/language-v1.0.0.json:641
 msgid "lang_aze"
 msgstr "azerbaigiano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:648
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:683
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3159
+#: sonar/common/jsonschemas/language-v1.0.0.json:645
 msgid "lang_bad"
 msgstr "banda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:652
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:687
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3163
+#: sonar/common/jsonschemas/language-v1.0.0.json:649
 msgid "lang_bai"
 msgstr "lingue bamileke"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:656
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:691
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3167
+#: sonar/common/jsonschemas/language-v1.0.0.json:653
 msgid "lang_bak"
 msgstr "baschiro"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:660
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:695
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3171
+#: sonar/common/jsonschemas/language-v1.0.0.json:657
 msgid "lang_bal"
 msgstr "beluci"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:664
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:699
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3175
+#: sonar/common/jsonschemas/language-v1.0.0.json:661
 msgid "lang_bam"
 msgstr "bambara"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:668
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:703
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3179
+#: sonar/common/jsonschemas/language-v1.0.0.json:665
 msgid "lang_ban"
 msgstr "balinese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:672
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:707
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3183
+#: sonar/common/jsonschemas/language-v1.0.0.json:669
 msgid "lang_baq"
 msgstr "basco"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:676
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:711
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3187
+#: sonar/common/jsonschemas/language-v1.0.0.json:673
 msgid "lang_bas"
 msgstr "basa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:680
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:715
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3191
+#: sonar/common/jsonschemas/language-v1.0.0.json:677
 msgid "lang_bat"
 msgstr "lingue baltiche (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:684
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:719
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3195
+#: sonar/common/jsonschemas/language-v1.0.0.json:681
 msgid "lang_bej"
 msgstr "begia"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:688
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:723
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3199
+#: sonar/common/jsonschemas/language-v1.0.0.json:685
 msgid "lang_bel"
 msgstr "bielorusso"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:692
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:727
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3203
+#: sonar/common/jsonschemas/language-v1.0.0.json:689
 msgid "lang_bem"
 msgstr "wemba"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:696
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:731
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3207
+#: sonar/common/jsonschemas/language-v1.0.0.json:693
 msgid "lang_ben"
 msgstr "bengalese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:700
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:735
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3211
+#: sonar/common/jsonschemas/language-v1.0.0.json:697
 msgid "lang_ber"
 msgstr "lingue berbere"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:704
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:739
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3215
+#: sonar/common/jsonschemas/language-v1.0.0.json:701
 msgid "lang_bho"
 msgstr "bhojpuri"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:708
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:743
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3219
+#: sonar/common/jsonschemas/language-v1.0.0.json:705
 msgid "lang_bih"
 msgstr "bihari"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:712
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:747
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3223
+#: sonar/common/jsonschemas/language-v1.0.0.json:709
 msgid "lang_bik"
 msgstr "bicol"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:716
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:751
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3227
+#: sonar/common/jsonschemas/language-v1.0.0.json:713
 msgid "lang_bin"
 msgstr "bini"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:720
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:755
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3231
+#: sonar/common/jsonschemas/language-v1.0.0.json:717
 msgid "lang_bis"
 msgstr "bislama"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:724
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:759
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3235
+#: sonar/common/jsonschemas/language-v1.0.0.json:721
 msgid "lang_bla"
 msgstr "siksika"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:728
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:763
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3239
+#: sonar/common/jsonschemas/language-v1.0.0.json:725
 msgid "lang_bnt"
 msgstr "bantu (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:732
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:767
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3243
+#: sonar/common/jsonschemas/language-v1.0.0.json:729
 msgid "lang_bos"
 msgstr "bosniaco"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:736
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:771
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3247
+#: sonar/common/jsonschemas/language-v1.0.0.json:733
 msgid "lang_bra"
 msgstr "braj"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:740
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:775
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3251
+#: sonar/common/jsonschemas/language-v1.0.0.json:737
 msgid "lang_bre"
 msgstr "bretone"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:744
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:779
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3255
+#: sonar/common/jsonschemas/language-v1.0.0.json:741
 msgid "lang_btk"
 msgstr "batak (indonesia)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:748
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:783
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3259
+#: sonar/common/jsonschemas/language-v1.0.0.json:745
 msgid "lang_bua"
 msgstr "buriat"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:752
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:787
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3263
+#: sonar/common/jsonschemas/language-v1.0.0.json:749
 msgid "lang_bug"
 msgstr "bugi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:756
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:791
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3267
+#: sonar/common/jsonschemas/language-v1.0.0.json:753
 msgid "lang_bul"
 msgstr "bulgaro"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:760
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:795
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3271
+#: sonar/common/jsonschemas/language-v1.0.0.json:757
 msgid "lang_bur"
 msgstr "birmano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:764
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:799
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3275
+#: sonar/common/jsonschemas/language-v1.0.0.json:761
 msgid "lang_byn"
 msgstr "blin"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:768
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:803
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3279
+#: sonar/common/jsonschemas/language-v1.0.0.json:765
 msgid "lang_cad"
 msgstr "caddo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:772
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:807
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3283
+#: sonar/common/jsonschemas/language-v1.0.0.json:769
 msgid "lang_cai"
 msgstr "indiane centro-americane (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:776
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:811
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3287
+#: sonar/common/jsonschemas/language-v1.0.0.json:773
 msgid "lang_car"
 msgstr "caribico"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:780
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:815
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3291
+#: sonar/common/jsonschemas/language-v1.0.0.json:777
 msgid "lang_cat"
 msgstr "catalano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:784
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:819
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3295
+#: sonar/common/jsonschemas/language-v1.0.0.json:781
 msgid "lang_cau"
 msgstr "lingue caucasiche (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:788
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:823
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3299
+#: sonar/common/jsonschemas/language-v1.0.0.json:785
 msgid "lang_ceb"
 msgstr "cebuano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:792
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:827
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3303
+#: sonar/common/jsonschemas/language-v1.0.0.json:789
 msgid "lang_cel"
 msgstr "lingue celtiche (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:796
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:831
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3307
+#: sonar/common/jsonschemas/language-v1.0.0.json:793
 msgid "lang_cha"
 msgstr "chamorro"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:800
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:835
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3311
+#: sonar/common/jsonschemas/language-v1.0.0.json:797
 msgid "lang_chb"
 msgstr "chibcha"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:804
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:839
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3315
+#: sonar/common/jsonschemas/language-v1.0.0.json:801
 msgid "lang_che"
 msgstr "ceceno"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:808
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:843
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3319
+#: sonar/common/jsonschemas/language-v1.0.0.json:805
 msgid "lang_chg"
 msgstr "ciagataico"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:812
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:847
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3323
+#: sonar/common/jsonschemas/language-v1.0.0.json:809
 msgid "lang_chi"
 msgstr "cinese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:816
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:851
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3327
+#: sonar/common/jsonschemas/language-v1.0.0.json:813
 msgid "lang_chk"
 msgstr "chuukese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:820
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:855
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3331
+#: sonar/common/jsonschemas/language-v1.0.0.json:817
 msgid "lang_chm"
 msgstr "mari"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:824
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:859
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3335
+#: sonar/common/jsonschemas/language-v1.0.0.json:821
 msgid "lang_chn"
 msgstr "gergo chinook"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:828
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:863
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3339
+#: sonar/common/jsonschemas/language-v1.0.0.json:825
 msgid "lang_cho"
 msgstr "choctaw"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:832
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:867
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3343
+#: sonar/common/jsonschemas/language-v1.0.0.json:829
 msgid "lang_chp"
 msgstr "chipewyan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:836
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:871
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3347
+#: sonar/common/jsonschemas/language-v1.0.0.json:833
 msgid "lang_chr"
 msgstr "cherokee"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:840
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:875
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3351
+#: sonar/common/jsonschemas/language-v1.0.0.json:837
 msgid "lang_chu"
 msgstr "slavo della Chiesa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:844
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:879
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3355
+#: sonar/common/jsonschemas/language-v1.0.0.json:841
 msgid "lang_chv"
 msgstr "ciuvascio"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:848
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:883
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3359
+#: sonar/common/jsonschemas/language-v1.0.0.json:845
 msgid "lang_chy"
 msgstr "cheyenne"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:852
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:887
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3363
+#: sonar/common/jsonschemas/language-v1.0.0.json:849
 msgid "lang_cmc"
 msgstr "chamic"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:856
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:891
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3367
+#: sonar/common/jsonschemas/language-v1.0.0.json:853
 msgid "lang_cnr"
 msgstr "montenegrino"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:860
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:895
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3371
+#: sonar/common/jsonschemas/language-v1.0.0.json:857
 msgid "lang_cop"
 msgstr "copto"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:864
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:899
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3375
+#: sonar/common/jsonschemas/language-v1.0.0.json:861
 msgid "lang_cor"
 msgstr "cornico"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:868
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:903
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3379
+#: sonar/common/jsonschemas/language-v1.0.0.json:865
 msgid "lang_cos"
 msgstr "corso"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:872
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:907
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3383
+#: sonar/common/jsonschemas/language-v1.0.0.json:869
 msgid "lang_cpe"
 msgstr "creoli e pidgin basati sull'inglese (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:876
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:911
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3387
+#: sonar/common/jsonschemas/language-v1.0.0.json:873
 msgid "lang_cpf"
 msgstr "creoli e pidgin basati sul francese (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:880
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:915
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3391
+#: sonar/common/jsonschemas/language-v1.0.0.json:877
 msgid "lang_cpp"
 msgstr "creoli e pidgin basati sul portoghese (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:884
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:919
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3395
+#: sonar/common/jsonschemas/language-v1.0.0.json:881
 msgid "lang_cre"
 msgstr "cree"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:888
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:923
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3399
+#: sonar/common/jsonschemas/language-v1.0.0.json:885
 msgid "lang_crh"
 msgstr "turco crimeo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:892
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:927
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3403
+#: sonar/common/jsonschemas/language-v1.0.0.json:889
 msgid "lang_crp"
 msgstr "creoli e pidgin (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:896
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:931
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3407
+#: sonar/common/jsonschemas/language-v1.0.0.json:893
 msgid "lang_csb"
 msgstr "kashubian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:900
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:935
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3411
+#: sonar/common/jsonschemas/language-v1.0.0.json:897
 msgid "lang_cus"
 msgstr "lingue cushitiche (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:904
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:939
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3415
+#: sonar/common/jsonschemas/language-v1.0.0.json:901
 msgid "lang_cze"
 msgstr "ceco"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:908
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:943
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3419
+#: sonar/common/jsonschemas/language-v1.0.0.json:905
 msgid "lang_dak"
 msgstr "dakota"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:912
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:947
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3423
+#: sonar/common/jsonschemas/language-v1.0.0.json:909
 msgid "lang_dan"
 msgstr "danese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:916
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:951
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3427
+#: sonar/common/jsonschemas/language-v1.0.0.json:913
 msgid "lang_dar"
 msgstr "dargwa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:920
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:955
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3431
+#: sonar/common/jsonschemas/language-v1.0.0.json:917
 msgid "lang_day"
 msgstr "dayak"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:924
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:959
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3435
+#: sonar/common/jsonschemas/language-v1.0.0.json:921
 msgid "lang_del"
 msgstr "delaware"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:928
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:963
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3439
+#: sonar/common/jsonschemas/language-v1.0.0.json:925
 msgid "lang_den"
 msgstr "slave"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:932
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:967
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3443
+#: sonar/common/jsonschemas/language-v1.0.0.json:929
 msgid "lang_dgr"
 msgstr "dogrib"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:936
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:971
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3447
+#: sonar/common/jsonschemas/language-v1.0.0.json:933
 msgid "lang_din"
 msgstr "dinca"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:940
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:975
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3451
+#: sonar/common/jsonschemas/language-v1.0.0.json:937
 msgid "lang_div"
 msgstr "divehi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:944
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:979
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3455
+#: sonar/common/jsonschemas/language-v1.0.0.json:941
 msgid "lang_doi"
 msgstr "dogri"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:948
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:983
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3459
+#: sonar/common/jsonschemas/language-v1.0.0.json:945
 msgid "lang_dra"
 msgstr "dravidiche (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:952
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:987
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3463
+#: sonar/common/jsonschemas/language-v1.0.0.json:949
 msgid "lang_dsb"
 msgstr "basso sorabo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:956
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:991
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3467
+#: sonar/common/jsonschemas/language-v1.0.0.json:953
 msgid "lang_dua"
 msgstr "duala"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:960
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:995
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3471
+#: sonar/common/jsonschemas/language-v1.0.0.json:957
 msgid "lang_dum"
 msgstr "olandese medio"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:964
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:999
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3475
+#: sonar/common/jsonschemas/language-v1.0.0.json:961
 msgid "lang_dut"
 msgstr "olandese; fiammingo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:968
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1003
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3479
+#: sonar/common/jsonschemas/language-v1.0.0.json:965
 msgid "lang_dyu"
 msgstr "diula"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:972
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1007
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3483
+#: sonar/common/jsonschemas/language-v1.0.0.json:969
 msgid "lang_dzo"
 msgstr "dzongkha"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:976
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1011
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3487
+#: sonar/common/jsonschemas/language-v1.0.0.json:973
 msgid "lang_efi"
 msgstr "efik"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:980
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1015
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3491
+#: sonar/common/jsonschemas/language-v1.0.0.json:977
 msgid "lang_egy"
 msgstr "egiziano antico"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:984
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1019
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3495
+#: sonar/common/jsonschemas/language-v1.0.0.json:981
 msgid "lang_eka"
 msgstr "ekajuka"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:988
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1023
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3499
+#: sonar/common/jsonschemas/language-v1.0.0.json:985
 msgid "lang_elx"
 msgstr "elamitico"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:992
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1027
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3503
+#: sonar/common/jsonschemas/language-v1.0.0.json:989
 msgid "lang_eng"
 msgstr "inglese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:997
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1032
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3508
+#: sonar/common/jsonschemas/language-v1.0.0.json:994
 msgid "lang_enm"
 msgstr "inglese medio"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1001
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1036
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3512
+#: sonar/common/jsonschemas/language-v1.0.0.json:998
 msgid "lang_epo"
 msgstr "esperanto"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1005
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1040
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3516
+#: sonar/common/jsonschemas/language-v1.0.0.json:1002
 msgid "lang_est"
 msgstr "estone"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1009
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1044
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3520
+#: sonar/common/jsonschemas/language-v1.0.0.json:1006
 msgid "lang_ewe"
 msgstr "ewe"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1013
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1048
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3524
+#: sonar/common/jsonschemas/language-v1.0.0.json:1010
 msgid "lang_ewo"
 msgstr "ewondo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1017
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1052
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3528
+#: sonar/common/jsonschemas/language-v1.0.0.json:1014
 msgid "lang_fan"
 msgstr "fang"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1021
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1056
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3532
+#: sonar/common/jsonschemas/language-v1.0.0.json:1018
 msgid "lang_fao"
 msgstr "faroese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1025
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1060
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3536
+#: sonar/common/jsonschemas/language-v1.0.0.json:1022
 msgid "lang_fat"
 msgstr "fanti"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1029
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1064
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3540
+#: sonar/common/jsonschemas/language-v1.0.0.json:1026
 msgid "lang_fij"
 msgstr "figiano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1033
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1068
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3544
+#: sonar/common/jsonschemas/language-v1.0.0.json:1030
 msgid "lang_fil"
 msgstr "filippino"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1037
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1072
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3548
+#: sonar/common/jsonschemas/language-v1.0.0.json:1034
 msgid "lang_fin"
 msgstr "finlandese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1041
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1076
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3552
+#: sonar/common/jsonschemas/language-v1.0.0.json:1038
 msgid "lang_fiu"
 msgstr "ugrofinniche (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1045
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1080
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3556
+#: sonar/common/jsonschemas/language-v1.0.0.json:1042
 msgid "lang_fon"
 msgstr "fon"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1049
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1084
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3560
+#: sonar/common/jsonschemas/language-v1.0.0.json:1046
 msgid "lang_fre"
 msgstr "francese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1054
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1089
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3565
+#: sonar/common/jsonschemas/language-v1.0.0.json:1051
 msgid "lang_frm"
 msgstr "francese medio"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1058
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1093
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3569
+#: sonar/common/jsonschemas/language-v1.0.0.json:1055
 msgid "lang_fro"
 msgstr "francese antico"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1062
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1097
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3573
+#: sonar/common/jsonschemas/language-v1.0.0.json:1059
 msgid "lang_frr"
 msgstr "frisone settentrionale"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1066
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1101
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3577
+#: sonar/common/jsonschemas/language-v1.0.0.json:1063
 msgid "lang_frs"
 msgstr "frisone orientale"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1070
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1105
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3581
+#: sonar/common/jsonschemas/language-v1.0.0.json:1067
 msgid "lang_fry"
 msgstr "frisone occidentale"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1074
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1109
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3585
+#: sonar/common/jsonschemas/language-v1.0.0.json:1071
 msgid "lang_ful"
 msgstr "fulah"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1078
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1113
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3589
+#: sonar/common/jsonschemas/language-v1.0.0.json:1075
 msgid "lang_fur"
 msgstr "friulano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1082
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1117
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3593
+#: sonar/common/jsonschemas/language-v1.0.0.json:1079
 msgid "lang_gaa"
 msgstr "ga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1086
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1121
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3597
+#: sonar/common/jsonschemas/language-v1.0.0.json:1083
 msgid "lang_gay"
 msgstr "gayo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1090
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1125
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3601
+#: sonar/common/jsonschemas/language-v1.0.0.json:1087
 msgid "lang_gba"
 msgstr "gbaya"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1094
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1129
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3605
+#: sonar/common/jsonschemas/language-v1.0.0.json:1091
 msgid "lang_gem"
 msgstr "lingue germaniche (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1098
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1133
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3609
+#: sonar/common/jsonschemas/language-v1.0.0.json:1095
 msgid "lang_geo"
 msgstr "georgiano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1102
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1137
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3613
+#: sonar/common/jsonschemas/language-v1.0.0.json:1099
 msgid "lang_ger"
 msgstr "tedesco"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1107
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1142
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3618
+#: sonar/common/jsonschemas/language-v1.0.0.json:1104
 msgid "lang_gez"
 msgstr "geez"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1111
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1146
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3622
+#: sonar/common/jsonschemas/language-v1.0.0.json:1108
 msgid "lang_gil"
 msgstr "gilbertese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1115
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1150
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3626
+#: sonar/common/jsonschemas/language-v1.0.0.json:1112
 msgid "lang_gla"
 msgstr "gaelico scozzese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1119
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1154
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3630
+#: sonar/common/jsonschemas/language-v1.0.0.json:1116
 msgid "lang_gle"
 msgstr "irlandese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1123
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1158
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3634
+#: sonar/common/jsonschemas/language-v1.0.0.json:1120
 msgid "lang_glg"
 msgstr "galiziano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1127
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1162
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3638
+#: sonar/common/jsonschemas/language-v1.0.0.json:1124
 msgid "lang_glv"
 msgstr "mannese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1131
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1166
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3642
+#: sonar/common/jsonschemas/language-v1.0.0.json:1128
 msgid "lang_gmh"
 msgstr "tedesco medio alto"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1135
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1170
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3646
+#: sonar/common/jsonschemas/language-v1.0.0.json:1132
 msgid "lang_goh"
 msgstr "tedesco antico alto"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1139
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1174
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3650
+#: sonar/common/jsonschemas/language-v1.0.0.json:1136
 msgid "lang_gon"
 msgstr "gondi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1143
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1178
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3654
+#: sonar/common/jsonschemas/language-v1.0.0.json:1140
 msgid "lang_gor"
 msgstr "gorontalo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1147
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1182
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3658
+#: sonar/common/jsonschemas/language-v1.0.0.json:1144
 msgid "lang_got"
 msgstr "gotico"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1151
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1186
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3662
+#: sonar/common/jsonschemas/language-v1.0.0.json:1148
 msgid "lang_grb"
 msgstr "grebo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1155
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1190
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3666
+#: sonar/common/jsonschemas/language-v1.0.0.json:1152
 msgid "lang_grc"
 msgstr "greco antico"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1159
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1194
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3670
+#: sonar/common/jsonschemas/language-v1.0.0.json:1156
 msgid "lang_gre"
 msgstr "greco moderno (dal 1453)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1163
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1198
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3674
+#: sonar/common/jsonschemas/language-v1.0.0.json:1160
 msgid "lang_grn"
 msgstr "guaraní"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1167
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1202
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3678
+#: sonar/common/jsonschemas/language-v1.0.0.json:1164
 msgid "lang_gsw"
 msgstr "tedesco svizzero"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1171
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1206
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3682
+#: sonar/common/jsonschemas/language-v1.0.0.json:1168
 msgid "lang_guj"
 msgstr "gujarati"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1175
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1210
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3686
+#: sonar/common/jsonschemas/language-v1.0.0.json:1172
 msgid "lang_gwi"
 msgstr "gwichʼin"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1179
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1214
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3690
+#: sonar/common/jsonschemas/language-v1.0.0.json:1176
 msgid "lang_hai"
 msgstr "haida"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1183
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1218
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3694
+#: sonar/common/jsonschemas/language-v1.0.0.json:1180
 msgid "lang_hat"
 msgstr "haitiano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1187
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1222
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3698
+#: sonar/common/jsonschemas/language-v1.0.0.json:1184
 msgid "lang_hau"
 msgstr "hausa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1191
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1226
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3702
+#: sonar/common/jsonschemas/language-v1.0.0.json:1188
 msgid "lang_haw"
 msgstr "hawaiano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1195
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1230
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3706
+#: sonar/common/jsonschemas/language-v1.0.0.json:1192
 msgid "lang_heb"
 msgstr "ebraico"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1199
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1234
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3710
+#: sonar/common/jsonschemas/language-v1.0.0.json:1196
 msgid "lang_her"
 msgstr "herero"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1203
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1238
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3714
+#: sonar/common/jsonschemas/language-v1.0.0.json:1200
 msgid "lang_hil"
 msgstr "ilongo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1207
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1242
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3718
+#: sonar/common/jsonschemas/language-v1.0.0.json:1204
 msgid "lang_him"
 msgstr "himachali"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1211
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1246
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3722
+#: sonar/common/jsonschemas/language-v1.0.0.json:1208
 msgid "lang_hin"
 msgstr "hindi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1215
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1250
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3726
+#: sonar/common/jsonschemas/language-v1.0.0.json:1212
 msgid "lang_hit"
 msgstr "hittite"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1219
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1254
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3730
+#: sonar/common/jsonschemas/language-v1.0.0.json:1216
 msgid "lang_hmn"
 msgstr "hmong"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1223
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1258
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3734
+#: sonar/common/jsonschemas/language-v1.0.0.json:1220
 msgid "lang_hmo"
 msgstr "hiri motu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1227
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1262
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3738
+#: sonar/common/jsonschemas/language-v1.0.0.json:1224
 msgid "lang_hrv"
 msgstr "croato"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1231
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1266
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3742
+#: sonar/common/jsonschemas/language-v1.0.0.json:1228
 msgid "lang_hsb"
 msgstr "alto sorabo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1235
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1270
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3746
+#: sonar/common/jsonschemas/language-v1.0.0.json:1232
 msgid "lang_hun"
 msgstr "ungherese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1239
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1274
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3750
+#: sonar/common/jsonschemas/language-v1.0.0.json:1236
 msgid "lang_hup"
 msgstr "hupa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1243
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1278
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3754
+#: sonar/common/jsonschemas/language-v1.0.0.json:1240
 msgid "lang_iba"
 msgstr "iban"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1247
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1282
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3758
+#: sonar/common/jsonschemas/language-v1.0.0.json:1244
 msgid "lang_ibo"
 msgstr "igbo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1251
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1286
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3762
+#: sonar/common/jsonschemas/language-v1.0.0.json:1248
 msgid "lang_ice"
 msgstr "islandese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1255
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1290
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3766
+#: sonar/common/jsonschemas/language-v1.0.0.json:1252
 msgid "lang_ido"
 msgstr "ido"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1259
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1294
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3770
+#: sonar/common/jsonschemas/language-v1.0.0.json:1256
 msgid "lang_iii"
 msgstr "sichuan yi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1263
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1298
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3774
+#: sonar/common/jsonschemas/language-v1.0.0.json:1260
 msgid "lang_ijo"
 msgstr "ijo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1267
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1302
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3778
+#: sonar/common/jsonschemas/language-v1.0.0.json:1264
 msgid "lang_iku"
 msgstr "inuktitut"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1271
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1306
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3782
+#: sonar/common/jsonschemas/language-v1.0.0.json:1268
 msgid "lang_ile"
 msgstr "interlingue"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1275
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1310
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3786
+#: sonar/common/jsonschemas/language-v1.0.0.json:1272
 msgid "lang_ilo"
 msgstr "ilocano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1279
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1314
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3790
+#: sonar/common/jsonschemas/language-v1.0.0.json:1276
 msgid "lang_ina"
 msgstr "interlingua"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1283
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1318
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3794
+#: sonar/common/jsonschemas/language-v1.0.0.json:1280
 msgid "lang_inc"
 msgstr "lingue indoarie (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1287
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1322
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3798
+#: sonar/common/jsonschemas/language-v1.0.0.json:1284
 msgid "lang_ind"
 msgstr "indonesiano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1291
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1326
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3802
+#: sonar/common/jsonschemas/language-v1.0.0.json:1288
 msgid "lang_ine"
 msgstr "lingue indoeuropee (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1295
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1330
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3806
+#: sonar/common/jsonschemas/language-v1.0.0.json:1292
 msgid "lang_inh"
 msgstr "ingush"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1299
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1334
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3810
+#: sonar/common/jsonschemas/language-v1.0.0.json:1296
 msgid "lang_ipk"
 msgstr "inupiak"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1303
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1338
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3814
+#: sonar/common/jsonschemas/language-v1.0.0.json:1300
 msgid "lang_ira"
 msgstr "lingue iraniche (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1307
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1342
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3818
+#: sonar/common/jsonschemas/language-v1.0.0.json:1304
 msgid "lang_iro"
 msgstr "lingue irochesi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1311
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1346
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3822
+#: sonar/common/jsonschemas/language-v1.0.0.json:1308
 msgid "lang_ita"
 msgstr "italiano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1316
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1351
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3827
+#: sonar/common/jsonschemas/language-v1.0.0.json:1313
 msgid "lang_jav"
 msgstr "giavanese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1320
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1355
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3831
+#: sonar/common/jsonschemas/language-v1.0.0.json:1317
 msgid "lang_jbo"
 msgstr "lojban"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1324
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1359
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3835
+#: sonar/common/jsonschemas/language-v1.0.0.json:1321
 msgid "lang_jpn"
 msgstr "giapponese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1328
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1363
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3839
+#: sonar/common/jsonschemas/language-v1.0.0.json:1325
 msgid "lang_jpr"
 msgstr "giudeo persiano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1332
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1367
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3843
+#: sonar/common/jsonschemas/language-v1.0.0.json:1329
 msgid "lang_jrb"
 msgstr "giudeo arabo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1336
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1371
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3847
+#: sonar/common/jsonschemas/language-v1.0.0.json:1333
 msgid "lang_kaa"
 msgstr "kara-kalpak"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1340
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1375
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3851
+#: sonar/common/jsonschemas/language-v1.0.0.json:1337
 msgid "lang_kab"
 msgstr "cabilo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1344
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1379
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3855
+#: sonar/common/jsonschemas/language-v1.0.0.json:1341
 msgid "lang_kac"
 msgstr "kachin"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1348
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1383
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3859
+#: sonar/common/jsonschemas/language-v1.0.0.json:1345
 msgid "lang_kal"
 msgstr "groenlandese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1352
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1387
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3863
+#: sonar/common/jsonschemas/language-v1.0.0.json:1349
 msgid "lang_kam"
 msgstr "kamba"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1356
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1391
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3867
+#: sonar/common/jsonschemas/language-v1.0.0.json:1353
 msgid "lang_kan"
 msgstr "kannada"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1360
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1395
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3871
+#: sonar/common/jsonschemas/language-v1.0.0.json:1357
 msgid "lang_kar"
 msgstr "karen"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1364
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1399
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3875
+#: sonar/common/jsonschemas/language-v1.0.0.json:1361
 msgid "lang_kas"
 msgstr "kashmiri"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1368
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1403
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3879
+#: sonar/common/jsonschemas/language-v1.0.0.json:1365
 msgid "lang_kau"
 msgstr "kanuri"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1372
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1407
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3883
+#: sonar/common/jsonschemas/language-v1.0.0.json:1369
 msgid "lang_kaw"
 msgstr "kawi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1376
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1411
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3887
+#: sonar/common/jsonschemas/language-v1.0.0.json:1373
 msgid "lang_kaz"
 msgstr "kazako"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1380
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1415
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3891
+#: sonar/common/jsonschemas/language-v1.0.0.json:1377
 msgid "lang_kbd"
 msgstr "cabardino"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1384
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1419
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3895
+#: sonar/common/jsonschemas/language-v1.0.0.json:1381
 msgid "lang_kha"
 msgstr "khasi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1388
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1423
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3899
+#: sonar/common/jsonschemas/language-v1.0.0.json:1385
 msgid "lang_khi"
 msgstr "khoisan (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1392
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1427
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3903
+#: sonar/common/jsonschemas/language-v1.0.0.json:1389
 msgid "lang_khm"
 msgstr "khmer"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1396
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1431
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3907
+#: sonar/common/jsonschemas/language-v1.0.0.json:1393
 msgid "lang_kho"
 msgstr "khotanese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1400
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1435
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3911
+#: sonar/common/jsonschemas/language-v1.0.0.json:1397
 msgid "lang_kik"
 msgstr "kikuyu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1404
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1439
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3915
+#: sonar/common/jsonschemas/language-v1.0.0.json:1401
 msgid "lang_kin"
 msgstr "kinyarwanda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1408
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1443
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3919
+#: sonar/common/jsonschemas/language-v1.0.0.json:1405
 msgid "lang_kir"
 msgstr "kirghiso"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1412
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1447
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3923
+#: sonar/common/jsonschemas/language-v1.0.0.json:1409
 msgid "lang_kmb"
 msgstr "kimbundu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1416
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1451
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3927
+#: sonar/common/jsonschemas/language-v1.0.0.json:1413
 msgid "lang_kok"
 msgstr "konkani"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1420
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1455
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3931
+#: sonar/common/jsonschemas/language-v1.0.0.json:1417
 msgid "lang_kom"
 msgstr "komi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1424
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1459
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3935
+#: sonar/common/jsonschemas/language-v1.0.0.json:1421
 msgid "lang_kon"
 msgstr "kongo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1428
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1463
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3939
+#: sonar/common/jsonschemas/language-v1.0.0.json:1425
 msgid "lang_kor"
 msgstr "coreano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1432
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1467
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3943
+#: sonar/common/jsonschemas/language-v1.0.0.json:1429
 msgid "lang_kos"
 msgstr "kosraean"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1436
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1471
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3947
+#: sonar/common/jsonschemas/language-v1.0.0.json:1433
 msgid "lang_kpe"
 msgstr "kpelle"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1440
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1475
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3951
+#: sonar/common/jsonschemas/language-v1.0.0.json:1437
 msgid "lang_krc"
 msgstr "karachay-Balkar"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1444
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1479
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3955
+#: sonar/common/jsonschemas/language-v1.0.0.json:1441
 msgid "lang_krl"
 msgstr "careliano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1448
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1483
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3959
+#: sonar/common/jsonschemas/language-v1.0.0.json:1445
 msgid "lang_kro"
 msgstr "kru"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1452
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1487
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3963
+#: sonar/common/jsonschemas/language-v1.0.0.json:1449
 msgid "lang_kru"
 msgstr "kurukh"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1456
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1491
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3967
+#: sonar/common/jsonschemas/language-v1.0.0.json:1453
 msgid "lang_kua"
 msgstr "kuanyama"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1460
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1495
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3971
+#: sonar/common/jsonschemas/language-v1.0.0.json:1457
 msgid "lang_kum"
 msgstr "kumyk"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1464
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1499
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3975
+#: sonar/common/jsonschemas/language-v1.0.0.json:1461
 msgid "lang_kur"
 msgstr "curdo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1468
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1503
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3979
+#: sonar/common/jsonschemas/language-v1.0.0.json:1465
 msgid "lang_kut"
 msgstr "kutenai"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1472
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1507
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3983
+#: sonar/common/jsonschemas/language-v1.0.0.json:1469
 msgid "lang_lad"
 msgstr "giudeo-spagnolo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1476
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1511
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3987
+#: sonar/common/jsonschemas/language-v1.0.0.json:1473
 msgid "lang_lah"
 msgstr "lahnda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1480
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1515
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3991
+#: sonar/common/jsonschemas/language-v1.0.0.json:1477
 msgid "lang_lam"
 msgstr "lamba"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1484
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1519
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3995
+#: sonar/common/jsonschemas/language-v1.0.0.json:1481
 msgid "lang_lao"
 msgstr "lao"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1488
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1523
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3999
+#: sonar/common/jsonschemas/language-v1.0.0.json:1485
 msgid "lang_lat"
 msgstr "latino"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1492
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1527
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4003
+#: sonar/common/jsonschemas/language-v1.0.0.json:1489
 msgid "lang_lav"
 msgstr "lettone"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1496
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1531
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4007
+#: sonar/common/jsonschemas/language-v1.0.0.json:1493
 msgid "lang_lez"
 msgstr "lesgo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1500
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1535
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4011
+#: sonar/common/jsonschemas/language-v1.0.0.json:1497
 msgid "lang_lim"
 msgstr "limburghese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1504
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1539
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4015
+#: sonar/common/jsonschemas/language-v1.0.0.json:1501
 msgid "lang_lin"
 msgstr "lingala"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1508
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1543
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4019
+#: sonar/common/jsonschemas/language-v1.0.0.json:1505
 msgid "lang_lit"
 msgstr "lituano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1512
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1547
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4023
+#: sonar/common/jsonschemas/language-v1.0.0.json:1509
 msgid "lang_lol"
 msgstr "lolo bantu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1516
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1551
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4027
+#: sonar/common/jsonschemas/language-v1.0.0.json:1513
 msgid "lang_loz"
 msgstr "lozi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1520
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1555
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4031
+#: sonar/common/jsonschemas/language-v1.0.0.json:1517
 msgid "lang_ltz"
 msgstr "lussemburghese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1524
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1559
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4035
+#: sonar/common/jsonschemas/language-v1.0.0.json:1521
 msgid "lang_lua"
 msgstr "luba-lulua"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1528
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1563
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4039
+#: sonar/common/jsonschemas/language-v1.0.0.json:1525
 msgid "lang_lub"
 msgstr "luba-katanga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1532
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1567
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4043
+#: sonar/common/jsonschemas/language-v1.0.0.json:1529
 msgid "lang_lug"
 msgstr "ganda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1536
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1571
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4047
+#: sonar/common/jsonschemas/language-v1.0.0.json:1533
 msgid "lang_lui"
 msgstr "luiseno"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1540
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1575
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4051
+#: sonar/common/jsonschemas/language-v1.0.0.json:1537
 msgid "lang_lun"
 msgstr "lunda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1544
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1579
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4055
+#: sonar/common/jsonschemas/language-v1.0.0.json:1541
 msgid "lang_luo"
 msgstr "luo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1548
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1583
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4059
+#: sonar/common/jsonschemas/language-v1.0.0.json:1545
 msgid "lang_lus"
 msgstr "lushai"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1552
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1587
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4063
+#: sonar/common/jsonschemas/language-v1.0.0.json:1549
 msgid "lang_mac"
 msgstr "macedone"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1556
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1591
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4067
+#: sonar/common/jsonschemas/language-v1.0.0.json:1553
 msgid "lang_mad"
 msgstr "madurese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1560
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1595
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4071
+#: sonar/common/jsonschemas/language-v1.0.0.json:1557
 msgid "lang_mag"
 msgstr "magahi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1564
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1599
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4075
+#: sonar/common/jsonschemas/language-v1.0.0.json:1561
 msgid "lang_mah"
 msgstr "marshallese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1568
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1603
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4079
+#: sonar/common/jsonschemas/language-v1.0.0.json:1565
 msgid "lang_mai"
 msgstr "maithili"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1572
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1607
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4083
+#: sonar/common/jsonschemas/language-v1.0.0.json:1569
 msgid "lang_mak"
 msgstr "makasar"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1576
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1611
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4087
+#: sonar/common/jsonschemas/language-v1.0.0.json:1573
 msgid "lang_mal"
 msgstr "malayalam"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1580
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1615
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4091
+#: sonar/common/jsonschemas/language-v1.0.0.json:1577
 msgid "lang_man"
 msgstr "mandingo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1584
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1619
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4095
+#: sonar/common/jsonschemas/language-v1.0.0.json:1581
 msgid "lang_mao"
 msgstr "maori"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1588
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1623
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4099
+#: sonar/common/jsonschemas/language-v1.0.0.json:1585
 msgid "lang_map"
 msgstr "austronesiano (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1592
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1627
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4103
+#: sonar/common/jsonschemas/language-v1.0.0.json:1589
 msgid "lang_mar"
 msgstr "marathi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1596
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1631
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4107
+#: sonar/common/jsonschemas/language-v1.0.0.json:1593
 msgid "lang_mas"
 msgstr "masai"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1600
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1635
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4111
+#: sonar/common/jsonschemas/language-v1.0.0.json:1597
 msgid "lang_may"
 msgstr "malay"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1604
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1639
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4115
+#: sonar/common/jsonschemas/language-v1.0.0.json:1601
 msgid "lang_mdf"
 msgstr "moksha"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1608
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1643
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4119
+#: sonar/common/jsonschemas/language-v1.0.0.json:1605
 msgid "lang_mdr"
 msgstr "mandar"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1612
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1647
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4123
+#: sonar/common/jsonschemas/language-v1.0.0.json:1609
 msgid "lang_men"
 msgstr "mende"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1616
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1651
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4127
+#: sonar/common/jsonschemas/language-v1.0.0.json:1613
 msgid "lang_mga"
 msgstr "irlandese medio"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1620
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1655
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4131
+#: sonar/common/jsonschemas/language-v1.0.0.json:1617
 msgid "lang_mic"
 msgstr "micmac"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1624
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1659
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4135
+#: sonar/common/jsonschemas/language-v1.0.0.json:1621
 msgid "lang_min"
 msgstr "menangkabau"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1628
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1663
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4139
+#: sonar/common/jsonschemas/language-v1.0.0.json:1625
 msgid "lang_mis"
 msgstr "ainu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1632
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1667
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4143
+#: sonar/common/jsonschemas/language-v1.0.0.json:1629
 msgid "lang_mkh"
 msgstr "mon-khmer (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1636
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1671
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4147
+#: sonar/common/jsonschemas/language-v1.0.0.json:1633
 msgid "lang_mlg"
 msgstr "malgascio"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1640
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1675
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4151
+#: sonar/common/jsonschemas/language-v1.0.0.json:1637
 msgid "lang_mlt"
 msgstr "maltese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1644
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1679
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4155
+#: sonar/common/jsonschemas/language-v1.0.0.json:1641
 msgid "lang_mnc"
 msgstr "manchu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1648
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1683
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4159
+#: sonar/common/jsonschemas/language-v1.0.0.json:1645
 msgid "lang_mni"
 msgstr "manipuri"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1652
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1687
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4163
+#: sonar/common/jsonschemas/language-v1.0.0.json:1649
 msgid "lang_mno"
 msgstr "lingue manobo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1656
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1691
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4167
+#: sonar/common/jsonschemas/language-v1.0.0.json:1653
 msgid "lang_moh"
 msgstr "mohawk"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1660
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1695
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4171
+#: sonar/common/jsonschemas/language-v1.0.0.json:1657
 msgid "lang_mon"
 msgstr "mongolo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1664
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1699
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4175
+#: sonar/common/jsonschemas/language-v1.0.0.json:1661
 msgid "lang_mos"
 msgstr "mossi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1668
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1703
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4179
+#: sonar/common/jsonschemas/language-v1.0.0.json:1665
 msgid "lang_mul"
 msgstr "multilingua"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1672
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1707
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4183
+#: sonar/common/jsonschemas/language-v1.0.0.json:1669
 msgid "lang_mun"
 msgstr "lingue munda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1676
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1711
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4187
+#: sonar/common/jsonschemas/language-v1.0.0.json:1673
 msgid "lang_mus"
 msgstr "creek"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1680
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1715
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4191
+#: sonar/common/jsonschemas/language-v1.0.0.json:1677
 msgid "lang_mwl"
 msgstr "mirandese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1684
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1719
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4195
+#: sonar/common/jsonschemas/language-v1.0.0.json:1681
 msgid "lang_mwr"
 msgstr "marwari"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1688
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1723
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4199
+#: sonar/common/jsonschemas/language-v1.0.0.json:1685
 msgid "lang_myn"
 msgstr "maya"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1692
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1727
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4203
+#: sonar/common/jsonschemas/language-v1.0.0.json:1689
 msgid "lang_myv"
 msgstr "erzya"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1696
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1731
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4207
+#: sonar/common/jsonschemas/language-v1.0.0.json:1693
 msgid "lang_nah"
 msgstr "nahuatl"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1700
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1735
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4211
+#: sonar/common/jsonschemas/language-v1.0.0.json:1697
 msgid "lang_nai"
 msgstr "indiano nordamericano (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1704
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1739
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4215
+#: sonar/common/jsonschemas/language-v1.0.0.json:1701
 msgid "lang_nap"
 msgstr "napoletano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1708
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1743
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4219
+#: sonar/common/jsonschemas/language-v1.0.0.json:1705
 msgid "lang_nau"
 msgstr "nauru"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1712
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1747
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4223
+#: sonar/common/jsonschemas/language-v1.0.0.json:1709
 msgid "lang_nav"
 msgstr "navajo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1716
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1751
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4227
+#: sonar/common/jsonschemas/language-v1.0.0.json:1713
 msgid "lang_nbl"
 msgstr "ndebele del sud"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1720
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1755
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4231
+#: sonar/common/jsonschemas/language-v1.0.0.json:1717
 msgid "lang_nde"
 msgstr "ndebele del nord"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1724
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1759
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4235
+#: sonar/common/jsonschemas/language-v1.0.0.json:1721
 msgid "lang_ndo"
 msgstr "ndonga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1728
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1763
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4239
+#: sonar/common/jsonschemas/language-v1.0.0.json:1725
 msgid "lang_nds"
 msgstr "basso tedesco"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1732
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1767
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4243
+#: sonar/common/jsonschemas/language-v1.0.0.json:1729
 msgid "lang_nep"
 msgstr "nepalese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1736
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1771
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4247
+#: sonar/common/jsonschemas/language-v1.0.0.json:1733
 msgid "lang_new"
 msgstr "newari"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1740
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1775
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4251
+#: sonar/common/jsonschemas/language-v1.0.0.json:1737
 msgid "lang_nia"
 msgstr "nias"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1744
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1779
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4255
+#: sonar/common/jsonschemas/language-v1.0.0.json:1741
 msgid "lang_nic"
 msgstr "niger-kordofaniane (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1748
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1783
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4259
+#: sonar/common/jsonschemas/language-v1.0.0.json:1745
 msgid "lang_niu"
 msgstr "niue"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1752
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1787
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4263
+#: sonar/common/jsonschemas/language-v1.0.0.json:1749
 msgid "lang_nno"
 msgstr "norvegese nynorsk"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1756
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1791
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4267
+#: sonar/common/jsonschemas/language-v1.0.0.json:1753
 msgid "lang_nob"
 msgstr "norvegese bokmål"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1760
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1795
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4271
+#: sonar/common/jsonschemas/language-v1.0.0.json:1757
 msgid "lang_nog"
 msgstr "nogai"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1764
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1799
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4275
+#: sonar/common/jsonschemas/language-v1.0.0.json:1761
 msgid "lang_non"
 msgstr "norse antico"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1768
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1803
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4279
+#: sonar/common/jsonschemas/language-v1.0.0.json:1765
 msgid "lang_nor"
 msgstr "norvegese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1772
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1807
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4283
+#: sonar/common/jsonschemas/language-v1.0.0.json:1769
 msgid "lang_nqo"
 msgstr "n’ko"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1776
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1811
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4287
+#: sonar/common/jsonschemas/language-v1.0.0.json:1773
 msgid "lang_nso"
 msgstr "sotho del nord"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1780
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1815
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4291
+#: sonar/common/jsonschemas/language-v1.0.0.json:1777
 msgid "lang_nub"
 msgstr "lingue nubiane"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1784
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1819
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4295
+#: sonar/common/jsonschemas/language-v1.0.0.json:1781
 msgid "lang_nwc"
 msgstr "newari classico"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1788
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1823
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4299
+#: sonar/common/jsonschemas/language-v1.0.0.json:1785
 msgid "lang_nya"
 msgstr "nyanja"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1792
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1827
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4303
+#: sonar/common/jsonschemas/language-v1.0.0.json:1789
 msgid "lang_nym"
 msgstr "nyamwezi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1796
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1831
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4307
+#: sonar/common/jsonschemas/language-v1.0.0.json:1793
 msgid "lang_nyn"
 msgstr "nyankole"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1800
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1835
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4311
+#: sonar/common/jsonschemas/language-v1.0.0.json:1797
 msgid "lang_nyo"
 msgstr "nyoro"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1804
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1839
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4315
+#: sonar/common/jsonschemas/language-v1.0.0.json:1801
 msgid "lang_nzi"
 msgstr "nzima"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1808
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1843
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4319
+#: sonar/common/jsonschemas/language-v1.0.0.json:1805
 msgid "lang_oci"
 msgstr "occitano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1812
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1847
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4323
+#: sonar/common/jsonschemas/language-v1.0.0.json:1809
 msgid "lang_oji"
 msgstr "ojibwa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1816
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1851
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4327
+#: sonar/common/jsonschemas/language-v1.0.0.json:1813
 msgid "lang_ori"
 msgstr "odia"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1820
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1855
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4331
+#: sonar/common/jsonschemas/language-v1.0.0.json:1817
 msgid "lang_orm"
 msgstr "oromo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1824
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1859
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4335
+#: sonar/common/jsonschemas/language-v1.0.0.json:1821
 msgid "lang_osa"
 msgstr "osage"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1828
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1863
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4339
+#: sonar/common/jsonschemas/language-v1.0.0.json:1825
 msgid "lang_oss"
 msgstr "ossetico"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1832
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1867
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4343
+#: sonar/common/jsonschemas/language-v1.0.0.json:1829
 msgid "lang_ota"
 msgstr "turco ottomano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1836
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1871
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4347
+#: sonar/common/jsonschemas/language-v1.0.0.json:1833
 msgid "lang_oto"
 msgstr "lingue otomiane"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1840
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1875
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4351
+#: sonar/common/jsonschemas/language-v1.0.0.json:1837
 msgid "lang_paa"
 msgstr "papuasiche"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1844
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1879
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4355
+#: sonar/common/jsonschemas/language-v1.0.0.json:1841
 msgid "lang_pag"
 msgstr "pangasinan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1848
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1883
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4359
+#: sonar/common/jsonschemas/language-v1.0.0.json:1845
 msgid "lang_pal"
 msgstr "pahlavi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1852
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1887
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4363
+#: sonar/common/jsonschemas/language-v1.0.0.json:1849
 msgid "lang_pam"
 msgstr "pampanga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1856
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1891
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4367
+#: sonar/common/jsonschemas/language-v1.0.0.json:1853
 msgid "lang_pan"
 msgstr "punjabi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1860
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1895
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4371
+#: sonar/common/jsonschemas/language-v1.0.0.json:1857
 msgid "lang_pap"
 msgstr "papiamento"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1864
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1899
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4375
+#: sonar/common/jsonschemas/language-v1.0.0.json:1861
 msgid "lang_pau"
 msgstr "palauano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1868
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1903
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4379
+#: sonar/common/jsonschemas/language-v1.0.0.json:1865
 msgid "lang_peo"
 msgstr "persiano antico"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1872
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1907
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4383
+#: sonar/common/jsonschemas/language-v1.0.0.json:1869
 msgid "lang_per"
 msgstr "persiano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1876
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1911
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4387
+#: sonar/common/jsonschemas/language-v1.0.0.json:1873
 msgid "lang_phi"
 msgstr "filippine (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1880
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1915
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4391
+#: sonar/common/jsonschemas/language-v1.0.0.json:1877
 msgid "lang_phn"
 msgstr "fenicio"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1884
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1919
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4395
+#: sonar/common/jsonschemas/language-v1.0.0.json:1881
 msgid "lang_pli"
 msgstr "pali"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1888
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1923
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4399
+#: sonar/common/jsonschemas/language-v1.0.0.json:1885
 msgid "lang_pol"
 msgstr "polacco"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1892
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1927
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4403
+#: sonar/common/jsonschemas/language-v1.0.0.json:1889
 msgid "lang_pon"
 msgstr "ponape"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1896
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1931
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4407
+#: sonar/common/jsonschemas/language-v1.0.0.json:1893
 msgid "lang_por"
 msgstr "portoghese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1900
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1935
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4411
+#: sonar/common/jsonschemas/language-v1.0.0.json:1897
 msgid "lang_pra"
 msgstr "lingue pracrite"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1904
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1939
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4415
+#: sonar/common/jsonschemas/language-v1.0.0.json:1901
 msgid "lang_pro"
 msgstr "provenzale antico"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1908
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1943
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4419
+#: sonar/common/jsonschemas/language-v1.0.0.json:1905
 msgid "lang_pus"
 msgstr "pashto"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1912
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1947
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4423
+#: sonar/common/jsonschemas/language-v1.0.0.json:1909
 msgid "lang_que"
 msgstr "quechua"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1916
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1951
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4427
+#: sonar/common/jsonschemas/language-v1.0.0.json:1913
 msgid "lang_raj"
 msgstr "rajasthani"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1920
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1955
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4431
+#: sonar/common/jsonschemas/language-v1.0.0.json:1917
 msgid "lang_rap"
 msgstr "rapanui"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1924
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1959
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4435
+#: sonar/common/jsonschemas/language-v1.0.0.json:1921
 msgid "lang_rar"
 msgstr "rarotonga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1928
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1963
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4439
+#: sonar/common/jsonschemas/language-v1.0.0.json:1925
 msgid "lang_roa"
 msgstr "lingue romanze (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1932
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1967
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4443
+#: sonar/common/jsonschemas/language-v1.0.0.json:1929
 msgid "lang_roh"
 msgstr "romancio"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1936
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1971
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4447
+#: sonar/common/jsonschemas/language-v1.0.0.json:1933
 msgid "lang_rom"
 msgstr "romani"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1940
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1975
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4451
+#: sonar/common/jsonschemas/language-v1.0.0.json:1937
 msgid "lang_rum"
 msgstr "romeno"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1944
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1979
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4455
+#: sonar/common/jsonschemas/language-v1.0.0.json:1941
 msgid "lang_run"
 msgstr "rundi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1948
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1983
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4459
+#: sonar/common/jsonschemas/language-v1.0.0.json:1945
 msgid "lang_rup"
 msgstr "arumeno"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1952
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1987
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4463
+#: sonar/common/jsonschemas/language-v1.0.0.json:1949
 msgid "lang_rus"
 msgstr "russo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1956
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1991
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4467
+#: sonar/common/jsonschemas/language-v1.0.0.json:1953
 msgid "lang_sad"
 msgstr "sandawe"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1960
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1995
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4471
+#: sonar/common/jsonschemas/language-v1.0.0.json:1957
 msgid "lang_sag"
 msgstr "sango"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1964
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1999
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4475
+#: sonar/common/jsonschemas/language-v1.0.0.json:1961
 msgid "lang_sah"
 msgstr "yakut"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1968
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2003
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4479
+#: sonar/common/jsonschemas/language-v1.0.0.json:1965
 msgid "lang_sai"
 msgstr "lingue indiane sudamericane (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1972
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2007
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4483
+#: sonar/common/jsonschemas/language-v1.0.0.json:1969
 msgid "lang_sal"
 msgstr "lingue salish"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1976
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2011
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4487
+#: sonar/common/jsonschemas/language-v1.0.0.json:1973
 msgid "lang_sam"
 msgstr "aramaico samaritano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1980
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2015
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4491
+#: sonar/common/jsonschemas/language-v1.0.0.json:1977
 msgid "lang_san"
 msgstr "sanscrito"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1984
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2019
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4495
+#: sonar/common/jsonschemas/language-v1.0.0.json:1981
 msgid "lang_sas"
 msgstr "sasak"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1988
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2023
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4499
+#: sonar/common/jsonschemas/language-v1.0.0.json:1985
 msgid "lang_sat"
 msgstr "santali"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1992
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2027
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4503
+#: sonar/common/jsonschemas/language-v1.0.0.json:1989
 msgid "lang_scn"
 msgstr "siciliano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1996
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2031
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4507
+#: sonar/common/jsonschemas/language-v1.0.0.json:1993
 msgid "lang_sco"
 msgstr "scozzese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2000
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2035
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4511
+#: sonar/common/jsonschemas/language-v1.0.0.json:1997
 msgid "lang_sel"
 msgstr "selkup"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2004
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2039
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4515
+#: sonar/common/jsonschemas/language-v1.0.0.json:2001
 msgid "lang_sem"
 msgstr "lingue semitiche (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2008
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2043
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4519
+#: sonar/common/jsonschemas/language-v1.0.0.json:2005
 msgid "lang_sga"
 msgstr "irlandese antico"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2012
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2047
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4523
+#: sonar/common/jsonschemas/language-v1.0.0.json:2009
 msgid "lang_sgn"
 msgstr "lingua dei segni"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2016
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2051
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4527
+#: sonar/common/jsonschemas/language-v1.0.0.json:2013
 msgid "lang_shn"
 msgstr "shan"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2020
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2055
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4531
+#: sonar/common/jsonschemas/language-v1.0.0.json:2017
 msgid "lang_sid"
 msgstr "sidamo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2024
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2059
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4535
+#: sonar/common/jsonschemas/language-v1.0.0.json:2021
 msgid "lang_sin"
 msgstr "singalese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2028
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2063
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4539
+#: sonar/common/jsonschemas/language-v1.0.0.json:2025
 msgid "lang_sio"
 msgstr "lingue sioux"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2032
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2067
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4543
+#: sonar/common/jsonschemas/language-v1.0.0.json:2029
 msgid "lang_sit"
 msgstr "sinotibetane (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2036
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2071
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4547
+#: sonar/common/jsonschemas/language-v1.0.0.json:2033
 msgid "lang_sla"
 msgstr "lingue slave (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2040
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2075
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4551
+#: sonar/common/jsonschemas/language-v1.0.0.json:2037
 msgid "lang_slo"
 msgstr "slovacco"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2044
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2079
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4555
+#: sonar/common/jsonschemas/language-v1.0.0.json:2041
 msgid "lang_slv"
 msgstr "sloveno"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2048
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2083
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4559
+#: sonar/common/jsonschemas/language-v1.0.0.json:2045
 msgid "lang_sma"
 msgstr "sami del sud"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2052
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2087
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4563
+#: sonar/common/jsonschemas/language-v1.0.0.json:2049
 msgid "lang_sme"
 msgstr "sami del nord"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2056
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2091
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4567
+#: sonar/common/jsonschemas/language-v1.0.0.json:2053
 msgid "lang_smi"
 msgstr "lingue sami (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2060
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2095
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4571
+#: sonar/common/jsonschemas/language-v1.0.0.json:2057
 msgid "lang_smj"
 msgstr "sami di Lule"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2064
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2099
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4575
+#: sonar/common/jsonschemas/language-v1.0.0.json:2061
 msgid "lang_smn"
 msgstr "sami di Inari"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2068
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2103
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4579
+#: sonar/common/jsonschemas/language-v1.0.0.json:2065
 msgid "lang_smo"
 msgstr "samoano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2072
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2107
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4583
+#: sonar/common/jsonschemas/language-v1.0.0.json:2069
 msgid "lang_sms"
 msgstr "sami skolt"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2076
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2111
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4587
+#: sonar/common/jsonschemas/language-v1.0.0.json:2073
 msgid "lang_sna"
 msgstr "shona"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2080
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2115
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4591
+#: sonar/common/jsonschemas/language-v1.0.0.json:2077
 msgid "lang_snd"
 msgstr "sindhi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2084
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2119
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4595
+#: sonar/common/jsonschemas/language-v1.0.0.json:2081
 msgid "lang_snk"
 msgstr "soninke"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2088
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2123
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4599
+#: sonar/common/jsonschemas/language-v1.0.0.json:2085
 msgid "lang_sog"
 msgstr "sogdiano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2092
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2127
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4603
+#: sonar/common/jsonschemas/language-v1.0.0.json:2089
 msgid "lang_som"
 msgstr "somalo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2096
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2131
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4607
+#: sonar/common/jsonschemas/language-v1.0.0.json:2093
 msgid "lang_son"
 msgstr "songhai"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2100
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2135
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4611
+#: sonar/common/jsonschemas/language-v1.0.0.json:2097
 msgid "lang_sot"
 msgstr "sotho del sud"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2104
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2139
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4615
+#: sonar/common/jsonschemas/language-v1.0.0.json:2101
 msgid "lang_spa"
 msgstr "spagnolo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2108
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2143
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4619
+#: sonar/common/jsonschemas/language-v1.0.0.json:2105
 msgid "lang_srd"
 msgstr "sardo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2112
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2147
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4623
+#: sonar/common/jsonschemas/language-v1.0.0.json:2109
 msgid "lang_srn"
 msgstr "sranan tongo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2116
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2151
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4627
+#: sonar/common/jsonschemas/language-v1.0.0.json:2113
 msgid "lang_srp"
 msgstr "serbo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2120
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2155
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4631
+#: sonar/common/jsonschemas/language-v1.0.0.json:2117
 msgid "lang_srr"
 msgstr "serer"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2124
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2159
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4635
+#: sonar/common/jsonschemas/language-v1.0.0.json:2121
 msgid "lang_ssa"
 msgstr "lingue nilo-sahariane (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2128
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2163
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4639
+#: sonar/common/jsonschemas/language-v1.0.0.json:2125
 msgid "lang_ssw"
 msgstr "swati"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2132
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2167
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4643
+#: sonar/common/jsonschemas/language-v1.0.0.json:2129
 msgid "lang_suk"
 msgstr "sukuma"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2136
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2171
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4647
+#: sonar/common/jsonschemas/language-v1.0.0.json:2133
 msgid "lang_sun"
 msgstr "sundanese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2140
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2175
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4651
+#: sonar/common/jsonschemas/language-v1.0.0.json:2137
 msgid "lang_sus"
 msgstr "susu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2144
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2179
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4655
+#: sonar/common/jsonschemas/language-v1.0.0.json:2141
 msgid "lang_sux"
 msgstr "sumero"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2148
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2183
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4659
+#: sonar/common/jsonschemas/language-v1.0.0.json:2145
 msgid "lang_swa"
 msgstr "swahili"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2152
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2187
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4663
+#: sonar/common/jsonschemas/language-v1.0.0.json:2149
 msgid "lang_swe"
 msgstr "svedese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2156
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2191
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4667
+#: sonar/common/jsonschemas/language-v1.0.0.json:2153
 msgid "lang_syc"
 msgstr "siriaco classico"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2160
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2195
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4671
+#: sonar/common/jsonschemas/language-v1.0.0.json:2157
 msgid "lang_syr"
 msgstr "siriaco"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2164
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2199
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4675
+#: sonar/common/jsonschemas/language-v1.0.0.json:2161
 msgid "lang_tah"
 msgstr "taitiano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2168
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2203
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4679
+#: sonar/common/jsonschemas/language-v1.0.0.json:2165
 msgid "lang_tai"
 msgstr "thailandese (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2172
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2207
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4683
+#: sonar/common/jsonschemas/language-v1.0.0.json:2169
 msgid "lang_tam"
 msgstr "tamil"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2176
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2211
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4687
+#: sonar/common/jsonschemas/language-v1.0.0.json:2173
 msgid "lang_tat"
 msgstr "tataro"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2180
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2215
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4691
+#: sonar/common/jsonschemas/language-v1.0.0.json:2177
 msgid "lang_tel"
 msgstr "telugu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2184
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2219
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4695
+#: sonar/common/jsonschemas/language-v1.0.0.json:2181
 msgid "lang_tem"
 msgstr "temne"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2188
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2223
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4699
+#: sonar/common/jsonschemas/language-v1.0.0.json:2185
 msgid "lang_ter"
 msgstr "tereno"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2192
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2227
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4703
+#: sonar/common/jsonschemas/language-v1.0.0.json:2189
 msgid "lang_tet"
 msgstr "tetum"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2196
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2231
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4707
+#: sonar/common/jsonschemas/language-v1.0.0.json:2193
 msgid "lang_tgk"
 msgstr "tagico"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2200
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2235
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4711
+#: sonar/common/jsonschemas/language-v1.0.0.json:2197
 msgid "lang_tgl"
 msgstr "tagalog"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2204
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2239
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4715
+#: sonar/common/jsonschemas/language-v1.0.0.json:2201
 msgid "lang_tha"
 msgstr "thai"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2208
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2243
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4719
+#: sonar/common/jsonschemas/language-v1.0.0.json:2205
 msgid "lang_tib"
 msgstr "tibetano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2212
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2247
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4723
+#: sonar/common/jsonschemas/language-v1.0.0.json:2209
 msgid "lang_tig"
 msgstr "tigre"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2216
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2251
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4727
+#: sonar/common/jsonschemas/language-v1.0.0.json:2213
 msgid "lang_tir"
 msgstr "tigrino"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2220
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2255
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4731
+#: sonar/common/jsonschemas/language-v1.0.0.json:2217
 msgid "lang_tiv"
 msgstr "tiv"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2224
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2259
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4735
+#: sonar/common/jsonschemas/language-v1.0.0.json:2221
 msgid "lang_tkl"
 msgstr "tokelau"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2228
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2263
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4739
+#: sonar/common/jsonschemas/language-v1.0.0.json:2225
 msgid "lang_tlh"
 msgstr "klingon"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2232
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2267
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4743
+#: sonar/common/jsonschemas/language-v1.0.0.json:2229
 msgid "lang_tli"
 msgstr "tlingit"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2236
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2271
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4747
+#: sonar/common/jsonschemas/language-v1.0.0.json:2233
 msgid "lang_tmh"
 msgstr "tamashek"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2240
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2275
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4751
+#: sonar/common/jsonschemas/language-v1.0.0.json:2237
 msgid "lang_tog"
 msgstr "nyasa del Tonga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2244
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2279
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4755
+#: sonar/common/jsonschemas/language-v1.0.0.json:2241
 msgid "lang_ton"
 msgstr "tongano"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2248
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2283
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4759
+#: sonar/common/jsonschemas/language-v1.0.0.json:2245
 msgid "lang_tpi"
 msgstr "tok pisin"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2252
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2287
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4763
+#: sonar/common/jsonschemas/language-v1.0.0.json:2249
 msgid "lang_tsi"
 msgstr "tsimshian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2256
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2291
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4767
+#: sonar/common/jsonschemas/language-v1.0.0.json:2253
 msgid "lang_tsn"
 msgstr "tswana"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2260
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2295
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4771
+#: sonar/common/jsonschemas/language-v1.0.0.json:2257
 msgid "lang_tso"
 msgstr "tsonga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2264
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2299
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4775
+#: sonar/common/jsonschemas/language-v1.0.0.json:2261
 msgid "lang_tuk"
 msgstr "turcomanno"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2268
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2303
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4779
+#: sonar/common/jsonschemas/language-v1.0.0.json:2265
 msgid "lang_tum"
 msgstr "tumbuka"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2272
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2307
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4783
+#: sonar/common/jsonschemas/language-v1.0.0.json:2269
 msgid "lang_tup"
 msgstr "lingue tupi"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2276
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2311
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4787
+#: sonar/common/jsonschemas/language-v1.0.0.json:2273
 msgid "lang_tur"
 msgstr "turco"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2280
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2315
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4791
+#: sonar/common/jsonschemas/language-v1.0.0.json:2277
 msgid "lang_tut"
 msgstr "altaiche (altre)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2284
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2319
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4795
+#: sonar/common/jsonschemas/language-v1.0.0.json:2281
 msgid "lang_tvl"
 msgstr "tuvalu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2288
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2323
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4799
+#: sonar/common/jsonschemas/language-v1.0.0.json:2285
 msgid "lang_twi"
 msgstr "ci"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2292
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2327
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4803
+#: sonar/common/jsonschemas/language-v1.0.0.json:2289
 msgid "lang_tyv"
 msgstr "tuvinian"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2296
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2331
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4807
+#: sonar/common/jsonschemas/language-v1.0.0.json:2293
 msgid "lang_udm"
 msgstr "udmurt"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2300
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2335
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4811
+#: sonar/common/jsonschemas/language-v1.0.0.json:2297
 msgid "lang_uga"
 msgstr "ugaritico"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2304
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2339
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4815
+#: sonar/common/jsonschemas/language-v1.0.0.json:2301
 msgid "lang_uig"
 msgstr "uiguro"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2308
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2343
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4819
+#: sonar/common/jsonschemas/language-v1.0.0.json:2305
 msgid "lang_ukr"
 msgstr "ucraino"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2312
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2347
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4823
+#: sonar/common/jsonschemas/language-v1.0.0.json:2309
 msgid "lang_umb"
 msgstr "mbundu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2316
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2351
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4827
+#: sonar/common/jsonschemas/language-v1.0.0.json:2313
 msgid "lang_und"
 msgstr "lingua imprecisata"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2320
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2355
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4831
+#: sonar/common/jsonschemas/language-v1.0.0.json:2317
 msgid "lang_urd"
 msgstr "urdu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2324
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2359
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4835
+#: sonar/common/jsonschemas/language-v1.0.0.json:2321
 msgid "lang_uzb"
 msgstr "uzbeco"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2328
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2363
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4839
+#: sonar/common/jsonschemas/language-v1.0.0.json:2325
 msgid "lang_vai"
 msgstr "vai"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2332
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2367
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4843
+#: sonar/common/jsonschemas/language-v1.0.0.json:2329
 msgid "lang_ven"
 msgstr "venda"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2336
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2371
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4847
+#: sonar/common/jsonschemas/language-v1.0.0.json:2333
 msgid "lang_vie"
 msgstr "vietnamita"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2340
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2375
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4851
+#: sonar/common/jsonschemas/language-v1.0.0.json:2337
 msgid "lang_vol"
 msgstr "volapük"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2344
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2379
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4855
+#: sonar/common/jsonschemas/language-v1.0.0.json:2341
 msgid "lang_vot"
 msgstr "voto"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2348
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2383
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4859
+#: sonar/common/jsonschemas/language-v1.0.0.json:2345
 msgid "lang_wak"
 msgstr "lingue wakash"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2352
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2387
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4863
+#: sonar/common/jsonschemas/language-v1.0.0.json:2349
 msgid "lang_wal"
 msgstr "walamo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2356
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2391
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4867
+#: sonar/common/jsonschemas/language-v1.0.0.json:2353
 msgid "lang_war"
 msgstr "waray"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2360
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2395
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4871
+#: sonar/common/jsonschemas/language-v1.0.0.json:2357
 msgid "lang_was"
 msgstr "washo"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2364
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2399
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4875
+#: sonar/common/jsonschemas/language-v1.0.0.json:2361
 msgid "lang_wel"
 msgstr "gallese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2368
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2403
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4879
+#: sonar/common/jsonschemas/language-v1.0.0.json:2365
 msgid "lang_wen"
 msgstr "lingue lusaziane"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2372
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2407
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4883
+#: sonar/common/jsonschemas/language-v1.0.0.json:2369
 msgid "lang_wln"
 msgstr "vallone"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2376
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2411
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4887
+#: sonar/common/jsonschemas/language-v1.0.0.json:2373
 msgid "lang_wol"
 msgstr "wolof"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2380
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2415
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4891
+#: sonar/common/jsonschemas/language-v1.0.0.json:2377
 msgid "lang_xal"
 msgstr "kalmyk"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2384
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2419
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4895
+#: sonar/common/jsonschemas/language-v1.0.0.json:2381
 msgid "lang_xho"
 msgstr "xhosa"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2388
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2423
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4899
+#: sonar/common/jsonschemas/language-v1.0.0.json:2385
 msgid "lang_yao"
 msgstr "yao (bantu)"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2392
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2427
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4903
+#: sonar/common/jsonschemas/language-v1.0.0.json:2389
 msgid "lang_yap"
 msgstr "yapese"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2396
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2431
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4907
+#: sonar/common/jsonschemas/language-v1.0.0.json:2393
 msgid "lang_yid"
 msgstr "yiddish"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2400
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2435
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4911
+#: sonar/common/jsonschemas/language-v1.0.0.json:2397
 msgid "lang_yor"
 msgstr "yoruba"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2404
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2439
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4915
+#: sonar/common/jsonschemas/language-v1.0.0.json:2401
 msgid "lang_ypk"
 msgstr "lingue yupik"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2408
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2443
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4919
+#: sonar/common/jsonschemas/language-v1.0.0.json:2405
 msgid "lang_zap"
 msgstr "zapotec"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2412
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2447
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4923
+#: sonar/common/jsonschemas/language-v1.0.0.json:2409
 msgid "lang_zbl"
 msgstr "blissymbol"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2416
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2451
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4927
+#: sonar/common/jsonschemas/language-v1.0.0.json:2413
 msgid "lang_zen"
 msgstr "zenaga"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2420
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2455
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4931
+#: sonar/common/jsonschemas/language-v1.0.0.json:2417
 msgid "lang_zha"
 msgstr "zhuang"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2424
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2459
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4935
+#: sonar/common/jsonschemas/language-v1.0.0.json:2421
 msgid "lang_znd"
 msgstr "zande"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2428
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2463
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4939
+#: sonar/common/jsonschemas/language-v1.0.0.json:2425
 msgid "lang_zul"
 msgstr "zulu"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2432
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2467
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4943
+#: sonar/common/jsonschemas/language-v1.0.0.json:2429
 msgid "lang_zun"
 msgstr "zuni"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2436
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2471
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4947
+#: sonar/common/jsonschemas/language-v1.0.0.json:2433
 msgid "lang_zxx"
 msgstr "nessun contenuto linguistico"
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2440
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2475
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4951
+#: sonar/common/jsonschemas/language-v1.0.0.json:2437
 msgid "lang_zza"
 msgstr "zaza"
 
@@ -5732,12 +4837,11 @@ msgstr "zaza"
 msgid "mainTeam"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:923
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1743
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1034
 msgid "name"
 msgstr "nome"
 
-#: sonar/modules/documents/views.py:172
+#: sonar/modules/documents/views.py:178
 msgid "no."
 msgstr "n."
 
@@ -5745,11 +4849,11 @@ msgstr "n."
 msgid "other files"
 msgstr "altri files"
 
-#: sonar/modules/documents/views.py:176
+#: sonar/modules/documents/views.py:182
 msgid "p."
 msgstr "p."
 
-#: sonar/config.py:546
+#: sonar/config.py:570
 msgid "pid"
 msgstr "pid"
 
@@ -5813,7 +4917,7 @@ msgstr ""
 msgid "startDate"
 msgstr ""
 
-#: sonar/config.py:547
+#: sonar/config.py:571
 msgid "status"
 msgstr "statuto"
 
@@ -5827,15 +4931,55 @@ msgstr "sostenuto da"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:489
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:808
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1615
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1627
 msgid "uri"
 msgstr "URI"
 
-#: sonar/config.py:548
+#: sonar/config.py:572
 msgid "user"
 msgstr "utente"
 
-#: sonar/modules/documents/views.py:168
+#: sonar/translations/manual_translations.txt:59
+msgid "validation_action_approve"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:61
+msgid "validation_action_ask_for_changes"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:58
+msgid "validation_action_publish"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:60
+msgid "validation_action_reject"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:57
+msgid "validation_action_save"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:54
+msgid "validation_status_ask_for_changes"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:50
+msgid "validation_status_in_progress"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:53
+msgid "validation_status_rejected"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:51
+msgid "validation_status_to_validate"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:52
+msgid "validation_status_validated"
+msgstr ""
+
+#: sonar/modules/documents/views.py:174
 msgid "vol."
 msgstr "vol."
 
@@ -5901,4 +5045,19 @@ msgstr ""
 
 #~ msgid "\\u200bSwiss National Science Foundation"
 #~ msgstr ""
+
+#~ msgid "Editors"
+#~ msgstr "Editori"
+
+#~ msgid "In the format \\"
+#~ msgstr "In formato \"Cognome, nome\""
+
+#~ msgid "Not OA / Rights reserved"
+#~ msgstr "Non OA / Diritti riservati"
+
+#~ msgid "Other OA / license undefined"
+#~ msgstr "Altro OA / licenza indefinita"
+
+#~ msgid "Specific collections"
+#~ msgstr "Collezioni specifiche"
 

--- a/sonar/translations/messages.pot
+++ b/sonar/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 1.0.0\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2021-06-01 15:56+0200\n"
+"POT-Creation-Date: 2021-06-14 13:34+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.1\n"
 
-#: sonar/theme/views.py:65
+#: sonar/theme/views.py:67
 #, python-format
 msgid "%(icon)s Profile"
 msgstr ""
@@ -30,13 +30,13 @@ msgstr ""
 msgid "About SONAR"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:681
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:697
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:795
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:811
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:663
 msgid "Abstract"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:678
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:792
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:659
 msgid "Abstracts"
 msgstr ""
@@ -54,10 +54,11 @@ msgid "Accompanying material of the resource, i.e. maps."
 msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:844
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1651
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1663
 msgid "Acquisition terms"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:77
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:210
 msgid "Action"
 msgstr ""
@@ -70,7 +71,11 @@ msgstr ""
 msgid "Actor involved"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:933
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:704
+msgid "Add a new collection"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1044
 msgid "Add a new project"
 msgstr ""
 
@@ -83,14 +88,13 @@ msgstr ""
 msgid "Administration"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:834
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1009
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1367
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:948
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1383
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:203
 msgid "Affiliation"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1180
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1196
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:159
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:250
 msgid "Agent"
@@ -126,8 +130,12 @@ msgid ""
 "underscores."
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1484
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1496
 msgid "Author or editor"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:612
+msgid "Authors / Editors"
 msgstr ""
 
 #: sonar/modules/documents/templates/documents/record.html:44
@@ -139,7 +147,7 @@ msgstr ""
 msgid "Back to SONAR"
 msgstr ""
 
-#: sonar/config.py:584
+#: sonar/config.py:608
 msgid "Best match"
 msgstr ""
 
@@ -155,12 +163,12 @@ msgstr ""
 msgid "Brief description of the report"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1788
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:30
 msgid "Bronze"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4993
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5008
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:110
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:125
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:20
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:34
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:15
@@ -178,35 +186,35 @@ msgstr ""
 msgid "CAS or DAS"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:27
+#: sonar/common/jsonschemas/license-v1.0.0.json:28
 msgid "CC BY"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:31
+#: sonar/common/jsonschemas/license-v1.0.0.json:32
 msgid "CC BY-NC"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:35
+#: sonar/common/jsonschemas/license-v1.0.0.json:36
 msgid "CC BY-NC-ND"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:39
+#: sonar/common/jsonschemas/license-v1.0.0.json:40
 msgid "CC BY-NC-SA"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:43
+#: sonar/common/jsonschemas/license-v1.0.0.json:44
 msgid "CC BY-ND"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:47
+#: sonar/common/jsonschemas/license-v1.0.0.json:48
 msgid "CC BY-SA"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:23
+#: sonar/common/jsonschemas/license-v1.0.0.json:24
 msgid "CC0"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5033
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:150
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:59
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:58
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:266
@@ -218,16 +226,16 @@ msgid "City"
 msgstr ""
 
 #: sonar/common/jsonschemas/classification-v1.0.0.json:2
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1015
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1031
 #: sonar/modules/documents/templates/documents/record.html:262
 msgid "Classification"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1066
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1082
 msgid "Classification portion"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1011
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1027
 msgid "Classifications"
 msgstr ""
 
@@ -239,7 +247,7 @@ msgstr ""
 msgid "Click here to reset your password"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1792
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:34
 msgid "Closed"
 msgstr ""
 
@@ -247,17 +255,26 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:999
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:680
 msgid "Collection"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:4
+#: sonar/modules/collections/templates/collections/index.html:21
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:676
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:995
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:999
+#: sonar/modules/documents/templates/documents/record.html:288
 msgid "Collections"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:106
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:245
 msgid "Comment"
+msgstr ""
+
+#: sonar/common/jsonschemas/validation-v1.0.0.json:107
+msgid "Comment associated with the current action."
 msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:513
@@ -276,37 +293,41 @@ msgstr ""
 msgid "Contact"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1094
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:540
+msgid "Contained in (journal, book, proceedings)"
+msgstr ""
+
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1110
 msgid "Content note"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1090
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1106
 msgid "Content notes"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1175
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1480
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1191
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1492
 msgid "Contribution"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1171
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1187
 msgid "Contributions"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:814
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:928
 msgid "Contributor"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:808
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:922
 msgid "Contributors"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1379
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1395
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:212
 msgid "Controlled affiliation"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1375
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1391
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:208
 msgid "Controlled affiliations"
 msgstr ""
@@ -316,27 +337,36 @@ msgstr ""
 msgid "Creativity, transformations and innovations in education"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:78
+msgid "Current action done in the validation process."
+msgstr ""
+
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:173
 msgid "Current cataloguing step."
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1799
+#: sonar/common/jsonschemas/validation-v1.0.0.json:65
+msgid "Current status of the record in the validation process."
+msgstr ""
+
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1774
 msgid "Custom field 1"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1819
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1794
 msgid "Custom field 2"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1839
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1814
 msgid "Custom field 3"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:42
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:240
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:777
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:891
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:496
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1123
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1295
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1139
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1311
 msgid "Date"
 msgstr ""
 
@@ -348,13 +378,17 @@ msgstr ""
 msgid "Date of approval by the Team Leader"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1271
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1287
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:34
 msgid "Date of birth"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1279
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1295
 msgid "Date of death"
+msgstr ""
+
+#: sonar/common/jsonschemas/validation-v1.0.0.json:43
+msgid "Date when the log is created."
 msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:640
@@ -366,8 +400,8 @@ msgstr ""
 msgid "Dear %(email)s"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:762
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1108
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:876
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1124
 msgid "Degree"
 msgstr ""
 
@@ -383,20 +417,22 @@ msgstr ""
 msgid "Deposit to validate"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5003
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:120
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:30
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:236
 msgid "Describes the information of a single file in the record."
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2497
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:941
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:56
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:740
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1052
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:38
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:55
 msgid "Description"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2493
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:52
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:736
 msgid "Descriptions"
 msgstr ""
 
@@ -412,8 +448,8 @@ msgstr ""
 msgid "Director, head of establishment"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:757
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1103
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:871
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1119
 msgid "Dissertation"
 msgstr ""
 
@@ -429,12 +465,12 @@ msgstr ""
 msgid "Doctorate supported by the HEP-VS"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:558
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1117
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:556
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1124
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:3
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:958
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1411
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1445
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1423
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1457
 msgid "Document"
 msgstr ""
 
@@ -442,7 +478,7 @@ msgstr ""
 msgid "Document ID"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1118
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1125
 msgid "Document created on basis of this deposit."
 msgstr ""
 
@@ -478,10 +514,6 @@ msgstr ""
 msgid "Edition"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:596
-msgid "Editors"
-msgstr ""
-
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:211
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:273
 msgid "Education, childhood and the learning Society 21"
@@ -510,7 +542,7 @@ msgid "Emotions, learning, and well-being at school"
 msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:80
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:959
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1075
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:79
 msgid "End date"
 msgstr ""
@@ -536,8 +568,15 @@ msgid ""
 "password."
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:886
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1020
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:569
+msgid "Example: 1"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:586
+msgid "Example: 10"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1000
 msgid "Example: 1111-2222-3333-4444"
 msgstr ""
 
@@ -546,13 +585,11 @@ msgstr ""
 msgid "Example: 2019 or 2019-01-01"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:782
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1127
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:896
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1143
 msgid "Example: 2019 or 2019-05-05"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:953
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:960
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:153
 msgid "Example: 2019-05-05"
 msgstr ""
@@ -563,6 +600,8 @@ msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:75
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:88
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1070
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1082
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:74
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:87
 msgid "Example: 2020-12-01"
@@ -576,17 +615,17 @@ msgstr ""
 msgid "Example: John"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1488
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1500
 msgid "Example: Muller, Hans"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:638
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:655
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:977
 msgid "Example: Published version"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:591
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1441
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:602
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1453
 msgid "Examples: 135, 5-27, …"
 msgstr ""
 
@@ -594,7 +633,11 @@ msgstr ""
 msgid "Except within organisation"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:913
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:685
+msgid "Existing collection"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1024
 msgid "Existing project"
 msgstr ""
 
@@ -622,20 +665,20 @@ msgstr ""
 msgid "External partners are involved"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5013
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:130
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:39
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:35
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:246
 msgid "File UUID"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5002
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:119
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:29
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:235
 msgid "File item"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4998
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:115
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:25
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:21
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:231
@@ -684,7 +727,7 @@ msgstr ""
 msgid "Formats"
 msgstr ""
 
-#: sonar/config.py:72
+#: sonar/config.py:74
 msgid "French"
 msgstr ""
 
@@ -705,12 +748,10 @@ msgstr ""
 msgid "Funding number"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1048
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:245
 msgid "Funding organisation"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1045
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:241
 #: sonar/theme/templates/sonar/projects/detail.html:64
 msgid "Funding organisations"
@@ -724,20 +765,20 @@ msgstr ""
 msgid "Funding was granted for the project"
 msgstr ""
 
-#: sonar/config.py:72
+#: sonar/config.py:74
 msgid "German"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1780
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:22
 msgid "Gold"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:772
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1118
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:886
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1134
 msgid "Granting institution"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1776
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:18
 msgid "Green"
 msgstr ""
 
@@ -765,7 +806,7 @@ msgstr ""
 msgid "Harvested"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:18
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:18
 msgid "Hash key"
 msgstr ""
 
@@ -773,8 +814,8 @@ msgstr ""
 msgid "Help & Documentation"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:559
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1451
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:557
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1463
 msgid ""
 "Host document, for example a journal for an article, or a book for a book"
 " chapter."
@@ -784,7 +825,7 @@ msgstr ""
 msgid "How are research results used in training?"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1784
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:26
 msgid "Hybrid"
 msgstr ""
 
@@ -793,24 +834,22 @@ msgid "IR hosting service"
 msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:867
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1674
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1686
 msgid "ISBN/ISSN status should be selected in the list below."
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1220
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1236
 msgid "Identified by"
 msgstr ""
 
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:2
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:3
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:9
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:13
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:13
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:15
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:360
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:966
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1058
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:693
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1500
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1512
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:13
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:13
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:9
@@ -821,7 +860,7 @@ msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:357
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:689
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1496
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1508
 #: sonar/modules/documents/templates/documents/record.html:237
 msgid "Identifiers"
 msgstr ""
@@ -836,10 +875,6 @@ msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:316
 msgid "In progress"
-msgstr ""
-
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:597
-msgid "In the format \\"
 msgstr ""
 
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:118
@@ -868,12 +903,10 @@ msgstr ""
 msgid "Invenio"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:974
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:154
 msgid "Investigator"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:971
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:150
 #: sonar/theme/templates/sonar/projects/detail.html:35
 msgid "Investigators"
@@ -887,21 +920,21 @@ msgstr ""
 msgid "Is shared"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1429
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1441
 msgid "Issue"
 msgstr ""
 
-#: sonar/config.py:73
+#: sonar/config.py:75
 msgid "Italian"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:767
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1113
-#: sonar/modules/documents/views.py:234
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:881
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1129
+#: sonar/modules/documents/views.py:240
 msgid "Jury note"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5023
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:140
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:49
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:47
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:256
@@ -912,7 +945,12 @@ msgstr ""
 msgid "Key (filename) of the file."
 msgstr ""
 
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:835
+msgid "Keyword"
+msgstr ""
+
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:391
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:832
 msgid "Keywords"
 msgstr ""
 
@@ -920,7 +958,7 @@ msgstr ""
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:69
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:503
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:903
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1154
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1170
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:94
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:141
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:188
@@ -934,8 +972,6 @@ msgid "Labels"
 msgstr ""
 
 #: sonar/common/jsonschemas/language-v1.0.0.json:2
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:37
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2513
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:354
 #: sonar/modules/documents/templates/documents/record.html:221
 msgid "Language"
@@ -958,7 +994,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:829
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:943
 msgid "Last name, first name, ex: Doe, John"
 msgstr ""
 
@@ -967,8 +1003,12 @@ msgid "Lecturer/professor"
 msgstr ""
 
 #: sonar/common/jsonschemas/license-v1.0.0.json:2
-#: sonar/modules/documents/templates/documents/record.html:288
+#: sonar/modules/documents/templates/documents/record.html:306
 msgid "License"
+msgstr ""
+
+#: sonar/common/jsonschemas/license-v1.0.0.json:52
+msgid "License undefined"
 msgstr ""
 
 #: sonar/theme/templates/sonar/projects/detail.html:79
@@ -983,17 +1023,22 @@ msgid ""
 " Enter one rule per line."
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4999
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:116
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:26
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:22
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:232
 msgid "List of files attached to the record."
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:21
+msgid "List of logs."
+msgstr ""
+
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:878
 msgid "Locality (Valais)"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:25
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:188
 msgid "Log"
 msgstr ""
@@ -1028,11 +1073,12 @@ msgstr ""
 msgid "Logout"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:20
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:184
 msgid "Logs"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5034
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:151
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:60
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:59
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:267
@@ -1073,38 +1119,38 @@ msgstr ""
 msgid "Mediator"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5028
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:145
 msgid "Mimetype"
 msgstr ""
 
-#: sonar/config.py:578
+#: sonar/config.py:602
 msgid "Most recent"
 msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:356
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:535
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:898
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:27
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:828
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:936
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:979
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1053
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:27
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:711
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:942
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1047
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:33
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:50
 msgid "Name"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:23
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:23
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:707
 msgid "Names"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:55
-msgid "Not OA / Rights reserved"
+#: sonar/modules/collections/templates/collections/index.html:32
+msgid "No collection found"
 msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:650
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:828
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1635
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1647
 msgid "Note"
 msgstr ""
 
@@ -1119,8 +1165,8 @@ msgid "Notes"
 msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:741
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:577
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1303
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:579
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1319
 msgid "Number"
 msgstr ""
 
@@ -1140,8 +1186,7 @@ msgstr ""
 msgid "OAI-PMH specific information."
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:880
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1014
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:994
 msgid "ORCID"
 msgstr ""
 
@@ -1150,18 +1195,17 @@ msgstr ""
 msgid "Object type"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1760
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:2
 msgid "Open access status"
 msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:93
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4969
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4973
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:86
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:90
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:222
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:5
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:84
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:287
-#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:291
 msgid "Organisation"
 msgstr ""
 
@@ -1200,26 +1244,22 @@ msgid ""
 "coloured."
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:51
-msgid "Other OA / license undefined"
-msgstr ""
-
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:882
 msgid "Other canton (Switzerland)"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:624
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:641
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:953
 #: sonar/modules/documents/templates/documents/record.html:208
 msgid "Other electronic version"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:621
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:638
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:949
 msgid "Other electronic versions"
 msgstr ""
 
-#: sonar/modules/documents/templates/documents/record.html:311
+#: sonar/modules/documents/templates/documents/record.html:329
 msgid "Other files"
 msgstr ""
 
@@ -1232,8 +1272,8 @@ msgstr ""
 msgid "PID type"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:585
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1437
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:596
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1449
 msgid "Pages"
 msgstr ""
 
@@ -1241,8 +1281,7 @@ msgstr ""
 msgid "Parents"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:540
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1407
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1419
 msgid "Part of (host document)"
 msgstr ""
 
@@ -1254,7 +1293,7 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: sonar/modules/documents/templates/documents/record.html:301
+#: sonar/modules/documents/templates/documents/record.html:319
 msgid "Permalink"
 msgstr ""
 
@@ -1271,7 +1310,7 @@ msgstr ""
 msgid "Phone number with the international prefix, without spaces."
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1287
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1303
 msgid "Place"
 msgstr ""
 
@@ -1281,6 +1320,15 @@ msgstr ""
 
 #: sonar/templates/security/email/welcome.html:5
 msgid "Please confirm your e-mail by clicking here"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:573
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:590
+msgid "Please enter a valid number."
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:606
+msgid "Please enter a valid pages range, example: 135, 5-27."
 msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:85
@@ -1310,13 +1358,13 @@ msgstr ""
 msgid "Practitioner-trainer"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1210
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1226
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:164
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:255
 msgid "Preferred name"
 msgstr ""
 
-#: sonar/modules/documents/templates/documents/record.html:329
+#: sonar/modules/documents/templates/documents/record.html:347
 #: sonar/theme/templates/sonar/preview/base.html:23
 msgid "Preview"
 msgstr ""
@@ -1336,11 +1384,11 @@ msgstr ""
 
 #: sonar/theme/templates/sonar/partial/dropdown_user.html:21
 #: sonar/theme/templates/sonar/partial/dropdown_user.html:24
-#: sonar/theme/views.py:66
+#: sonar/theme/views.py:68
 msgid "Profile"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:916
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1027
 msgid "Project"
 msgstr ""
 
@@ -1380,12 +1428,12 @@ msgstr ""
 msgid "Public foundation"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:633
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:650
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:973
 msgid "Public note"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1456
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1468
 msgid "Publication"
 msgstr ""
 
@@ -1398,12 +1446,12 @@ msgid "Published in"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:332
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:606
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:623
 msgid "Publisher"
 msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:836
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1643
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1655
 msgid "Qualifier"
 msgstr ""
 
@@ -1411,15 +1459,19 @@ msgstr ""
 msgid "Realization framework"
 msgstr ""
 
+#: sonar/modules/validation/api.py:216
+msgid "Record validation"
+msgstr ""
+
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:4
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:908
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1732
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1019
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1744
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:4
 msgid "Research project"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:901
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1728
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1015
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1740
 #: sonar/modules/documents/templates/documents/record.html:183
 msgid "Research projects"
 msgstr ""
@@ -1435,15 +1487,18 @@ msgstr ""
 msgid "Responsibility"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:839
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:984
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1330
+#: sonar/common/jsonschemas/license-v1.0.0.json:56
+msgid "Rights reserved"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:953
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1346
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:99
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:181
 msgid "Role"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1326
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1342
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:177
 msgid "Roles"
 msgstr ""
@@ -1466,6 +1521,10 @@ msgstr ""
 msgid "Schema"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:3
+msgid "Schema representing a validation workflow."
+msgstr ""
+
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:9
 msgid "Schema to validate document against."
 msgstr ""
@@ -1479,6 +1538,10 @@ msgstr ""
 #: sonar/theme/templates/sonar/partial/navbar.html:52
 #: sonar/theme/templates/sonar/partial/organisation.html:21
 msgid "Search"
+msgstr ""
+
+#: sonar/modules/collections/templates/collections/item.html:48
+msgid "Search in collection"
 msgstr ""
 
 #: sonar/theme/templates/sonar/frontpage.html:57
@@ -1538,14 +1601,14 @@ msgstr ""
 msgid "Sign-up with SWITCHaai"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5039
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:156
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:65
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:64
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:272
 msgid "Size"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5040
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:157
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:66
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:65
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:273
@@ -1560,8 +1623,8 @@ msgstr ""
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:510
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:849
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:926
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1245
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1656
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1261
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1668
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:117
 msgid "Source"
 msgstr ""
@@ -1574,13 +1637,9 @@ msgstr ""
 msgid "Special education teacher"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:659
-msgid "Specific collections"
-msgstr ""
-
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:67
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:952
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1461
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1063
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1473
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:66
 msgid "Start date"
 msgstr ""
@@ -1606,7 +1665,7 @@ msgid "State of Valais, parastatal institution"
 msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:474
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1466
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1478
 msgid "Statement"
 msgstr ""
 
@@ -1614,10 +1673,11 @@ msgstr ""
 msgid "Statements"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:64
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:39
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:136
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:860
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1667
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1679
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:39
 msgid "Status"
 msgstr ""
@@ -1646,14 +1706,11 @@ msgstr ""
 msgid "Student in training"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:721
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:898
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:915
 msgid "Subject"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:718
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:737
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:894
 msgid "Subjects"
 msgstr ""
@@ -1675,7 +1732,7 @@ msgstr ""
 msgid "Suspended"
 msgstr ""
 
-#: sonar/config.py:94 sonar/config.py:98
+#: sonar/config.py:96 sonar/config.py:100
 msgid "Swiss Open Access Repository"
 msgstr ""
 
@@ -1705,7 +1762,7 @@ msgid ""
 "with Swiss public research institutions."
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:660
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:677
 msgid ""
 "The names of the organisation's specific/patrimonial collections to which"
 " this document belongs"
@@ -1734,7 +1791,7 @@ msgstr ""
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:304
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:264
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:627
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1450
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1462
 msgid "Title"
 msgstr ""
 
@@ -1773,11 +1830,11 @@ msgstr ""
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:449
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:478
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:698
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1022
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1052
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1185
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1225
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1505
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1038
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1068
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1201
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1241
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1517
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:97
 msgid "Type"
 msgstr ""
@@ -1790,7 +1847,7 @@ msgstr ""
 msgid "Type of the file"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:643
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:660
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:963
 msgid "URL"
 msgstr ""
@@ -1807,10 +1864,12 @@ msgstr ""
 msgid "UUID of the bucket the tile is assigned to."
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1146
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1162
 msgid "Usage and access policy"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:90
+#: sonar/common/jsonschemas/validation-v1.0.0.json:96
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:116
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:121
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:120
@@ -1818,15 +1877,25 @@ msgstr ""
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:198
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:202
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:5
-#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:311
-#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:316
+#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:310
+#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:315
 msgid "User"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:91
+msgid "User which created the record."
+msgstr ""
+
+#: sonar/common/jsonschemas/validation-v1.0.0.json:2
+msgid "Validation"
+msgstr ""
+
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:39
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:32
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2502
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:32
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:61
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:505
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:716
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:745
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:296
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:320
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:405
@@ -1835,8 +1904,8 @@ msgstr ""
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:668
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:823
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:911
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1256
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1630
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1272
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1642
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:99
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:146
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:193
@@ -1844,7 +1913,11 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5018
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:851
+msgid "Values"
+msgstr ""
+
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:135
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:44
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:41
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:251
@@ -1855,8 +1928,8 @@ msgstr ""
 msgid "Vice-rector HE"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:569
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1421
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:562
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1433
 msgid "Volume"
 msgstr ""
 
@@ -1864,7 +1937,7 @@ msgstr ""
 msgid "Welcome to SONAR"
 msgstr ""
 
-#: sonar/config.py:125
+#: sonar/config.py:127
 msgid "Welcome to SONAR, the Swiss Open Access Repository!"
 msgstr ""
 
@@ -1896,8 +1969,7 @@ msgstr ""
 msgid "Why?"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:564
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1416
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1428
 msgid "Year"
 msgstr ""
 
@@ -1919,78 +1991,78 @@ msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:417
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:728
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1535
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1547
 msgid "bf:AudioIssueNumber"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1049
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1065
 msgid "bf:ClassificationDdc"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1019
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1035
 msgid "bf:ClassificationUdc"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:402
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:732
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1539
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1551
 msgid "bf:Doi"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:421
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:736
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1543
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1555
 msgid "bf:Ean"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:425
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:740
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1547
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1559
 msgid "bf:Gtin14Number"
 msgstr ""
 
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:17
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:429
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:744
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1234
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1551
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1250
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1563
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:106
 msgid "bf:Identifier"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:433
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:748
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1555
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1567
 msgid "bf:Isan"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:412
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:752
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1559
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1571
 msgid "bf:Isbn"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:437
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:756
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1563
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1575
 msgid "bf:Ismn"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:441
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:760
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1567
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1579
 msgid "bf:Isrc"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:445
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:764
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1571
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1583
 msgid "bf:Issn"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:449
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:768
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1575
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1587
 msgid "bf:IssnL"
 msgstr ""
 
@@ -2001,8 +2073,8 @@ msgstr ""
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:21
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:453
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:772
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1238
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1579
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1254
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1591
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:110
 msgid "bf:Local"
 msgstr ""
@@ -2013,37 +2085,37 @@ msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:457
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:776
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1583
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1595
 msgid "bf:MatrixNumber"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1203
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1219
 msgid "bf:Meeting"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:461
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:780
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1587
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1599
 msgid "bf:MusicDistributorNumber"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:465
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:784
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1591
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1603
 msgid "bf:MusicPlate"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:469
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:788
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1595
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1607
 msgid "bf:MusicPublisherNumber"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1199
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1215
 msgid "bf:Organization"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1195
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1211
 msgid "bf:Person"
 msgstr ""
 
@@ -2057,19 +2129,19 @@ msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:473
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:792
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1599
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1611
 msgid "bf:PublisherNumber"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:493
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:812
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1619
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1631
 msgid "bf:ReportNumber"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:497
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:816
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1623
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1635
 msgid "bf:Strn"
 msgstr ""
 
@@ -2079,19 +2151,19 @@ msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:477
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:796
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1603
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1615
 msgid "bf:Upc"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:481
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:800
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1607
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1619
 msgid "bf:Urn"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:485
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:804
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1611
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1623
 msgid "bf:VideoRecordingNumber"
 msgstr ""
 
@@ -2455,41 +2527,40 @@ msgstr ""
 msgid "coar:c_f1cf"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1002
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:195
 msgid "coinvestigator"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:857
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1351
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:971
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1367
 msgid "contribution_role_cre"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:861
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1359
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:975
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1375
 msgid "contribution_role_ctb"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:869
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1343
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:983
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1359
 msgid "contribution_role_dgs"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:865
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1355
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:979
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1371
 msgid "contribution_role_edt"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:873
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1347
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:987
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1363
 msgid "contribution_role_prt"
 msgstr ""
 
-#: sonar/modules/documents/views.py:266
+#: sonar/modules/documents/views.py:272
 msgid "contribution_role_{role}"
 msgstr ""
 
-#: sonar/config.py:549
+#: sonar/config.py:573
 msgid "contributor"
 msgstr ""
 
@@ -2773,7 +2844,6 @@ msgstr ""
 msgid "innerSearcher"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:998
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:191
 msgid "investigator"
 msgstr ""
@@ -2782,2913 +2852,1948 @@ msgstr ""
 msgid "keywords"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:500
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:535
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3011
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:694
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1010
+msgid "label"
+msgstr ""
+
+#: sonar/common/jsonschemas/language-v1.0.0.json:497
 msgid "lang_aar"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:504
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:539
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3015
+#: sonar/common/jsonschemas/language-v1.0.0.json:501
 msgid "lang_abk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:508
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:543
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3019
+#: sonar/common/jsonschemas/language-v1.0.0.json:505
 msgid "lang_ace"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:512
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:547
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3023
+#: sonar/common/jsonschemas/language-v1.0.0.json:509
 msgid "lang_ach"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:516
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:551
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3027
+#: sonar/common/jsonschemas/language-v1.0.0.json:513
 msgid "lang_ada"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:520
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:555
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3031
+#: sonar/common/jsonschemas/language-v1.0.0.json:517
 msgid "lang_ady"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:524
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:559
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3035
+#: sonar/common/jsonschemas/language-v1.0.0.json:521
 msgid "lang_afa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:528
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:563
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3039
+#: sonar/common/jsonschemas/language-v1.0.0.json:525
 msgid "lang_afh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:532
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:567
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3043
+#: sonar/common/jsonschemas/language-v1.0.0.json:529
 msgid "lang_afr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:536
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:571
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3047
+#: sonar/common/jsonschemas/language-v1.0.0.json:533
 msgid "lang_ain"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:540
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:575
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3051
+#: sonar/common/jsonschemas/language-v1.0.0.json:537
 msgid "lang_aka"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:544
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:579
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3055
+#: sonar/common/jsonschemas/language-v1.0.0.json:541
 msgid "lang_akk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:548
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:583
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3059
+#: sonar/common/jsonschemas/language-v1.0.0.json:545
 msgid "lang_alb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:552
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:587
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3063
+#: sonar/common/jsonschemas/language-v1.0.0.json:549
 msgid "lang_ale"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:556
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:591
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3067
+#: sonar/common/jsonschemas/language-v1.0.0.json:553
 msgid "lang_alg"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:560
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:595
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3071
+#: sonar/common/jsonschemas/language-v1.0.0.json:557
 msgid "lang_alt"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:564
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:599
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3075
+#: sonar/common/jsonschemas/language-v1.0.0.json:561
 msgid "lang_amh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:568
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:603
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3079
+#: sonar/common/jsonschemas/language-v1.0.0.json:565
 msgid "lang_ang"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:572
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:607
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3083
+#: sonar/common/jsonschemas/language-v1.0.0.json:569
 msgid "lang_anp"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:576
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:611
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3087
+#: sonar/common/jsonschemas/language-v1.0.0.json:573
 msgid "lang_apa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:580
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:615
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3091
+#: sonar/common/jsonschemas/language-v1.0.0.json:577
 msgid "lang_ara"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:584
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:619
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3095
+#: sonar/common/jsonschemas/language-v1.0.0.json:581
 msgid "lang_arc"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:588
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:623
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3099
+#: sonar/common/jsonschemas/language-v1.0.0.json:585
 msgid "lang_arg"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:592
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:627
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3103
+#: sonar/common/jsonschemas/language-v1.0.0.json:589
 msgid "lang_arm"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:596
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:631
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3107
+#: sonar/common/jsonschemas/language-v1.0.0.json:593
 msgid "lang_arn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:600
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:635
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3111
+#: sonar/common/jsonschemas/language-v1.0.0.json:597
 msgid "lang_arp"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:604
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:639
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3115
+#: sonar/common/jsonschemas/language-v1.0.0.json:601
 msgid "lang_art"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:608
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:643
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3119
+#: sonar/common/jsonschemas/language-v1.0.0.json:605
 msgid "lang_arw"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:612
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:647
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3123
+#: sonar/common/jsonschemas/language-v1.0.0.json:609
 msgid "lang_asm"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:616
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:651
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3127
+#: sonar/common/jsonschemas/language-v1.0.0.json:613
 msgid "lang_ast"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:620
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:655
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3131
+#: sonar/common/jsonschemas/language-v1.0.0.json:617
 msgid "lang_ath"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:624
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:659
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3135
+#: sonar/common/jsonschemas/language-v1.0.0.json:621
 msgid "lang_aus"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:628
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:663
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3139
+#: sonar/common/jsonschemas/language-v1.0.0.json:625
 msgid "lang_ava"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:632
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:667
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3143
+#: sonar/common/jsonschemas/language-v1.0.0.json:629
 msgid "lang_ave"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:636
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:671
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3147
+#: sonar/common/jsonschemas/language-v1.0.0.json:633
 msgid "lang_awa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:640
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:675
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3151
+#: sonar/common/jsonschemas/language-v1.0.0.json:637
 msgid "lang_aym"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:644
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:679
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3155
+#: sonar/common/jsonschemas/language-v1.0.0.json:641
 msgid "lang_aze"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:648
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:683
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3159
+#: sonar/common/jsonschemas/language-v1.0.0.json:645
 msgid "lang_bad"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:652
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:687
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3163
+#: sonar/common/jsonschemas/language-v1.0.0.json:649
 msgid "lang_bai"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:656
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:691
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3167
+#: sonar/common/jsonschemas/language-v1.0.0.json:653
 msgid "lang_bak"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:660
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:695
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3171
+#: sonar/common/jsonschemas/language-v1.0.0.json:657
 msgid "lang_bal"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:664
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:699
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3175
+#: sonar/common/jsonschemas/language-v1.0.0.json:661
 msgid "lang_bam"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:668
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:703
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3179
+#: sonar/common/jsonschemas/language-v1.0.0.json:665
 msgid "lang_ban"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:672
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:707
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3183
+#: sonar/common/jsonschemas/language-v1.0.0.json:669
 msgid "lang_baq"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:676
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:711
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3187
+#: sonar/common/jsonschemas/language-v1.0.0.json:673
 msgid "lang_bas"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:680
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:715
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3191
+#: sonar/common/jsonschemas/language-v1.0.0.json:677
 msgid "lang_bat"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:684
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:719
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3195
+#: sonar/common/jsonschemas/language-v1.0.0.json:681
 msgid "lang_bej"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:688
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:723
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3199
+#: sonar/common/jsonschemas/language-v1.0.0.json:685
 msgid "lang_bel"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:692
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:727
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3203
+#: sonar/common/jsonschemas/language-v1.0.0.json:689
 msgid "lang_bem"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:696
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:731
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3207
+#: sonar/common/jsonschemas/language-v1.0.0.json:693
 msgid "lang_ben"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:700
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:735
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3211
+#: sonar/common/jsonschemas/language-v1.0.0.json:697
 msgid "lang_ber"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:704
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:739
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3215
+#: sonar/common/jsonschemas/language-v1.0.0.json:701
 msgid "lang_bho"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:708
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:743
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3219
+#: sonar/common/jsonschemas/language-v1.0.0.json:705
 msgid "lang_bih"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:712
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:747
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3223
+#: sonar/common/jsonschemas/language-v1.0.0.json:709
 msgid "lang_bik"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:716
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:751
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3227
+#: sonar/common/jsonschemas/language-v1.0.0.json:713
 msgid "lang_bin"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:720
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:755
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3231
+#: sonar/common/jsonschemas/language-v1.0.0.json:717
 msgid "lang_bis"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:724
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:759
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3235
+#: sonar/common/jsonschemas/language-v1.0.0.json:721
 msgid "lang_bla"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:728
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:763
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3239
+#: sonar/common/jsonschemas/language-v1.0.0.json:725
 msgid "lang_bnt"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:732
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:767
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3243
+#: sonar/common/jsonschemas/language-v1.0.0.json:729
 msgid "lang_bos"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:736
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:771
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3247
+#: sonar/common/jsonschemas/language-v1.0.0.json:733
 msgid "lang_bra"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:740
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:775
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3251
+#: sonar/common/jsonschemas/language-v1.0.0.json:737
 msgid "lang_bre"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:744
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:779
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3255
+#: sonar/common/jsonschemas/language-v1.0.0.json:741
 msgid "lang_btk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:748
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:783
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3259
+#: sonar/common/jsonschemas/language-v1.0.0.json:745
 msgid "lang_bua"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:752
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:787
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3263
+#: sonar/common/jsonschemas/language-v1.0.0.json:749
 msgid "lang_bug"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:756
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:791
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3267
+#: sonar/common/jsonschemas/language-v1.0.0.json:753
 msgid "lang_bul"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:760
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:795
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3271
+#: sonar/common/jsonschemas/language-v1.0.0.json:757
 msgid "lang_bur"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:764
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:799
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3275
+#: sonar/common/jsonschemas/language-v1.0.0.json:761
 msgid "lang_byn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:768
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:803
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3279
+#: sonar/common/jsonschemas/language-v1.0.0.json:765
 msgid "lang_cad"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:772
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:807
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3283
+#: sonar/common/jsonschemas/language-v1.0.0.json:769
 msgid "lang_cai"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:776
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:811
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3287
+#: sonar/common/jsonschemas/language-v1.0.0.json:773
 msgid "lang_car"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:780
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:815
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3291
+#: sonar/common/jsonschemas/language-v1.0.0.json:777
 msgid "lang_cat"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:784
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:819
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3295
+#: sonar/common/jsonschemas/language-v1.0.0.json:781
 msgid "lang_cau"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:788
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:823
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3299
+#: sonar/common/jsonschemas/language-v1.0.0.json:785
 msgid "lang_ceb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:792
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:827
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3303
+#: sonar/common/jsonschemas/language-v1.0.0.json:789
 msgid "lang_cel"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:796
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:831
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3307
+#: sonar/common/jsonschemas/language-v1.0.0.json:793
 msgid "lang_cha"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:800
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:835
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3311
+#: sonar/common/jsonschemas/language-v1.0.0.json:797
 msgid "lang_chb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:804
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:839
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3315
+#: sonar/common/jsonschemas/language-v1.0.0.json:801
 msgid "lang_che"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:808
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:843
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3319
+#: sonar/common/jsonschemas/language-v1.0.0.json:805
 msgid "lang_chg"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:812
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:847
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3323
+#: sonar/common/jsonschemas/language-v1.0.0.json:809
 msgid "lang_chi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:816
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:851
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3327
+#: sonar/common/jsonschemas/language-v1.0.0.json:813
 msgid "lang_chk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:820
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:855
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3331
+#: sonar/common/jsonschemas/language-v1.0.0.json:817
 msgid "lang_chm"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:824
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:859
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3335
+#: sonar/common/jsonschemas/language-v1.0.0.json:821
 msgid "lang_chn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:828
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:863
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3339
+#: sonar/common/jsonschemas/language-v1.0.0.json:825
 msgid "lang_cho"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:832
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:867
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3343
+#: sonar/common/jsonschemas/language-v1.0.0.json:829
 msgid "lang_chp"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:836
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:871
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3347
+#: sonar/common/jsonschemas/language-v1.0.0.json:833
 msgid "lang_chr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:840
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:875
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3351
+#: sonar/common/jsonschemas/language-v1.0.0.json:837
 msgid "lang_chu"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:844
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:879
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3355
+#: sonar/common/jsonschemas/language-v1.0.0.json:841
 msgid "lang_chv"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:848
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:883
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3359
+#: sonar/common/jsonschemas/language-v1.0.0.json:845
 msgid "lang_chy"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:852
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:887
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3363
+#: sonar/common/jsonschemas/language-v1.0.0.json:849
 msgid "lang_cmc"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:856
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:891
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3367
+#: sonar/common/jsonschemas/language-v1.0.0.json:853
 msgid "lang_cnr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:860
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:895
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3371
+#: sonar/common/jsonschemas/language-v1.0.0.json:857
 msgid "lang_cop"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:864
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:899
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3375
+#: sonar/common/jsonschemas/language-v1.0.0.json:861
 msgid "lang_cor"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:868
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:903
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3379
+#: sonar/common/jsonschemas/language-v1.0.0.json:865
 msgid "lang_cos"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:872
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:907
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3383
+#: sonar/common/jsonschemas/language-v1.0.0.json:869
 msgid "lang_cpe"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:876
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:911
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3387
+#: sonar/common/jsonschemas/language-v1.0.0.json:873
 msgid "lang_cpf"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:880
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:915
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3391
+#: sonar/common/jsonschemas/language-v1.0.0.json:877
 msgid "lang_cpp"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:884
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:919
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3395
+#: sonar/common/jsonschemas/language-v1.0.0.json:881
 msgid "lang_cre"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:888
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:923
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3399
+#: sonar/common/jsonschemas/language-v1.0.0.json:885
 msgid "lang_crh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:892
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:927
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3403
+#: sonar/common/jsonschemas/language-v1.0.0.json:889
 msgid "lang_crp"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:896
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:931
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3407
+#: sonar/common/jsonschemas/language-v1.0.0.json:893
 msgid "lang_csb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:900
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:935
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3411
+#: sonar/common/jsonschemas/language-v1.0.0.json:897
 msgid "lang_cus"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:904
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:939
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3415
+#: sonar/common/jsonschemas/language-v1.0.0.json:901
 msgid "lang_cze"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:908
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:943
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3419
+#: sonar/common/jsonschemas/language-v1.0.0.json:905
 msgid "lang_dak"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:912
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:947
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3423
+#: sonar/common/jsonschemas/language-v1.0.0.json:909
 msgid "lang_dan"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:916
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:951
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3427
+#: sonar/common/jsonschemas/language-v1.0.0.json:913
 msgid "lang_dar"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:920
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:955
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3431
+#: sonar/common/jsonschemas/language-v1.0.0.json:917
 msgid "lang_day"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:924
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:959
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3435
+#: sonar/common/jsonschemas/language-v1.0.0.json:921
 msgid "lang_del"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:928
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:963
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3439
+#: sonar/common/jsonschemas/language-v1.0.0.json:925
 msgid "lang_den"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:932
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:967
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3443
+#: sonar/common/jsonschemas/language-v1.0.0.json:929
 msgid "lang_dgr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:936
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:971
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3447
+#: sonar/common/jsonschemas/language-v1.0.0.json:933
 msgid "lang_din"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:940
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:975
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3451
+#: sonar/common/jsonschemas/language-v1.0.0.json:937
 msgid "lang_div"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:944
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:979
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3455
+#: sonar/common/jsonschemas/language-v1.0.0.json:941
 msgid "lang_doi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:948
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:983
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3459
+#: sonar/common/jsonschemas/language-v1.0.0.json:945
 msgid "lang_dra"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:952
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:987
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3463
+#: sonar/common/jsonschemas/language-v1.0.0.json:949
 msgid "lang_dsb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:956
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:991
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3467
+#: sonar/common/jsonschemas/language-v1.0.0.json:953
 msgid "lang_dua"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:960
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:995
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3471
+#: sonar/common/jsonschemas/language-v1.0.0.json:957
 msgid "lang_dum"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:964
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:999
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3475
+#: sonar/common/jsonschemas/language-v1.0.0.json:961
 msgid "lang_dut"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:968
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1003
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3479
+#: sonar/common/jsonschemas/language-v1.0.0.json:965
 msgid "lang_dyu"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:972
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1007
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3483
+#: sonar/common/jsonschemas/language-v1.0.0.json:969
 msgid "lang_dzo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:976
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1011
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3487
+#: sonar/common/jsonschemas/language-v1.0.0.json:973
 msgid "lang_efi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:980
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1015
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3491
+#: sonar/common/jsonschemas/language-v1.0.0.json:977
 msgid "lang_egy"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:984
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1019
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3495
+#: sonar/common/jsonschemas/language-v1.0.0.json:981
 msgid "lang_eka"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:988
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1023
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3499
+#: sonar/common/jsonschemas/language-v1.0.0.json:985
 msgid "lang_elx"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:992
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1027
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3503
+#: sonar/common/jsonschemas/language-v1.0.0.json:989
 msgid "lang_eng"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:997
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1032
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3508
+#: sonar/common/jsonschemas/language-v1.0.0.json:994
 msgid "lang_enm"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1001
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1036
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3512
+#: sonar/common/jsonschemas/language-v1.0.0.json:998
 msgid "lang_epo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1005
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1040
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3516
+#: sonar/common/jsonschemas/language-v1.0.0.json:1002
 msgid "lang_est"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1009
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1044
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3520
+#: sonar/common/jsonschemas/language-v1.0.0.json:1006
 msgid "lang_ewe"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1013
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1048
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3524
+#: sonar/common/jsonschemas/language-v1.0.0.json:1010
 msgid "lang_ewo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1017
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1052
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3528
+#: sonar/common/jsonschemas/language-v1.0.0.json:1014
 msgid "lang_fan"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1021
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1056
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3532
+#: sonar/common/jsonschemas/language-v1.0.0.json:1018
 msgid "lang_fao"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1025
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1060
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3536
+#: sonar/common/jsonschemas/language-v1.0.0.json:1022
 msgid "lang_fat"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1029
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1064
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3540
+#: sonar/common/jsonschemas/language-v1.0.0.json:1026
 msgid "lang_fij"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1033
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1068
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3544
+#: sonar/common/jsonschemas/language-v1.0.0.json:1030
 msgid "lang_fil"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1037
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1072
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3548
+#: sonar/common/jsonschemas/language-v1.0.0.json:1034
 msgid "lang_fin"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1041
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1076
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3552
+#: sonar/common/jsonschemas/language-v1.0.0.json:1038
 msgid "lang_fiu"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1045
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1080
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3556
+#: sonar/common/jsonschemas/language-v1.0.0.json:1042
 msgid "lang_fon"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1049
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1084
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3560
+#: sonar/common/jsonschemas/language-v1.0.0.json:1046
 msgid "lang_fre"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1054
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1089
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3565
+#: sonar/common/jsonschemas/language-v1.0.0.json:1051
 msgid "lang_frm"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1058
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1093
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3569
+#: sonar/common/jsonschemas/language-v1.0.0.json:1055
 msgid "lang_fro"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1062
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1097
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3573
+#: sonar/common/jsonschemas/language-v1.0.0.json:1059
 msgid "lang_frr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1066
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1101
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3577
+#: sonar/common/jsonschemas/language-v1.0.0.json:1063
 msgid "lang_frs"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1070
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1105
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3581
+#: sonar/common/jsonschemas/language-v1.0.0.json:1067
 msgid "lang_fry"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1074
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1109
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3585
+#: sonar/common/jsonschemas/language-v1.0.0.json:1071
 msgid "lang_ful"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1078
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1113
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3589
+#: sonar/common/jsonschemas/language-v1.0.0.json:1075
 msgid "lang_fur"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1082
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1117
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3593
+#: sonar/common/jsonschemas/language-v1.0.0.json:1079
 msgid "lang_gaa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1086
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1121
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3597
+#: sonar/common/jsonschemas/language-v1.0.0.json:1083
 msgid "lang_gay"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1090
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1125
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3601
+#: sonar/common/jsonschemas/language-v1.0.0.json:1087
 msgid "lang_gba"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1094
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1129
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3605
+#: sonar/common/jsonschemas/language-v1.0.0.json:1091
 msgid "lang_gem"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1098
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1133
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3609
+#: sonar/common/jsonschemas/language-v1.0.0.json:1095
 msgid "lang_geo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1102
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1137
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3613
+#: sonar/common/jsonschemas/language-v1.0.0.json:1099
 msgid "lang_ger"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1107
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1142
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3618
+#: sonar/common/jsonschemas/language-v1.0.0.json:1104
 msgid "lang_gez"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1111
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1146
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3622
+#: sonar/common/jsonschemas/language-v1.0.0.json:1108
 msgid "lang_gil"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1115
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1150
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3626
+#: sonar/common/jsonschemas/language-v1.0.0.json:1112
 msgid "lang_gla"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1119
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1154
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3630
+#: sonar/common/jsonschemas/language-v1.0.0.json:1116
 msgid "lang_gle"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1123
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1158
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3634
+#: sonar/common/jsonschemas/language-v1.0.0.json:1120
 msgid "lang_glg"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1127
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1162
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3638
+#: sonar/common/jsonschemas/language-v1.0.0.json:1124
 msgid "lang_glv"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1131
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1166
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3642
+#: sonar/common/jsonschemas/language-v1.0.0.json:1128
 msgid "lang_gmh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1135
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1170
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3646
+#: sonar/common/jsonschemas/language-v1.0.0.json:1132
 msgid "lang_goh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1139
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1174
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3650
+#: sonar/common/jsonschemas/language-v1.0.0.json:1136
 msgid "lang_gon"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1143
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1178
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3654
+#: sonar/common/jsonschemas/language-v1.0.0.json:1140
 msgid "lang_gor"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1147
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1182
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3658
+#: sonar/common/jsonschemas/language-v1.0.0.json:1144
 msgid "lang_got"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1151
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1186
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3662
+#: sonar/common/jsonschemas/language-v1.0.0.json:1148
 msgid "lang_grb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1155
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1190
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3666
+#: sonar/common/jsonschemas/language-v1.0.0.json:1152
 msgid "lang_grc"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1159
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1194
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3670
+#: sonar/common/jsonschemas/language-v1.0.0.json:1156
 msgid "lang_gre"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1163
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1198
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3674
+#: sonar/common/jsonschemas/language-v1.0.0.json:1160
 msgid "lang_grn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1167
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1202
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3678
+#: sonar/common/jsonschemas/language-v1.0.0.json:1164
 msgid "lang_gsw"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1171
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1206
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3682
+#: sonar/common/jsonschemas/language-v1.0.0.json:1168
 msgid "lang_guj"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1175
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1210
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3686
+#: sonar/common/jsonschemas/language-v1.0.0.json:1172
 msgid "lang_gwi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1179
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1214
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3690
+#: sonar/common/jsonschemas/language-v1.0.0.json:1176
 msgid "lang_hai"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1183
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1218
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3694
+#: sonar/common/jsonschemas/language-v1.0.0.json:1180
 msgid "lang_hat"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1187
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1222
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3698
+#: sonar/common/jsonschemas/language-v1.0.0.json:1184
 msgid "lang_hau"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1191
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1226
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3702
+#: sonar/common/jsonschemas/language-v1.0.0.json:1188
 msgid "lang_haw"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1195
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1230
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3706
+#: sonar/common/jsonschemas/language-v1.0.0.json:1192
 msgid "lang_heb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1199
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1234
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3710
+#: sonar/common/jsonschemas/language-v1.0.0.json:1196
 msgid "lang_her"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1203
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1238
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3714
+#: sonar/common/jsonschemas/language-v1.0.0.json:1200
 msgid "lang_hil"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1207
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1242
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3718
+#: sonar/common/jsonschemas/language-v1.0.0.json:1204
 msgid "lang_him"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1211
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1246
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3722
+#: sonar/common/jsonschemas/language-v1.0.0.json:1208
 msgid "lang_hin"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1215
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1250
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3726
+#: sonar/common/jsonschemas/language-v1.0.0.json:1212
 msgid "lang_hit"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1219
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1254
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3730
+#: sonar/common/jsonschemas/language-v1.0.0.json:1216
 msgid "lang_hmn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1223
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1258
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3734
+#: sonar/common/jsonschemas/language-v1.0.0.json:1220
 msgid "lang_hmo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1227
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1262
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3738
+#: sonar/common/jsonschemas/language-v1.0.0.json:1224
 msgid "lang_hrv"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1231
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1266
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3742
+#: sonar/common/jsonschemas/language-v1.0.0.json:1228
 msgid "lang_hsb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1235
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1270
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3746
+#: sonar/common/jsonschemas/language-v1.0.0.json:1232
 msgid "lang_hun"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1239
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1274
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3750
+#: sonar/common/jsonschemas/language-v1.0.0.json:1236
 msgid "lang_hup"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1243
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1278
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3754
+#: sonar/common/jsonschemas/language-v1.0.0.json:1240
 msgid "lang_iba"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1247
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1282
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3758
+#: sonar/common/jsonschemas/language-v1.0.0.json:1244
 msgid "lang_ibo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1251
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1286
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3762
+#: sonar/common/jsonschemas/language-v1.0.0.json:1248
 msgid "lang_ice"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1255
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1290
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3766
+#: sonar/common/jsonschemas/language-v1.0.0.json:1252
 msgid "lang_ido"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1259
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1294
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3770
+#: sonar/common/jsonschemas/language-v1.0.0.json:1256
 msgid "lang_iii"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1263
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1298
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3774
+#: sonar/common/jsonschemas/language-v1.0.0.json:1260
 msgid "lang_ijo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1267
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1302
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3778
+#: sonar/common/jsonschemas/language-v1.0.0.json:1264
 msgid "lang_iku"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1271
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1306
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3782
+#: sonar/common/jsonschemas/language-v1.0.0.json:1268
 msgid "lang_ile"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1275
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1310
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3786
+#: sonar/common/jsonschemas/language-v1.0.0.json:1272
 msgid "lang_ilo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1279
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1314
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3790
+#: sonar/common/jsonschemas/language-v1.0.0.json:1276
 msgid "lang_ina"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1283
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1318
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3794
+#: sonar/common/jsonschemas/language-v1.0.0.json:1280
 msgid "lang_inc"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1287
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1322
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3798
+#: sonar/common/jsonschemas/language-v1.0.0.json:1284
 msgid "lang_ind"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1291
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1326
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3802
+#: sonar/common/jsonschemas/language-v1.0.0.json:1288
 msgid "lang_ine"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1295
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1330
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3806
+#: sonar/common/jsonschemas/language-v1.0.0.json:1292
 msgid "lang_inh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1299
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1334
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3810
+#: sonar/common/jsonschemas/language-v1.0.0.json:1296
 msgid "lang_ipk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1303
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1338
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3814
+#: sonar/common/jsonschemas/language-v1.0.0.json:1300
 msgid "lang_ira"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1307
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1342
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3818
+#: sonar/common/jsonschemas/language-v1.0.0.json:1304
 msgid "lang_iro"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1311
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1346
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3822
+#: sonar/common/jsonschemas/language-v1.0.0.json:1308
 msgid "lang_ita"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1316
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1351
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3827
+#: sonar/common/jsonschemas/language-v1.0.0.json:1313
 msgid "lang_jav"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1320
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1355
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3831
+#: sonar/common/jsonschemas/language-v1.0.0.json:1317
 msgid "lang_jbo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1324
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1359
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3835
+#: sonar/common/jsonschemas/language-v1.0.0.json:1321
 msgid "lang_jpn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1328
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1363
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3839
+#: sonar/common/jsonschemas/language-v1.0.0.json:1325
 msgid "lang_jpr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1332
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1367
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3843
+#: sonar/common/jsonschemas/language-v1.0.0.json:1329
 msgid "lang_jrb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1336
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1371
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3847
+#: sonar/common/jsonschemas/language-v1.0.0.json:1333
 msgid "lang_kaa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1340
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1375
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3851
+#: sonar/common/jsonschemas/language-v1.0.0.json:1337
 msgid "lang_kab"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1344
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1379
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3855
+#: sonar/common/jsonschemas/language-v1.0.0.json:1341
 msgid "lang_kac"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1348
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1383
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3859
+#: sonar/common/jsonschemas/language-v1.0.0.json:1345
 msgid "lang_kal"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1352
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1387
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3863
+#: sonar/common/jsonschemas/language-v1.0.0.json:1349
 msgid "lang_kam"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1356
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1391
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3867
+#: sonar/common/jsonschemas/language-v1.0.0.json:1353
 msgid "lang_kan"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1360
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1395
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3871
+#: sonar/common/jsonschemas/language-v1.0.0.json:1357
 msgid "lang_kar"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1364
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1399
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3875
+#: sonar/common/jsonschemas/language-v1.0.0.json:1361
 msgid "lang_kas"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1368
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1403
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3879
+#: sonar/common/jsonschemas/language-v1.0.0.json:1365
 msgid "lang_kau"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1372
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1407
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3883
+#: sonar/common/jsonschemas/language-v1.0.0.json:1369
 msgid "lang_kaw"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1376
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1411
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3887
+#: sonar/common/jsonschemas/language-v1.0.0.json:1373
 msgid "lang_kaz"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1380
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1415
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3891
+#: sonar/common/jsonschemas/language-v1.0.0.json:1377
 msgid "lang_kbd"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1384
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1419
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3895
+#: sonar/common/jsonschemas/language-v1.0.0.json:1381
 msgid "lang_kha"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1388
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1423
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3899
+#: sonar/common/jsonschemas/language-v1.0.0.json:1385
 msgid "lang_khi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1392
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1427
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3903
+#: sonar/common/jsonschemas/language-v1.0.0.json:1389
 msgid "lang_khm"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1396
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1431
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3907
+#: sonar/common/jsonschemas/language-v1.0.0.json:1393
 msgid "lang_kho"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1400
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1435
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3911
+#: sonar/common/jsonschemas/language-v1.0.0.json:1397
 msgid "lang_kik"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1404
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1439
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3915
+#: sonar/common/jsonschemas/language-v1.0.0.json:1401
 msgid "lang_kin"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1408
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1443
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3919
+#: sonar/common/jsonschemas/language-v1.0.0.json:1405
 msgid "lang_kir"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1412
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1447
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3923
+#: sonar/common/jsonschemas/language-v1.0.0.json:1409
 msgid "lang_kmb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1416
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1451
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3927
+#: sonar/common/jsonschemas/language-v1.0.0.json:1413
 msgid "lang_kok"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1420
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1455
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3931
+#: sonar/common/jsonschemas/language-v1.0.0.json:1417
 msgid "lang_kom"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1424
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1459
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3935
+#: sonar/common/jsonschemas/language-v1.0.0.json:1421
 msgid "lang_kon"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1428
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1463
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3939
+#: sonar/common/jsonschemas/language-v1.0.0.json:1425
 msgid "lang_kor"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1432
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1467
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3943
+#: sonar/common/jsonschemas/language-v1.0.0.json:1429
 msgid "lang_kos"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1436
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1471
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3947
+#: sonar/common/jsonschemas/language-v1.0.0.json:1433
 msgid "lang_kpe"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1440
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1475
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3951
+#: sonar/common/jsonschemas/language-v1.0.0.json:1437
 msgid "lang_krc"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1444
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1479
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3955
+#: sonar/common/jsonschemas/language-v1.0.0.json:1441
 msgid "lang_krl"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1448
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1483
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3959
+#: sonar/common/jsonschemas/language-v1.0.0.json:1445
 msgid "lang_kro"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1452
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1487
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3963
+#: sonar/common/jsonschemas/language-v1.0.0.json:1449
 msgid "lang_kru"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1456
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1491
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3967
+#: sonar/common/jsonschemas/language-v1.0.0.json:1453
 msgid "lang_kua"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1460
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1495
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3971
+#: sonar/common/jsonschemas/language-v1.0.0.json:1457
 msgid "lang_kum"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1464
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1499
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3975
+#: sonar/common/jsonschemas/language-v1.0.0.json:1461
 msgid "lang_kur"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1468
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1503
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3979
+#: sonar/common/jsonschemas/language-v1.0.0.json:1465
 msgid "lang_kut"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1472
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1507
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3983
+#: sonar/common/jsonschemas/language-v1.0.0.json:1469
 msgid "lang_lad"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1476
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1511
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3987
+#: sonar/common/jsonschemas/language-v1.0.0.json:1473
 msgid "lang_lah"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1480
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1515
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3991
+#: sonar/common/jsonschemas/language-v1.0.0.json:1477
 msgid "lang_lam"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1484
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1519
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3995
+#: sonar/common/jsonschemas/language-v1.0.0.json:1481
 msgid "lang_lao"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1488
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1523
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3999
+#: sonar/common/jsonschemas/language-v1.0.0.json:1485
 msgid "lang_lat"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1492
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1527
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4003
+#: sonar/common/jsonschemas/language-v1.0.0.json:1489
 msgid "lang_lav"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1496
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1531
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4007
+#: sonar/common/jsonschemas/language-v1.0.0.json:1493
 msgid "lang_lez"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1500
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1535
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4011
+#: sonar/common/jsonschemas/language-v1.0.0.json:1497
 msgid "lang_lim"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1504
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1539
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4015
+#: sonar/common/jsonschemas/language-v1.0.0.json:1501
 msgid "lang_lin"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1508
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1543
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4019
+#: sonar/common/jsonschemas/language-v1.0.0.json:1505
 msgid "lang_lit"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1512
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1547
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4023
+#: sonar/common/jsonschemas/language-v1.0.0.json:1509
 msgid "lang_lol"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1516
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1551
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4027
+#: sonar/common/jsonschemas/language-v1.0.0.json:1513
 msgid "lang_loz"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1520
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1555
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4031
+#: sonar/common/jsonschemas/language-v1.0.0.json:1517
 msgid "lang_ltz"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1524
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1559
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4035
+#: sonar/common/jsonschemas/language-v1.0.0.json:1521
 msgid "lang_lua"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1528
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1563
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4039
+#: sonar/common/jsonschemas/language-v1.0.0.json:1525
 msgid "lang_lub"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1532
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1567
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4043
+#: sonar/common/jsonschemas/language-v1.0.0.json:1529
 msgid "lang_lug"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1536
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1571
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4047
+#: sonar/common/jsonschemas/language-v1.0.0.json:1533
 msgid "lang_lui"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1540
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1575
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4051
+#: sonar/common/jsonschemas/language-v1.0.0.json:1537
 msgid "lang_lun"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1544
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1579
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4055
+#: sonar/common/jsonschemas/language-v1.0.0.json:1541
 msgid "lang_luo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1548
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1583
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4059
+#: sonar/common/jsonschemas/language-v1.0.0.json:1545
 msgid "lang_lus"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1552
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1587
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4063
+#: sonar/common/jsonschemas/language-v1.0.0.json:1549
 msgid "lang_mac"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1556
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1591
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4067
+#: sonar/common/jsonschemas/language-v1.0.0.json:1553
 msgid "lang_mad"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1560
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1595
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4071
+#: sonar/common/jsonschemas/language-v1.0.0.json:1557
 msgid "lang_mag"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1564
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1599
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4075
+#: sonar/common/jsonschemas/language-v1.0.0.json:1561
 msgid "lang_mah"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1568
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1603
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4079
+#: sonar/common/jsonschemas/language-v1.0.0.json:1565
 msgid "lang_mai"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1572
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1607
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4083
+#: sonar/common/jsonschemas/language-v1.0.0.json:1569
 msgid "lang_mak"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1576
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1611
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4087
+#: sonar/common/jsonschemas/language-v1.0.0.json:1573
 msgid "lang_mal"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1580
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1615
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4091
+#: sonar/common/jsonschemas/language-v1.0.0.json:1577
 msgid "lang_man"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1584
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1619
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4095
+#: sonar/common/jsonschemas/language-v1.0.0.json:1581
 msgid "lang_mao"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1588
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1623
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4099
+#: sonar/common/jsonschemas/language-v1.0.0.json:1585
 msgid "lang_map"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1592
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1627
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4103
+#: sonar/common/jsonschemas/language-v1.0.0.json:1589
 msgid "lang_mar"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1596
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1631
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4107
+#: sonar/common/jsonschemas/language-v1.0.0.json:1593
 msgid "lang_mas"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1600
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1635
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4111
+#: sonar/common/jsonschemas/language-v1.0.0.json:1597
 msgid "lang_may"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1604
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1639
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4115
+#: sonar/common/jsonschemas/language-v1.0.0.json:1601
 msgid "lang_mdf"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1608
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1643
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4119
+#: sonar/common/jsonschemas/language-v1.0.0.json:1605
 msgid "lang_mdr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1612
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1647
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4123
+#: sonar/common/jsonschemas/language-v1.0.0.json:1609
 msgid "lang_men"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1616
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1651
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4127
+#: sonar/common/jsonschemas/language-v1.0.0.json:1613
 msgid "lang_mga"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1620
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1655
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4131
+#: sonar/common/jsonschemas/language-v1.0.0.json:1617
 msgid "lang_mic"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1624
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1659
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4135
+#: sonar/common/jsonschemas/language-v1.0.0.json:1621
 msgid "lang_min"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1628
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1663
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4139
+#: sonar/common/jsonschemas/language-v1.0.0.json:1625
 msgid "lang_mis"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1632
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1667
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4143
+#: sonar/common/jsonschemas/language-v1.0.0.json:1629
 msgid "lang_mkh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1636
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1671
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4147
+#: sonar/common/jsonschemas/language-v1.0.0.json:1633
 msgid "lang_mlg"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1640
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1675
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4151
+#: sonar/common/jsonschemas/language-v1.0.0.json:1637
 msgid "lang_mlt"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1644
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1679
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4155
+#: sonar/common/jsonschemas/language-v1.0.0.json:1641
 msgid "lang_mnc"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1648
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1683
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4159
+#: sonar/common/jsonschemas/language-v1.0.0.json:1645
 msgid "lang_mni"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1652
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1687
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4163
+#: sonar/common/jsonschemas/language-v1.0.0.json:1649
 msgid "lang_mno"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1656
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1691
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4167
+#: sonar/common/jsonschemas/language-v1.0.0.json:1653
 msgid "lang_moh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1660
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1695
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4171
+#: sonar/common/jsonschemas/language-v1.0.0.json:1657
 msgid "lang_mon"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1664
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1699
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4175
+#: sonar/common/jsonschemas/language-v1.0.0.json:1661
 msgid "lang_mos"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1668
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1703
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4179
+#: sonar/common/jsonschemas/language-v1.0.0.json:1665
 msgid "lang_mul"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1672
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1707
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4183
+#: sonar/common/jsonschemas/language-v1.0.0.json:1669
 msgid "lang_mun"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1676
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1711
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4187
+#: sonar/common/jsonschemas/language-v1.0.0.json:1673
 msgid "lang_mus"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1680
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1715
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4191
+#: sonar/common/jsonschemas/language-v1.0.0.json:1677
 msgid "lang_mwl"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1684
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1719
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4195
+#: sonar/common/jsonschemas/language-v1.0.0.json:1681
 msgid "lang_mwr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1688
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1723
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4199
+#: sonar/common/jsonschemas/language-v1.0.0.json:1685
 msgid "lang_myn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1692
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1727
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4203
+#: sonar/common/jsonschemas/language-v1.0.0.json:1689
 msgid "lang_myv"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1696
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1731
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4207
+#: sonar/common/jsonschemas/language-v1.0.0.json:1693
 msgid "lang_nah"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1700
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1735
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4211
+#: sonar/common/jsonschemas/language-v1.0.0.json:1697
 msgid "lang_nai"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1704
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1739
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4215
+#: sonar/common/jsonschemas/language-v1.0.0.json:1701
 msgid "lang_nap"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1708
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1743
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4219
+#: sonar/common/jsonschemas/language-v1.0.0.json:1705
 msgid "lang_nau"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1712
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1747
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4223
+#: sonar/common/jsonschemas/language-v1.0.0.json:1709
 msgid "lang_nav"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1716
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1751
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4227
+#: sonar/common/jsonschemas/language-v1.0.0.json:1713
 msgid "lang_nbl"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1720
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1755
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4231
+#: sonar/common/jsonschemas/language-v1.0.0.json:1717
 msgid "lang_nde"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1724
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1759
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4235
+#: sonar/common/jsonschemas/language-v1.0.0.json:1721
 msgid "lang_ndo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1728
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1763
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4239
+#: sonar/common/jsonschemas/language-v1.0.0.json:1725
 msgid "lang_nds"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1732
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1767
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4243
+#: sonar/common/jsonschemas/language-v1.0.0.json:1729
 msgid "lang_nep"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1736
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1771
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4247
+#: sonar/common/jsonschemas/language-v1.0.0.json:1733
 msgid "lang_new"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1740
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1775
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4251
+#: sonar/common/jsonschemas/language-v1.0.0.json:1737
 msgid "lang_nia"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1744
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1779
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4255
+#: sonar/common/jsonschemas/language-v1.0.0.json:1741
 msgid "lang_nic"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1748
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1783
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4259
+#: sonar/common/jsonschemas/language-v1.0.0.json:1745
 msgid "lang_niu"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1752
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1787
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4263
+#: sonar/common/jsonschemas/language-v1.0.0.json:1749
 msgid "lang_nno"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1756
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1791
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4267
+#: sonar/common/jsonschemas/language-v1.0.0.json:1753
 msgid "lang_nob"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1760
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1795
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4271
+#: sonar/common/jsonschemas/language-v1.0.0.json:1757
 msgid "lang_nog"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1764
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1799
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4275
+#: sonar/common/jsonschemas/language-v1.0.0.json:1761
 msgid "lang_non"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1768
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1803
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4279
+#: sonar/common/jsonschemas/language-v1.0.0.json:1765
 msgid "lang_nor"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1772
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1807
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4283
+#: sonar/common/jsonschemas/language-v1.0.0.json:1769
 msgid "lang_nqo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1776
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1811
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4287
+#: sonar/common/jsonschemas/language-v1.0.0.json:1773
 msgid "lang_nso"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1780
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1815
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4291
+#: sonar/common/jsonschemas/language-v1.0.0.json:1777
 msgid "lang_nub"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1784
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1819
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4295
+#: sonar/common/jsonschemas/language-v1.0.0.json:1781
 msgid "lang_nwc"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1788
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1823
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4299
+#: sonar/common/jsonschemas/language-v1.0.0.json:1785
 msgid "lang_nya"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1792
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1827
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4303
+#: sonar/common/jsonschemas/language-v1.0.0.json:1789
 msgid "lang_nym"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1796
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1831
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4307
+#: sonar/common/jsonschemas/language-v1.0.0.json:1793
 msgid "lang_nyn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1800
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1835
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4311
+#: sonar/common/jsonschemas/language-v1.0.0.json:1797
 msgid "lang_nyo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1804
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1839
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4315
+#: sonar/common/jsonschemas/language-v1.0.0.json:1801
 msgid "lang_nzi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1808
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1843
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4319
+#: sonar/common/jsonschemas/language-v1.0.0.json:1805
 msgid "lang_oci"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1812
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1847
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4323
+#: sonar/common/jsonschemas/language-v1.0.0.json:1809
 msgid "lang_oji"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1816
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1851
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4327
+#: sonar/common/jsonschemas/language-v1.0.0.json:1813
 msgid "lang_ori"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1820
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1855
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4331
+#: sonar/common/jsonschemas/language-v1.0.0.json:1817
 msgid "lang_orm"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1824
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1859
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4335
+#: sonar/common/jsonschemas/language-v1.0.0.json:1821
 msgid "lang_osa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1828
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1863
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4339
+#: sonar/common/jsonschemas/language-v1.0.0.json:1825
 msgid "lang_oss"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1832
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1867
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4343
+#: sonar/common/jsonschemas/language-v1.0.0.json:1829
 msgid "lang_ota"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1836
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1871
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4347
+#: sonar/common/jsonschemas/language-v1.0.0.json:1833
 msgid "lang_oto"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1840
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1875
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4351
+#: sonar/common/jsonschemas/language-v1.0.0.json:1837
 msgid "lang_paa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1844
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1879
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4355
+#: sonar/common/jsonschemas/language-v1.0.0.json:1841
 msgid "lang_pag"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1848
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1883
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4359
+#: sonar/common/jsonschemas/language-v1.0.0.json:1845
 msgid "lang_pal"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1852
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1887
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4363
+#: sonar/common/jsonschemas/language-v1.0.0.json:1849
 msgid "lang_pam"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1856
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1891
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4367
+#: sonar/common/jsonschemas/language-v1.0.0.json:1853
 msgid "lang_pan"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1860
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1895
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4371
+#: sonar/common/jsonschemas/language-v1.0.0.json:1857
 msgid "lang_pap"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1864
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1899
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4375
+#: sonar/common/jsonschemas/language-v1.0.0.json:1861
 msgid "lang_pau"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1868
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1903
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4379
+#: sonar/common/jsonschemas/language-v1.0.0.json:1865
 msgid "lang_peo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1872
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1907
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4383
+#: sonar/common/jsonschemas/language-v1.0.0.json:1869
 msgid "lang_per"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1876
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1911
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4387
+#: sonar/common/jsonschemas/language-v1.0.0.json:1873
 msgid "lang_phi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1880
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1915
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4391
+#: sonar/common/jsonschemas/language-v1.0.0.json:1877
 msgid "lang_phn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1884
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1919
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4395
+#: sonar/common/jsonschemas/language-v1.0.0.json:1881
 msgid "lang_pli"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1888
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1923
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4399
+#: sonar/common/jsonschemas/language-v1.0.0.json:1885
 msgid "lang_pol"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1892
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1927
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4403
+#: sonar/common/jsonschemas/language-v1.0.0.json:1889
 msgid "lang_pon"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1896
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1931
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4407
+#: sonar/common/jsonschemas/language-v1.0.0.json:1893
 msgid "lang_por"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1900
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1935
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4411
+#: sonar/common/jsonschemas/language-v1.0.0.json:1897
 msgid "lang_pra"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1904
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1939
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4415
+#: sonar/common/jsonschemas/language-v1.0.0.json:1901
 msgid "lang_pro"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1908
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1943
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4419
+#: sonar/common/jsonschemas/language-v1.0.0.json:1905
 msgid "lang_pus"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1912
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1947
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4423
+#: sonar/common/jsonschemas/language-v1.0.0.json:1909
 msgid "lang_que"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1916
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1951
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4427
+#: sonar/common/jsonschemas/language-v1.0.0.json:1913
 msgid "lang_raj"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1920
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1955
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4431
+#: sonar/common/jsonschemas/language-v1.0.0.json:1917
 msgid "lang_rap"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1924
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1959
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4435
+#: sonar/common/jsonschemas/language-v1.0.0.json:1921
 msgid "lang_rar"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1928
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1963
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4439
+#: sonar/common/jsonschemas/language-v1.0.0.json:1925
 msgid "lang_roa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1932
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1967
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4443
+#: sonar/common/jsonschemas/language-v1.0.0.json:1929
 msgid "lang_roh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1936
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1971
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4447
+#: sonar/common/jsonschemas/language-v1.0.0.json:1933
 msgid "lang_rom"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1940
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1975
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4451
+#: sonar/common/jsonschemas/language-v1.0.0.json:1937
 msgid "lang_rum"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1944
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1979
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4455
+#: sonar/common/jsonschemas/language-v1.0.0.json:1941
 msgid "lang_run"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1948
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1983
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4459
+#: sonar/common/jsonschemas/language-v1.0.0.json:1945
 msgid "lang_rup"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1952
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1987
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4463
+#: sonar/common/jsonschemas/language-v1.0.0.json:1949
 msgid "lang_rus"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1956
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1991
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4467
+#: sonar/common/jsonschemas/language-v1.0.0.json:1953
 msgid "lang_sad"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1960
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1995
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4471
+#: sonar/common/jsonschemas/language-v1.0.0.json:1957
 msgid "lang_sag"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1964
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1999
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4475
+#: sonar/common/jsonschemas/language-v1.0.0.json:1961
 msgid "lang_sah"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1968
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2003
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4479
+#: sonar/common/jsonschemas/language-v1.0.0.json:1965
 msgid "lang_sai"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1972
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2007
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4483
+#: sonar/common/jsonschemas/language-v1.0.0.json:1969
 msgid "lang_sal"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1976
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2011
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4487
+#: sonar/common/jsonschemas/language-v1.0.0.json:1973
 msgid "lang_sam"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1980
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2015
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4491
+#: sonar/common/jsonschemas/language-v1.0.0.json:1977
 msgid "lang_san"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1984
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2019
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4495
+#: sonar/common/jsonschemas/language-v1.0.0.json:1981
 msgid "lang_sas"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1988
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2023
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4499
+#: sonar/common/jsonschemas/language-v1.0.0.json:1985
 msgid "lang_sat"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1992
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2027
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4503
+#: sonar/common/jsonschemas/language-v1.0.0.json:1989
 msgid "lang_scn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1996
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2031
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4507
+#: sonar/common/jsonschemas/language-v1.0.0.json:1993
 msgid "lang_sco"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2000
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2035
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4511
+#: sonar/common/jsonschemas/language-v1.0.0.json:1997
 msgid "lang_sel"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2004
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2039
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4515
+#: sonar/common/jsonschemas/language-v1.0.0.json:2001
 msgid "lang_sem"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2008
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2043
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4519
+#: sonar/common/jsonschemas/language-v1.0.0.json:2005
 msgid "lang_sga"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2012
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2047
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4523
+#: sonar/common/jsonschemas/language-v1.0.0.json:2009
 msgid "lang_sgn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2016
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2051
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4527
+#: sonar/common/jsonschemas/language-v1.0.0.json:2013
 msgid "lang_shn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2020
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2055
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4531
+#: sonar/common/jsonschemas/language-v1.0.0.json:2017
 msgid "lang_sid"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2024
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2059
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4535
+#: sonar/common/jsonschemas/language-v1.0.0.json:2021
 msgid "lang_sin"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2028
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2063
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4539
+#: sonar/common/jsonschemas/language-v1.0.0.json:2025
 msgid "lang_sio"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2032
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2067
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4543
+#: sonar/common/jsonschemas/language-v1.0.0.json:2029
 msgid "lang_sit"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2036
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2071
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4547
+#: sonar/common/jsonschemas/language-v1.0.0.json:2033
 msgid "lang_sla"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2040
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2075
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4551
+#: sonar/common/jsonschemas/language-v1.0.0.json:2037
 msgid "lang_slo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2044
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2079
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4555
+#: sonar/common/jsonschemas/language-v1.0.0.json:2041
 msgid "lang_slv"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2048
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2083
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4559
+#: sonar/common/jsonschemas/language-v1.0.0.json:2045
 msgid "lang_sma"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2052
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2087
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4563
+#: sonar/common/jsonschemas/language-v1.0.0.json:2049
 msgid "lang_sme"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2056
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2091
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4567
+#: sonar/common/jsonschemas/language-v1.0.0.json:2053
 msgid "lang_smi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2060
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2095
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4571
+#: sonar/common/jsonschemas/language-v1.0.0.json:2057
 msgid "lang_smj"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2064
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2099
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4575
+#: sonar/common/jsonschemas/language-v1.0.0.json:2061
 msgid "lang_smn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2068
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2103
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4579
+#: sonar/common/jsonschemas/language-v1.0.0.json:2065
 msgid "lang_smo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2072
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2107
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4583
+#: sonar/common/jsonschemas/language-v1.0.0.json:2069
 msgid "lang_sms"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2076
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2111
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4587
+#: sonar/common/jsonschemas/language-v1.0.0.json:2073
 msgid "lang_sna"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2080
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2115
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4591
+#: sonar/common/jsonschemas/language-v1.0.0.json:2077
 msgid "lang_snd"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2084
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2119
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4595
+#: sonar/common/jsonschemas/language-v1.0.0.json:2081
 msgid "lang_snk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2088
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2123
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4599
+#: sonar/common/jsonschemas/language-v1.0.0.json:2085
 msgid "lang_sog"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2092
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2127
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4603
+#: sonar/common/jsonschemas/language-v1.0.0.json:2089
 msgid "lang_som"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2096
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2131
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4607
+#: sonar/common/jsonschemas/language-v1.0.0.json:2093
 msgid "lang_son"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2100
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2135
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4611
+#: sonar/common/jsonschemas/language-v1.0.0.json:2097
 msgid "lang_sot"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2104
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2139
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4615
+#: sonar/common/jsonschemas/language-v1.0.0.json:2101
 msgid "lang_spa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2108
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2143
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4619
+#: sonar/common/jsonschemas/language-v1.0.0.json:2105
 msgid "lang_srd"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2112
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2147
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4623
+#: sonar/common/jsonschemas/language-v1.0.0.json:2109
 msgid "lang_srn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2116
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2151
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4627
+#: sonar/common/jsonschemas/language-v1.0.0.json:2113
 msgid "lang_srp"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2120
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2155
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4631
+#: sonar/common/jsonschemas/language-v1.0.0.json:2117
 msgid "lang_srr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2124
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2159
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4635
+#: sonar/common/jsonschemas/language-v1.0.0.json:2121
 msgid "lang_ssa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2128
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2163
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4639
+#: sonar/common/jsonschemas/language-v1.0.0.json:2125
 msgid "lang_ssw"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2132
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2167
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4643
+#: sonar/common/jsonschemas/language-v1.0.0.json:2129
 msgid "lang_suk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2136
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2171
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4647
+#: sonar/common/jsonschemas/language-v1.0.0.json:2133
 msgid "lang_sun"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2140
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2175
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4651
+#: sonar/common/jsonschemas/language-v1.0.0.json:2137
 msgid "lang_sus"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2144
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2179
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4655
+#: sonar/common/jsonschemas/language-v1.0.0.json:2141
 msgid "lang_sux"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2148
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2183
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4659
+#: sonar/common/jsonschemas/language-v1.0.0.json:2145
 msgid "lang_swa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2152
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2187
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4663
+#: sonar/common/jsonschemas/language-v1.0.0.json:2149
 msgid "lang_swe"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2156
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2191
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4667
+#: sonar/common/jsonschemas/language-v1.0.0.json:2153
 msgid "lang_syc"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2160
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2195
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4671
+#: sonar/common/jsonschemas/language-v1.0.0.json:2157
 msgid "lang_syr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2164
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2199
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4675
+#: sonar/common/jsonschemas/language-v1.0.0.json:2161
 msgid "lang_tah"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2168
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2203
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4679
+#: sonar/common/jsonschemas/language-v1.0.0.json:2165
 msgid "lang_tai"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2172
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2207
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4683
+#: sonar/common/jsonschemas/language-v1.0.0.json:2169
 msgid "lang_tam"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2176
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2211
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4687
+#: sonar/common/jsonschemas/language-v1.0.0.json:2173
 msgid "lang_tat"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2180
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2215
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4691
+#: sonar/common/jsonschemas/language-v1.0.0.json:2177
 msgid "lang_tel"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2184
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2219
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4695
+#: sonar/common/jsonschemas/language-v1.0.0.json:2181
 msgid "lang_tem"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2188
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2223
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4699
+#: sonar/common/jsonschemas/language-v1.0.0.json:2185
 msgid "lang_ter"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2192
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2227
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4703
+#: sonar/common/jsonschemas/language-v1.0.0.json:2189
 msgid "lang_tet"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2196
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2231
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4707
+#: sonar/common/jsonschemas/language-v1.0.0.json:2193
 msgid "lang_tgk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2200
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2235
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4711
+#: sonar/common/jsonschemas/language-v1.0.0.json:2197
 msgid "lang_tgl"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2204
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2239
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4715
+#: sonar/common/jsonschemas/language-v1.0.0.json:2201
 msgid "lang_tha"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2208
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2243
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4719
+#: sonar/common/jsonschemas/language-v1.0.0.json:2205
 msgid "lang_tib"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2212
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2247
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4723
+#: sonar/common/jsonschemas/language-v1.0.0.json:2209
 msgid "lang_tig"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2216
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2251
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4727
+#: sonar/common/jsonschemas/language-v1.0.0.json:2213
 msgid "lang_tir"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2220
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2255
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4731
+#: sonar/common/jsonschemas/language-v1.0.0.json:2217
 msgid "lang_tiv"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2224
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2259
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4735
+#: sonar/common/jsonschemas/language-v1.0.0.json:2221
 msgid "lang_tkl"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2228
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2263
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4739
+#: sonar/common/jsonschemas/language-v1.0.0.json:2225
 msgid "lang_tlh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2232
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2267
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4743
+#: sonar/common/jsonschemas/language-v1.0.0.json:2229
 msgid "lang_tli"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2236
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2271
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4747
+#: sonar/common/jsonschemas/language-v1.0.0.json:2233
 msgid "lang_tmh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2240
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2275
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4751
+#: sonar/common/jsonschemas/language-v1.0.0.json:2237
 msgid "lang_tog"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2244
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2279
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4755
+#: sonar/common/jsonschemas/language-v1.0.0.json:2241
 msgid "lang_ton"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2248
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2283
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4759
+#: sonar/common/jsonschemas/language-v1.0.0.json:2245
 msgid "lang_tpi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2252
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2287
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4763
+#: sonar/common/jsonschemas/language-v1.0.0.json:2249
 msgid "lang_tsi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2256
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2291
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4767
+#: sonar/common/jsonschemas/language-v1.0.0.json:2253
 msgid "lang_tsn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2260
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2295
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4771
+#: sonar/common/jsonschemas/language-v1.0.0.json:2257
 msgid "lang_tso"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2264
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2299
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4775
+#: sonar/common/jsonschemas/language-v1.0.0.json:2261
 msgid "lang_tuk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2268
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2303
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4779
+#: sonar/common/jsonschemas/language-v1.0.0.json:2265
 msgid "lang_tum"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2272
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2307
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4783
+#: sonar/common/jsonschemas/language-v1.0.0.json:2269
 msgid "lang_tup"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2276
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2311
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4787
+#: sonar/common/jsonschemas/language-v1.0.0.json:2273
 msgid "lang_tur"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2280
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2315
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4791
+#: sonar/common/jsonschemas/language-v1.0.0.json:2277
 msgid "lang_tut"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2284
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2319
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4795
+#: sonar/common/jsonschemas/language-v1.0.0.json:2281
 msgid "lang_tvl"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2288
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2323
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4799
+#: sonar/common/jsonschemas/language-v1.0.0.json:2285
 msgid "lang_twi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2292
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2327
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4803
+#: sonar/common/jsonschemas/language-v1.0.0.json:2289
 msgid "lang_tyv"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2296
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2331
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4807
+#: sonar/common/jsonschemas/language-v1.0.0.json:2293
 msgid "lang_udm"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2300
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2335
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4811
+#: sonar/common/jsonschemas/language-v1.0.0.json:2297
 msgid "lang_uga"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2304
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2339
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4815
+#: sonar/common/jsonschemas/language-v1.0.0.json:2301
 msgid "lang_uig"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2308
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2343
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4819
+#: sonar/common/jsonschemas/language-v1.0.0.json:2305
 msgid "lang_ukr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2312
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2347
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4823
+#: sonar/common/jsonschemas/language-v1.0.0.json:2309
 msgid "lang_umb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2316
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2351
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4827
+#: sonar/common/jsonschemas/language-v1.0.0.json:2313
 msgid "lang_und"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2320
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2355
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4831
+#: sonar/common/jsonschemas/language-v1.0.0.json:2317
 msgid "lang_urd"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2324
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2359
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4835
+#: sonar/common/jsonschemas/language-v1.0.0.json:2321
 msgid "lang_uzb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2328
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2363
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4839
+#: sonar/common/jsonschemas/language-v1.0.0.json:2325
 msgid "lang_vai"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2332
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2367
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4843
+#: sonar/common/jsonschemas/language-v1.0.0.json:2329
 msgid "lang_ven"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2336
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2371
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4847
+#: sonar/common/jsonschemas/language-v1.0.0.json:2333
 msgid "lang_vie"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2340
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2375
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4851
+#: sonar/common/jsonschemas/language-v1.0.0.json:2337
 msgid "lang_vol"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2344
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2379
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4855
+#: sonar/common/jsonschemas/language-v1.0.0.json:2341
 msgid "lang_vot"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2348
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2383
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4859
+#: sonar/common/jsonschemas/language-v1.0.0.json:2345
 msgid "lang_wak"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2352
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2387
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4863
+#: sonar/common/jsonschemas/language-v1.0.0.json:2349
 msgid "lang_wal"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2356
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2391
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4867
+#: sonar/common/jsonschemas/language-v1.0.0.json:2353
 msgid "lang_war"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2360
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2395
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4871
+#: sonar/common/jsonschemas/language-v1.0.0.json:2357
 msgid "lang_was"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2364
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2399
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4875
+#: sonar/common/jsonschemas/language-v1.0.0.json:2361
 msgid "lang_wel"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2368
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2403
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4879
+#: sonar/common/jsonschemas/language-v1.0.0.json:2365
 msgid "lang_wen"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2372
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2407
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4883
+#: sonar/common/jsonschemas/language-v1.0.0.json:2369
 msgid "lang_wln"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2376
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2411
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4887
+#: sonar/common/jsonschemas/language-v1.0.0.json:2373
 msgid "lang_wol"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2380
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2415
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4891
+#: sonar/common/jsonschemas/language-v1.0.0.json:2377
 msgid "lang_xal"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2384
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2419
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4895
+#: sonar/common/jsonschemas/language-v1.0.0.json:2381
 msgid "lang_xho"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2388
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2423
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4899
+#: sonar/common/jsonschemas/language-v1.0.0.json:2385
 msgid "lang_yao"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2392
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2427
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4903
+#: sonar/common/jsonschemas/language-v1.0.0.json:2389
 msgid "lang_yap"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2396
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2431
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4907
+#: sonar/common/jsonschemas/language-v1.0.0.json:2393
 msgid "lang_yid"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2400
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2435
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4911
+#: sonar/common/jsonschemas/language-v1.0.0.json:2397
 msgid "lang_yor"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2404
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2439
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4915
+#: sonar/common/jsonschemas/language-v1.0.0.json:2401
 msgid "lang_ypk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2408
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2443
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4919
+#: sonar/common/jsonschemas/language-v1.0.0.json:2405
 msgid "lang_zap"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2412
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2447
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4923
+#: sonar/common/jsonschemas/language-v1.0.0.json:2409
 msgid "lang_zbl"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2416
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2451
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4927
+#: sonar/common/jsonschemas/language-v1.0.0.json:2413
 msgid "lang_zen"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2420
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2455
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4931
+#: sonar/common/jsonschemas/language-v1.0.0.json:2417
 msgid "lang_zha"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2424
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2459
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4935
+#: sonar/common/jsonschemas/language-v1.0.0.json:2421
 msgid "lang_znd"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2428
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2463
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4939
+#: sonar/common/jsonschemas/language-v1.0.0.json:2425
 msgid "lang_zul"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2432
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2467
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4943
+#: sonar/common/jsonschemas/language-v1.0.0.json:2429
 msgid "lang_zun"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2436
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2471
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4947
+#: sonar/common/jsonschemas/language-v1.0.0.json:2433
 msgid "lang_zxx"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2440
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2475
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4951
+#: sonar/common/jsonschemas/language-v1.0.0.json:2437
 msgid "lang_zza"
 msgstr ""
 
@@ -5696,12 +4801,11 @@ msgstr ""
 msgid "mainTeam"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:923
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1743
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1034
 msgid "name"
 msgstr ""
 
-#: sonar/modules/documents/views.py:172
+#: sonar/modules/documents/views.py:178
 msgid "no."
 msgstr ""
 
@@ -5709,11 +4813,11 @@ msgstr ""
 msgid "other files"
 msgstr ""
 
-#: sonar/modules/documents/views.py:176
+#: sonar/modules/documents/views.py:182
 msgid "p."
 msgstr ""
 
-#: sonar/config.py:546
+#: sonar/config.py:570
 msgid "pid"
 msgstr ""
 
@@ -5777,7 +4881,7 @@ msgstr ""
 msgid "startDate"
 msgstr ""
 
-#: sonar/config.py:547
+#: sonar/config.py:571
 msgid "status"
 msgstr ""
 
@@ -5791,15 +4895,55 @@ msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:489
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:808
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1615
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1627
 msgid "uri"
 msgstr ""
 
-#: sonar/config.py:548
+#: sonar/config.py:572
 msgid "user"
 msgstr ""
 
-#: sonar/modules/documents/views.py:168
+#: sonar/translations/manual_translations.txt:59
+msgid "validation_action_approve"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:61
+msgid "validation_action_ask_for_changes"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:58
+msgid "validation_action_publish"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:60
+msgid "validation_action_reject"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:57
+msgid "validation_action_save"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:54
+msgid "validation_status_ask_for_changes"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:50
+msgid "validation_status_in_progress"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:53
+msgid "validation_status_rejected"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:51
+msgid "validation_status_to_validate"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:52
+msgid "validation_status_validated"
+msgstr ""
+
+#: sonar/modules/documents/views.py:174
 msgid "vol."
 msgstr ""
 

--- a/sonar/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/sonar/translations/nb_NO/LC_MESSAGES/messages.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.5.0\n"
 "Report-Msgid-Bugs-To: nicolas.prongue@rero.ch\n"
-"POT-Creation-Date: 2021-06-01 15:56+0200\n"
-"PO-Revision-Date: 2020-09-18 15:36+0000\n"
-"Last-Translator: Allan Nordhøy <epost@anotheragency.no>\n"
+"POT-Creation-Date: 2021-06-14 13:34+0200\n"
+"PO-Revision-Date: 2021-06-11 07:32+0000\n"
+"Last-Translator: Nicolas Prongué <n.prongue@outlook.com>\n"
 "Language: nb_NO\n"
 "Language-Team: Norwegian Bokmål "
 "<https://hosted.weblate.org/projects/rero_plus/sonar/nb_NO/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.1\n"
 
-#: sonar/theme/views.py:65
+#: sonar/theme/views.py:67
 #, python-format
 msgid "%(icon)s Profile"
 msgstr "%(icon)s Profil"
@@ -32,13 +32,13 @@ msgstr ""
 msgid "About SONAR"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:681
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:697
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:795
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:811
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:663
 msgid "Abstract"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:678
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:792
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:659
 msgid "Abstracts"
 msgstr ""
@@ -56,10 +56,11 @@ msgid "Accompanying material of the resource, i.e. maps."
 msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:844
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1651
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1663
 msgid "Acquisition terms"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:77
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:210
 msgid "Action"
 msgstr "Handling"
@@ -72,7 +73,11 @@ msgstr ""
 msgid "Actor involved"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:933
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:704
+msgid "Add a new collection"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1044
 msgid "Add a new project"
 msgstr ""
 
@@ -85,14 +90,13 @@ msgstr ""
 msgid "Administration"
 msgstr "Administrasjon"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:834
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1009
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1367
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:948
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1383
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:203
 msgid "Affiliation"
 msgstr "Tilknytning"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1180
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1196
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:159
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:250
 msgid "Agent"
@@ -128,8 +132,12 @@ msgid ""
 "underscores."
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1484
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1496
 msgid "Author or editor"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:612
+msgid "Authors / Editors"
 msgstr ""
 
 #: sonar/modules/documents/templates/documents/record.html:44
@@ -141,7 +149,7 @@ msgstr ""
 msgid "Back to SONAR"
 msgstr "Tilbake til SONAR"
 
-#: sonar/config.py:584
+#: sonar/config.py:608
 msgid "Best match"
 msgstr "Nærmeste treff"
 
@@ -157,12 +165,12 @@ msgstr ""
 msgid "Brief description of the report"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1788
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:30
 msgid "Bronze"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4993
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5008
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:110
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:125
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:20
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:34
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:15
@@ -180,35 +188,35 @@ msgstr ""
 msgid "CAS or DAS"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:27
+#: sonar/common/jsonschemas/license-v1.0.0.json:28
 msgid "CC BY"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:31
+#: sonar/common/jsonschemas/license-v1.0.0.json:32
 msgid "CC BY-NC"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:35
+#: sonar/common/jsonschemas/license-v1.0.0.json:36
 msgid "CC BY-NC-ND"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:39
+#: sonar/common/jsonschemas/license-v1.0.0.json:40
 msgid "CC BY-NC-SA"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:43
+#: sonar/common/jsonschemas/license-v1.0.0.json:44
 msgid "CC BY-ND"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:47
+#: sonar/common/jsonschemas/license-v1.0.0.json:48
 msgid "CC BY-SA"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:23
+#: sonar/common/jsonschemas/license-v1.0.0.json:24
 msgid "CC0"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5033
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:150
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:59
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:58
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:266
@@ -220,16 +228,16 @@ msgid "City"
 msgstr "By"
 
 #: sonar/common/jsonschemas/classification-v1.0.0.json:2
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1015
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1031
 #: sonar/modules/documents/templates/documents/record.html:262
 msgid "Classification"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1066
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1082
 msgid "Classification portion"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1011
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1027
 msgid "Classifications"
 msgstr ""
 
@@ -241,7 +249,7 @@ msgstr ""
 msgid "Click here to reset your password"
 msgstr "Klikk her for å tilbakestille passordet ditt"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1792
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:34
 msgid "Closed"
 msgstr ""
 
@@ -249,18 +257,27 @@ msgstr ""
 msgid "Code"
 msgstr "Kode"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:999
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:680
 msgid "Collection"
 msgstr "Samling"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:4
+#: sonar/modules/collections/templates/collections/index.html:21
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:676
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:995
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:999
+#: sonar/modules/documents/templates/documents/record.html:288
 msgid "Collections"
 msgstr "Samlinger"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:106
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:245
 msgid "Comment"
 msgstr "Kommentar"
+
+#: sonar/common/jsonschemas/validation-v1.0.0.json:107
+msgid "Comment associated with the current action."
+msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:513
 msgid "Company"
@@ -278,37 +295,41 @@ msgstr ""
 msgid "Contact"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1094
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:540
+msgid "Contained in (journal, book, proceedings)"
+msgstr ""
+
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1110
 msgid "Content note"
 msgstr "Kommentarmerknad"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1090
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1106
 msgid "Content notes"
 msgstr "Kommentarmerknader"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1175
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1480
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1191
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1492
 msgid "Contribution"
 msgstr "Bidragsyter"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1171
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1187
 msgid "Contributions"
 msgstr "Bidragsytere"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:814
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:928
 msgid "Contributor"
 msgstr "Bidragsyter"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:808
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:922
 msgid "Contributors"
 msgstr "Bidragsytere"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1379
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1395
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:212
 msgid "Controlled affiliation"
 msgstr "Kontrollert tilknytning"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1375
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1391
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:208
 msgid "Controlled affiliations"
 msgstr "Kontrollerte tilknytninger"
@@ -318,27 +339,36 @@ msgstr "Kontrollerte tilknytninger"
 msgid "Creativity, transformations and innovations in education"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:78
+msgid "Current action done in the validation process."
+msgstr ""
+
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:173
 msgid "Current cataloguing step."
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1799
+#: sonar/common/jsonschemas/validation-v1.0.0.json:65
+msgid "Current status of the record in the validation process."
+msgstr ""
+
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1774
 msgid "Custom field 1"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1819
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1794
 msgid "Custom field 2"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1839
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1814
 msgid "Custom field 3"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:42
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:240
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:777
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:891
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:496
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1123
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1295
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1139
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1311
 msgid "Date"
 msgstr "Dato"
 
@@ -350,14 +380,18 @@ msgstr ""
 msgid "Date of approval by the Team Leader"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1271
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1287
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:34
 msgid "Date of birth"
 msgstr "Fødselsdato"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1279
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1295
 msgid "Date of death"
 msgstr "Avdød"
+
+#: sonar/common/jsonschemas/validation-v1.0.0.json:43
+msgid "Date when the log is created."
+msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:640
 msgid "Dean of a school"
@@ -368,8 +402,8 @@ msgstr ""
 msgid "Dear %(email)s"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:762
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1108
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:876
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1124
 msgid "Degree"
 msgstr ""
 
@@ -385,20 +419,22 @@ msgstr ""
 msgid "Deposit to validate"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5003
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:120
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:30
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:236
 msgid "Describes the information of a single file in the record."
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2497
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:941
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:56
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:740
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1052
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:38
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:55
 msgid "Description"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2493
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:52
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:736
 msgid "Descriptions"
 msgstr ""
 
@@ -414,8 +450,8 @@ msgstr ""
 msgid "Director, head of establishment"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:757
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1103
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:871
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1119
 msgid "Dissertation"
 msgstr ""
 
@@ -431,12 +467,12 @@ msgstr ""
 msgid "Doctorate supported by the HEP-VS"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:558
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1117
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:556
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1124
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:3
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:958
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1411
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1445
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1423
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1457
 msgid "Document"
 msgstr "Dokument"
 
@@ -444,7 +480,7 @@ msgstr "Dokument"
 msgid "Document ID"
 msgstr "Dokument-ID"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1118
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1125
 msgid "Document created on basis of this deposit."
 msgstr ""
 
@@ -480,10 +516,6 @@ msgstr ""
 msgid "Edition"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:596
-msgid "Editors"
-msgstr ""
-
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:211
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:273
 msgid "Education, childhood and the learning Society 21"
@@ -512,7 +544,7 @@ msgid "Emotions, learning, and well-being at school"
 msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:80
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:959
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1075
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:79
 msgid "End date"
 msgstr ""
@@ -538,8 +570,15 @@ msgid ""
 "password."
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:886
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1020
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:569
+msgid "Example: 1"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:586
+msgid "Example: 10"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1000
 msgid "Example: 1111-2222-3333-4444"
 msgstr ""
 
@@ -548,13 +587,11 @@ msgstr ""
 msgid "Example: 2019 or 2019-01-01"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:782
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1127
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:896
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1143
 msgid "Example: 2019 or 2019-05-05"
 msgstr "Eksempel: 2019 eller 2019-05-05"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:953
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:960
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:153
 msgid "Example: 2019-05-05"
 msgstr ""
@@ -565,6 +602,8 @@ msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:75
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:88
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1070
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1082
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:74
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:87
 msgid "Example: 2020-12-01"
@@ -578,17 +617,17 @@ msgstr "Eksempel: Nordmann"
 msgid "Example: John"
 msgstr "Eksempel: Ola"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1488
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1500
 msgid "Example: Muller, Hans"
 msgstr "Eksempel: Muller, Hans"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:638
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:655
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:977
 msgid "Example: Published version"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:591
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1441
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:602
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1453
 msgid "Examples: 135, 5-27, …"
 msgstr "Eksempler: 135, 5-27, …"
 
@@ -596,7 +635,11 @@ msgstr "Eksempler: 135, 5-27, …"
 msgid "Except within organisation"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:913
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:685
+msgid "Existing collection"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1024
 msgid "Existing project"
 msgstr ""
 
@@ -624,20 +667,20 @@ msgstr ""
 msgid "External partners are involved"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5013
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:130
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:39
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:35
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:246
 msgid "File UUID"
 msgstr "Fil-UUID"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5002
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:119
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:29
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:235
 msgid "File item"
 msgstr "Fil-element"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4998
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:115
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:25
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:21
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:231
@@ -688,7 +731,7 @@ msgstr ""
 msgid "Formats"
 msgstr "Formater"
 
-#: sonar/config.py:72
+#: sonar/config.py:74
 msgid "French"
 msgstr "Fransk"
 
@@ -709,12 +752,10 @@ msgstr ""
 msgid "Funding number"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1048
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:245
 msgid "Funding organisation"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1045
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:241
 #: sonar/theme/templates/sonar/projects/detail.html:64
 msgid "Funding organisations"
@@ -728,20 +769,20 @@ msgstr ""
 msgid "Funding was granted for the project"
 msgstr ""
 
-#: sonar/config.py:72
+#: sonar/config.py:74
 msgid "German"
 msgstr "Tysk"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1780
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:22
 msgid "Gold"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:772
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1118
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:886
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1134
 msgid "Granting institution"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1776
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:18
 msgid "Green"
 msgstr ""
 
@@ -769,7 +810,7 @@ msgstr ""
 msgid "Harvested"
 msgstr "Høstet"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:18
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:18
 msgid "Hash key"
 msgstr ""
 
@@ -777,8 +818,8 @@ msgstr ""
 msgid "Help & Documentation"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:559
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1451
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:557
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1463
 msgid ""
 "Host document, for example a journal for an article, or a book for a book"
 " chapter."
@@ -790,7 +831,7 @@ msgstr ""
 msgid "How are research results used in training?"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1784
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:26
 msgid "Hybrid"
 msgstr ""
 
@@ -799,24 +840,22 @@ msgid "IR hosting service"
 msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:867
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1674
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1686
 msgid "ISBN/ISSN status should be selected in the list below."
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1220
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1236
 msgid "Identified by"
 msgstr "Identifisert av"
 
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:2
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:3
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:9
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:13
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:13
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:15
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:360
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:966
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1058
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:693
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1500
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1512
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:13
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:13
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:9
@@ -827,7 +866,7 @@ msgstr "Identifikator"
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:357
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:689
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1496
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1508
 #: sonar/modules/documents/templates/documents/record.html:237
 msgid "Identifiers"
 msgstr "Identifikatorer"
@@ -843,10 +882,6 @@ msgstr ""
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:316
 msgid "In progress"
 msgstr ""
-
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:597
-msgid "In the format \\"
-msgstr "I formatet \\"
 
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:118
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:165
@@ -874,12 +909,10 @@ msgstr ""
 msgid "Invenio"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:974
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:154
 msgid "Investigator"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:971
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:150
 #: sonar/theme/templates/sonar/projects/detail.html:35
 msgid "Investigators"
@@ -893,21 +926,21 @@ msgstr ""
 msgid "Is shared"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1429
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1441
 msgid "Issue"
 msgstr ""
 
-#: sonar/config.py:73
+#: sonar/config.py:75
 msgid "Italian"
 msgstr "Italiensk"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:767
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1113
-#: sonar/modules/documents/views.py:234
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:881
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1129
+#: sonar/modules/documents/views.py:240
 msgid "Jury note"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5023
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:140
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:49
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:47
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:256
@@ -918,7 +951,12 @@ msgstr "Nøkkel"
 msgid "Key (filename) of the file."
 msgstr ""
 
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:835
+msgid "Keyword"
+msgstr ""
+
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:391
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:832
 msgid "Keywords"
 msgstr ""
 
@@ -926,7 +964,7 @@ msgstr ""
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:69
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:503
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:903
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1154
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1170
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:94
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:141
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:188
@@ -940,8 +978,6 @@ msgid "Labels"
 msgstr ""
 
 #: sonar/common/jsonschemas/language-v1.0.0.json:2
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:37
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2513
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:354
 #: sonar/modules/documents/templates/documents/record.html:221
 msgid "Language"
@@ -964,7 +1000,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:829
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:943
 msgid "Last name, first name, ex: Doe, John"
 msgstr "Etternavn, fornavn, f.eks: Nordmann, Ola"
 
@@ -973,8 +1009,12 @@ msgid "Lecturer/professor"
 msgstr ""
 
 #: sonar/common/jsonschemas/license-v1.0.0.json:2
-#: sonar/modules/documents/templates/documents/record.html:288
+#: sonar/modules/documents/templates/documents/record.html:306
 msgid "License"
+msgstr ""
+
+#: sonar/common/jsonschemas/license-v1.0.0.json:52
+msgid "License undefined"
 msgstr ""
 
 #: sonar/theme/templates/sonar/projects/detail.html:79
@@ -989,17 +1029,22 @@ msgid ""
 " Enter one rule per line."
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4999
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:116
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:26
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:22
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:232
 msgid "List of files attached to the record."
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:21
+msgid "List of logs."
+msgstr ""
+
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:878
 msgid "Locality (Valais)"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:25
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:188
 msgid "Log"
 msgstr "Logg"
@@ -1034,11 +1079,12 @@ msgstr ""
 msgid "Logout"
 msgstr "Logg ut"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:20
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:184
 msgid "Logs"
 msgstr "Logger"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5034
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:151
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:60
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:59
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:267
@@ -1057,11 +1103,11 @@ msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:291
 msgid "Main title"
-msgstr "Hovedtittel"
+msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:287
 msgid "Main titles"
-msgstr "Hovedtitler"
+msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:836
 msgid "Mandate"
@@ -1079,38 +1125,38 @@ msgstr ""
 msgid "Mediator"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5028
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:145
 msgid "Mimetype"
 msgstr ""
 
-#: sonar/config.py:578
+#: sonar/config.py:602
 msgid "Most recent"
 msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:356
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:535
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:898
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:27
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:828
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:936
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:979
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1053
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:27
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:711
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:942
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1047
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:33
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:50
 msgid "Name"
 msgstr "Navn"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:23
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:23
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:707
 msgid "Names"
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:55
-msgid "Not OA / Rights reserved"
+#: sonar/modules/collections/templates/collections/index.html:32
+msgid "No collection found"
 msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:650
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:828
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1635
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1647
 msgid "Note"
 msgstr "Merknad"
 
@@ -1125,8 +1171,8 @@ msgid "Notes"
 msgstr "Merknader"
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:741
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:577
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1303
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:579
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1319
 msgid "Number"
 msgstr "Nummer"
 
@@ -1146,8 +1192,7 @@ msgstr ""
 msgid "OAI-PMH specific information."
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:880
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1014
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:994
 msgid "ORCID"
 msgstr ""
 
@@ -1156,18 +1201,17 @@ msgstr ""
 msgid "Object type"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1760
+#: sonar/common/jsonschemas/oa-status-v1.0.0.json:2
 msgid "Open access status"
 msgstr ""
 
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:93
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4969
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4973
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:86
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:90
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:222
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:5
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:84
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:287
-#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:291
 msgid "Organisation"
 msgstr "Organisasjon"
 
@@ -1206,26 +1250,22 @@ msgid ""
 "coloured."
 msgstr ""
 
-#: sonar/common/jsonschemas/license-v1.0.0.json:51
-msgid "Other OA / license undefined"
-msgstr ""
-
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:882
 msgid "Other canton (Switzerland)"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:624
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:641
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:953
 #: sonar/modules/documents/templates/documents/record.html:208
 msgid "Other electronic version"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:621
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:638
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:949
 msgid "Other electronic versions"
 msgstr ""
 
-#: sonar/modules/documents/templates/documents/record.html:311
+#: sonar/modules/documents/templates/documents/record.html:329
 msgid "Other files"
 msgstr ""
 
@@ -1238,8 +1278,8 @@ msgstr ""
 msgid "PID type"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:585
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1437
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:596
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1449
 msgid "Pages"
 msgstr ""
 
@@ -1247,8 +1287,7 @@ msgstr ""
 msgid "Parents"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:540
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1407
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1419
 msgid "Part of (host document)"
 msgstr ""
 
@@ -1260,7 +1299,7 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-#: sonar/modules/documents/templates/documents/record.html:301
+#: sonar/modules/documents/templates/documents/record.html:319
 msgid "Permalink"
 msgstr ""
 
@@ -1277,7 +1316,7 @@ msgstr "Telefonnummer"
 msgid "Phone number with the international prefix, without spaces."
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1287
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1303
 msgid "Place"
 msgstr "Sted"
 
@@ -1287,6 +1326,15 @@ msgstr ""
 
 #: sonar/templates/security/email/welcome.html:5
 msgid "Please confirm your e-mail by clicking here"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:573
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:590
+msgid "Please enter a valid number."
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:606
+msgid "Please enter a valid pages range, example: 135, 5-27."
 msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:85
@@ -1316,13 +1364,13 @@ msgstr "Drevet av <a href=\"%(link)s\" target=\"_blank\">RERO</a>"
 msgid "Practitioner-trainer"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1210
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1226
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:164
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:255
 msgid "Preferred name"
 msgstr "Foretrukket navn"
 
-#: sonar/modules/documents/templates/documents/record.html:329
+#: sonar/modules/documents/templates/documents/record.html:347
 #: sonar/theme/templates/sonar/preview/base.html:23
 msgid "Preview"
 msgstr ""
@@ -1342,11 +1390,11 @@ msgstr ""
 
 #: sonar/theme/templates/sonar/partial/dropdown_user.html:21
 #: sonar/theme/templates/sonar/partial/dropdown_user.html:24
-#: sonar/theme/views.py:66
+#: sonar/theme/views.py:68
 msgid "Profile"
 msgstr "Profil"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:916
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1027
 msgid "Project"
 msgstr ""
 
@@ -1386,12 +1434,12 @@ msgstr ""
 msgid "Public foundation"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:633
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:650
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:973
 msgid "Public note"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1456
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1468
 msgid "Publication"
 msgstr ""
 
@@ -1404,12 +1452,12 @@ msgid "Published in"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:332
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:606
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:623
 msgid "Publisher"
 msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:836
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1643
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1655
 msgid "Qualifier"
 msgstr ""
 
@@ -1417,15 +1465,19 @@ msgstr ""
 msgid "Realization framework"
 msgstr ""
 
+#: sonar/modules/validation/api.py:216
+msgid "Record validation"
+msgstr ""
+
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:4
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:908
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1732
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1019
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1744
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:4
 msgid "Research project"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:901
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1728
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1015
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1740
 #: sonar/modules/documents/templates/documents/record.html:183
 msgid "Research projects"
 msgstr ""
@@ -1441,15 +1493,18 @@ msgstr "Tilbakestill passord"
 msgid "Responsibility"
 msgstr "Ansvar"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:839
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:984
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1330
+#: sonar/common/jsonschemas/license-v1.0.0.json:56
+msgid "Rights reserved"
+msgstr ""
+
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:953
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1346
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:99
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:181
 msgid "Role"
 msgstr "Rolle"
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1326
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1342
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:177
 msgid "Roles"
 msgstr "Roller"
@@ -1472,6 +1527,10 @@ msgstr ""
 msgid "Schema"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:3
+msgid "Schema representing a validation workflow."
+msgstr ""
+
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:9
 msgid "Schema to validate document against."
 msgstr ""
@@ -1486,6 +1545,10 @@ msgstr ""
 #: sonar/theme/templates/sonar/partial/organisation.html:21
 msgid "Search"
 msgstr "Søk"
+
+#: sonar/modules/collections/templates/collections/item.html:48
+msgid "Search in collection"
+msgstr ""
 
 #: sonar/theme/templates/sonar/frontpage.html:57
 msgid "Search publications, authors, projects..."
@@ -1544,14 +1607,14 @@ msgstr ""
 msgid "Sign-up with SWITCHaai"
 msgstr ""
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5039
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:156
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:65
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:64
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:272
 msgid "Size"
 msgstr "Størrelse"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5040
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:157
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:66
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:65
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:273
@@ -1566,8 +1629,8 @@ msgstr ""
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:510
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:849
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:926
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1245
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1656
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1261
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1668
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:117
 msgid "Source"
 msgstr "Kilde"
@@ -1580,13 +1643,9 @@ msgstr "Kildekode på"
 msgid "Special education teacher"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:659
-msgid "Specific collections"
-msgstr ""
-
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:67
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:952
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1461
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1063
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1473
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:66
 msgid "Start date"
 msgstr "Startdato"
@@ -1612,7 +1671,7 @@ msgid "State of Valais, parastatal institution"
 msgstr ""
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:474
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1466
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1478
 msgid "Statement"
 msgstr ""
 
@@ -1620,10 +1679,11 @@ msgstr ""
 msgid "Statements"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:64
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:39
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:136
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:860
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1667
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1679
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:39
 msgid "Status"
 msgstr "Status"
@@ -1652,14 +1712,11 @@ msgstr ""
 msgid "Student in training"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:721
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:898
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:915
 msgid "Subject"
 msgstr "Emne"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:718
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:737
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:894
 msgid "Subjects"
 msgstr "Emner"
@@ -1681,7 +1738,7 @@ msgstr "Super-administrasjon"
 msgid "Suspended"
 msgstr ""
 
-#: sonar/config.py:94 sonar/config.py:98
+#: sonar/config.py:96 sonar/config.py:100
 msgid "Swiss Open Access Repository"
 msgstr ""
 
@@ -1711,7 +1768,7 @@ msgid ""
 "with Swiss public research institutions."
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:660
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:677
 msgid ""
 "The names of the organisation's specific/patrimonial collections to which"
 " this document belongs"
@@ -1740,7 +1797,7 @@ msgstr ""
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:304
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:264
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:627
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1450
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1462
 msgid "Title"
 msgstr "Tittel"
 
@@ -1779,11 +1836,11 @@ msgstr ""
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:449
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:478
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:698
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1022
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1052
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1185
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1225
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1505
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1038
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1068
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1201
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1241
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1517
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:97
 msgid "Type"
 msgstr "Typer"
@@ -1796,7 +1853,7 @@ msgstr ""
 msgid "Type of the file"
 msgstr "Filtype"
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:643
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:660
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:963
 msgid "URL"
 msgstr "Nettadresse"
@@ -1813,10 +1870,12 @@ msgstr ""
 msgid "UUID of the bucket the tile is assigned to."
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1146
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1162
 msgid "Usage and access policy"
 msgstr ""
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:90
+#: sonar/common/jsonschemas/validation-v1.0.0.json:96
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:116
 #: sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json:121
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:120
@@ -1824,15 +1883,25 @@ msgstr ""
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:198
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:202
 #: sonar/modules/users/jsonschemas/users/user-v1.0.0.json:5
-#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:311
-#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:316
+#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:310
+#: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:315
 msgid "User"
 msgstr "Bruker"
 
+#: sonar/common/jsonschemas/validation-v1.0.0.json:91
+msgid "User which created the record."
+msgstr ""
+
+#: sonar/common/jsonschemas/validation-v1.0.0.json:2
+msgid "Validation"
+msgstr ""
+
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:39
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:32
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2502
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:32
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:61
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:505
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:716
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:745
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:296
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:320
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:405
@@ -1841,8 +1910,8 @@ msgstr "Bruker"
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:668
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:823
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:911
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1256
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1630
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1272
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1642
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:99
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:146
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:193
@@ -1850,7 +1919,11 @@ msgstr "Bruker"
 msgid "Value"
 msgstr "Verdi"
 
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:5018
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:851
+msgid "Values"
+msgstr ""
+
+#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json:135
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:44
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:41
 #: sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json:251
@@ -1861,8 +1934,8 @@ msgstr "Versjons-UUID"
 msgid "Vice-rector HE"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:569
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1421
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:562
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1433
 msgid "Volume"
 msgstr ""
 
@@ -1870,7 +1943,7 @@ msgstr ""
 msgid "Welcome to SONAR"
 msgstr ""
 
-#: sonar/config.py:125
+#: sonar/config.py:127
 msgid "Welcome to SONAR, the Swiss Open Access Repository!"
 msgstr ""
 
@@ -1902,8 +1975,7 @@ msgstr ""
 msgid "Why?"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:564
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1416
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1428
 msgid "Year"
 msgstr "År"
 
@@ -1925,78 +1997,78 @@ msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:417
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:728
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1535
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1547
 msgid "bf:AudioIssueNumber"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1049
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1065
 msgid "bf:ClassificationDdc"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1019
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1035
 msgid "bf:ClassificationUdc"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:402
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:732
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1539
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1551
 msgid "bf:Doi"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:421
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:736
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1543
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1555
 msgid "bf:Ean"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:425
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:740
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1547
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1559
 msgid "bf:Gtin14Number"
 msgstr ""
 
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:17
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:429
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:744
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1234
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1551
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1250
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1563
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:106
 msgid "bf:Identifier"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:433
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:748
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1555
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1567
 msgid "bf:Isan"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:412
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:752
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1559
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1571
 msgid "bf:Isbn"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:437
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:756
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1563
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1575
 msgid "bf:Ismn"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:441
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:760
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1567
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1579
 msgid "bf:Isrc"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:445
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:764
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1571
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1583
 msgid "bf:Issn"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:449
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:768
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1575
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1587
 msgid "bf:IssnL"
 msgstr ""
 
@@ -2007,8 +2079,8 @@ msgstr ""
 #: sonar/common/jsonschemas/identifiedby-v1.0.0.json:21
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:453
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:772
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1238
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1579
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1254
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1591
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:110
 msgid "bf:Local"
 msgstr ""
@@ -2019,37 +2091,37 @@ msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:457
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:776
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1583
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1595
 msgid "bf:MatrixNumber"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1203
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1219
 msgid "bf:Meeting"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:461
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:780
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1587
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1599
 msgid "bf:MusicDistributorNumber"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:465
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:784
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1591
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1603
 msgid "bf:MusicPlate"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:469
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:788
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1595
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1607
 msgid "bf:MusicPublisherNumber"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1199
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1215
 msgid "bf:Organization"
 msgstr ""
 
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1195
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1211
 msgid "bf:Person"
 msgstr ""
 
@@ -2063,19 +2135,19 @@ msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:473
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:792
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1599
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1611
 msgid "bf:PublisherNumber"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:493
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:812
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1619
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1631
 msgid "bf:ReportNumber"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:497
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:816
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1623
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1635
 msgid "bf:Strn"
 msgstr ""
 
@@ -2085,19 +2157,19 @@ msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:477
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:796
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1603
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1615
 msgid "bf:Upc"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:481
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:800
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1607
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1619
 msgid "bf:Urn"
 msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:485
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:804
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1611
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1623
 msgid "bf:VideoRecordingNumber"
 msgstr ""
 
@@ -2461,41 +2533,40 @@ msgstr ""
 msgid "coar:c_f1cf"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1002
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:195
 msgid "coinvestigator"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:857
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1351
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:971
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1367
 msgid "contribution_role_cre"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:861
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1359
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:975
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1375
 msgid "contribution_role_ctb"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:869
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1343
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:983
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1359
 msgid "contribution_role_dgs"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:865
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1355
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:979
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1371
 msgid "contribution_role_edt"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:873
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1347
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:987
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1363
 msgid "contribution_role_prt"
 msgstr ""
 
-#: sonar/modules/documents/views.py:266
+#: sonar/modules/documents/views.py:272
 msgid "contribution_role_{role}"
 msgstr ""
 
-#: sonar/config.py:549
+#: sonar/config.py:573
 msgid "contributor"
 msgstr ""
 
@@ -2779,7 +2850,6 @@ msgstr ""
 msgid "innerSearcher"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:998
 #: sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json:191
 msgid "investigator"
 msgstr ""
@@ -2788,2913 +2858,1948 @@ msgstr ""
 msgid "keywords"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:500
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:535
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3011
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:694
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1010
+msgid "label"
+msgstr ""
+
+#: sonar/common/jsonschemas/language-v1.0.0.json:497
 msgid "lang_aar"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:504
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:539
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3015
+#: sonar/common/jsonschemas/language-v1.0.0.json:501
 msgid "lang_abk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:508
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:543
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3019
+#: sonar/common/jsonschemas/language-v1.0.0.json:505
 msgid "lang_ace"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:512
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:547
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3023
+#: sonar/common/jsonschemas/language-v1.0.0.json:509
 msgid "lang_ach"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:516
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:551
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3027
+#: sonar/common/jsonschemas/language-v1.0.0.json:513
 msgid "lang_ada"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:520
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:555
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3031
+#: sonar/common/jsonschemas/language-v1.0.0.json:517
 msgid "lang_ady"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:524
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:559
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3035
+#: sonar/common/jsonschemas/language-v1.0.0.json:521
 msgid "lang_afa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:528
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:563
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3039
+#: sonar/common/jsonschemas/language-v1.0.0.json:525
 msgid "lang_afh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:532
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:567
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3043
+#: sonar/common/jsonschemas/language-v1.0.0.json:529
 msgid "lang_afr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:536
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:571
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3047
+#: sonar/common/jsonschemas/language-v1.0.0.json:533
 msgid "lang_ain"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:540
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:575
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3051
+#: sonar/common/jsonschemas/language-v1.0.0.json:537
 msgid "lang_aka"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:544
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:579
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3055
+#: sonar/common/jsonschemas/language-v1.0.0.json:541
 msgid "lang_akk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:548
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:583
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3059
+#: sonar/common/jsonschemas/language-v1.0.0.json:545
 msgid "lang_alb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:552
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:587
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3063
+#: sonar/common/jsonschemas/language-v1.0.0.json:549
 msgid "lang_ale"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:556
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:591
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3067
+#: sonar/common/jsonschemas/language-v1.0.0.json:553
 msgid "lang_alg"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:560
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:595
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3071
+#: sonar/common/jsonschemas/language-v1.0.0.json:557
 msgid "lang_alt"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:564
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:599
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3075
+#: sonar/common/jsonschemas/language-v1.0.0.json:561
 msgid "lang_amh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:568
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:603
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3079
+#: sonar/common/jsonschemas/language-v1.0.0.json:565
 msgid "lang_ang"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:572
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:607
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3083
+#: sonar/common/jsonschemas/language-v1.0.0.json:569
 msgid "lang_anp"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:576
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:611
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3087
+#: sonar/common/jsonschemas/language-v1.0.0.json:573
 msgid "lang_apa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:580
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:615
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3091
+#: sonar/common/jsonschemas/language-v1.0.0.json:577
 msgid "lang_ara"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:584
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:619
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3095
+#: sonar/common/jsonschemas/language-v1.0.0.json:581
 msgid "lang_arc"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:588
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:623
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3099
+#: sonar/common/jsonschemas/language-v1.0.0.json:585
 msgid "lang_arg"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:592
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:627
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3103
+#: sonar/common/jsonschemas/language-v1.0.0.json:589
 msgid "lang_arm"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:596
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:631
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3107
+#: sonar/common/jsonschemas/language-v1.0.0.json:593
 msgid "lang_arn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:600
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:635
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3111
+#: sonar/common/jsonschemas/language-v1.0.0.json:597
 msgid "lang_arp"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:604
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:639
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3115
+#: sonar/common/jsonschemas/language-v1.0.0.json:601
 msgid "lang_art"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:608
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:643
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3119
+#: sonar/common/jsonschemas/language-v1.0.0.json:605
 msgid "lang_arw"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:612
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:647
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3123
+#: sonar/common/jsonschemas/language-v1.0.0.json:609
 msgid "lang_asm"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:616
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:651
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3127
+#: sonar/common/jsonschemas/language-v1.0.0.json:613
 msgid "lang_ast"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:620
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:655
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3131
+#: sonar/common/jsonschemas/language-v1.0.0.json:617
 msgid "lang_ath"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:624
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:659
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3135
+#: sonar/common/jsonschemas/language-v1.0.0.json:621
 msgid "lang_aus"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:628
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:663
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3139
+#: sonar/common/jsonschemas/language-v1.0.0.json:625
 msgid "lang_ava"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:632
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:667
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3143
+#: sonar/common/jsonschemas/language-v1.0.0.json:629
 msgid "lang_ave"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:636
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:671
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3147
+#: sonar/common/jsonschemas/language-v1.0.0.json:633
 msgid "lang_awa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:640
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:675
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3151
+#: sonar/common/jsonschemas/language-v1.0.0.json:637
 msgid "lang_aym"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:644
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:679
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3155
+#: sonar/common/jsonschemas/language-v1.0.0.json:641
 msgid "lang_aze"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:648
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:683
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3159
+#: sonar/common/jsonschemas/language-v1.0.0.json:645
 msgid "lang_bad"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:652
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:687
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3163
+#: sonar/common/jsonschemas/language-v1.0.0.json:649
 msgid "lang_bai"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:656
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:691
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3167
+#: sonar/common/jsonschemas/language-v1.0.0.json:653
 msgid "lang_bak"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:660
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:695
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3171
+#: sonar/common/jsonschemas/language-v1.0.0.json:657
 msgid "lang_bal"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:664
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:699
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3175
+#: sonar/common/jsonschemas/language-v1.0.0.json:661
 msgid "lang_bam"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:668
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:703
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3179
+#: sonar/common/jsonschemas/language-v1.0.0.json:665
 msgid "lang_ban"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:672
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:707
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3183
+#: sonar/common/jsonschemas/language-v1.0.0.json:669
 msgid "lang_baq"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:676
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:711
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3187
+#: sonar/common/jsonschemas/language-v1.0.0.json:673
 msgid "lang_bas"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:680
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:715
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3191
+#: sonar/common/jsonschemas/language-v1.0.0.json:677
 msgid "lang_bat"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:684
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:719
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3195
+#: sonar/common/jsonschemas/language-v1.0.0.json:681
 msgid "lang_bej"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:688
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:723
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3199
+#: sonar/common/jsonschemas/language-v1.0.0.json:685
 msgid "lang_bel"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:692
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:727
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3203
+#: sonar/common/jsonschemas/language-v1.0.0.json:689
 msgid "lang_bem"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:696
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:731
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3207
+#: sonar/common/jsonschemas/language-v1.0.0.json:693
 msgid "lang_ben"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:700
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:735
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3211
+#: sonar/common/jsonschemas/language-v1.0.0.json:697
 msgid "lang_ber"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:704
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:739
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3215
+#: sonar/common/jsonschemas/language-v1.0.0.json:701
 msgid "lang_bho"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:708
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:743
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3219
+#: sonar/common/jsonschemas/language-v1.0.0.json:705
 msgid "lang_bih"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:712
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:747
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3223
+#: sonar/common/jsonschemas/language-v1.0.0.json:709
 msgid "lang_bik"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:716
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:751
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3227
+#: sonar/common/jsonschemas/language-v1.0.0.json:713
 msgid "lang_bin"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:720
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:755
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3231
+#: sonar/common/jsonschemas/language-v1.0.0.json:717
 msgid "lang_bis"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:724
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:759
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3235
+#: sonar/common/jsonschemas/language-v1.0.0.json:721
 msgid "lang_bla"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:728
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:763
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3239
+#: sonar/common/jsonschemas/language-v1.0.0.json:725
 msgid "lang_bnt"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:732
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:767
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3243
+#: sonar/common/jsonschemas/language-v1.0.0.json:729
 msgid "lang_bos"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:736
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:771
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3247
+#: sonar/common/jsonschemas/language-v1.0.0.json:733
 msgid "lang_bra"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:740
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:775
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3251
+#: sonar/common/jsonschemas/language-v1.0.0.json:737
 msgid "lang_bre"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:744
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:779
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3255
+#: sonar/common/jsonschemas/language-v1.0.0.json:741
 msgid "lang_btk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:748
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:783
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3259
+#: sonar/common/jsonschemas/language-v1.0.0.json:745
 msgid "lang_bua"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:752
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:787
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3263
+#: sonar/common/jsonschemas/language-v1.0.0.json:749
 msgid "lang_bug"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:756
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:791
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3267
+#: sonar/common/jsonschemas/language-v1.0.0.json:753
 msgid "lang_bul"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:760
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:795
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3271
+#: sonar/common/jsonschemas/language-v1.0.0.json:757
 msgid "lang_bur"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:764
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:799
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3275
+#: sonar/common/jsonschemas/language-v1.0.0.json:761
 msgid "lang_byn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:768
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:803
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3279
+#: sonar/common/jsonschemas/language-v1.0.0.json:765
 msgid "lang_cad"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:772
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:807
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3283
+#: sonar/common/jsonschemas/language-v1.0.0.json:769
 msgid "lang_cai"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:776
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:811
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3287
+#: sonar/common/jsonschemas/language-v1.0.0.json:773
 msgid "lang_car"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:780
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:815
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3291
+#: sonar/common/jsonschemas/language-v1.0.0.json:777
 msgid "lang_cat"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:784
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:819
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3295
+#: sonar/common/jsonschemas/language-v1.0.0.json:781
 msgid "lang_cau"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:788
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:823
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3299
+#: sonar/common/jsonschemas/language-v1.0.0.json:785
 msgid "lang_ceb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:792
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:827
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3303
+#: sonar/common/jsonschemas/language-v1.0.0.json:789
 msgid "lang_cel"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:796
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:831
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3307
+#: sonar/common/jsonschemas/language-v1.0.0.json:793
 msgid "lang_cha"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:800
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:835
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3311
+#: sonar/common/jsonschemas/language-v1.0.0.json:797
 msgid "lang_chb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:804
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:839
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3315
+#: sonar/common/jsonschemas/language-v1.0.0.json:801
 msgid "lang_che"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:808
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:843
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3319
+#: sonar/common/jsonschemas/language-v1.0.0.json:805
 msgid "lang_chg"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:812
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:847
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3323
+#: sonar/common/jsonschemas/language-v1.0.0.json:809
 msgid "lang_chi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:816
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:851
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3327
+#: sonar/common/jsonschemas/language-v1.0.0.json:813
 msgid "lang_chk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:820
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:855
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3331
+#: sonar/common/jsonschemas/language-v1.0.0.json:817
 msgid "lang_chm"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:824
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:859
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3335
+#: sonar/common/jsonschemas/language-v1.0.0.json:821
 msgid "lang_chn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:828
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:863
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3339
+#: sonar/common/jsonschemas/language-v1.0.0.json:825
 msgid "lang_cho"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:832
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:867
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3343
+#: sonar/common/jsonschemas/language-v1.0.0.json:829
 msgid "lang_chp"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:836
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:871
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3347
+#: sonar/common/jsonschemas/language-v1.0.0.json:833
 msgid "lang_chr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:840
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:875
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3351
+#: sonar/common/jsonschemas/language-v1.0.0.json:837
 msgid "lang_chu"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:844
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:879
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3355
+#: sonar/common/jsonschemas/language-v1.0.0.json:841
 msgid "lang_chv"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:848
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:883
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3359
+#: sonar/common/jsonschemas/language-v1.0.0.json:845
 msgid "lang_chy"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:852
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:887
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3363
+#: sonar/common/jsonschemas/language-v1.0.0.json:849
 msgid "lang_cmc"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:856
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:891
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3367
+#: sonar/common/jsonschemas/language-v1.0.0.json:853
 msgid "lang_cnr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:860
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:895
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3371
+#: sonar/common/jsonschemas/language-v1.0.0.json:857
 msgid "lang_cop"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:864
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:899
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3375
+#: sonar/common/jsonschemas/language-v1.0.0.json:861
 msgid "lang_cor"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:868
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:903
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3379
+#: sonar/common/jsonschemas/language-v1.0.0.json:865
 msgid "lang_cos"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:872
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:907
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3383
+#: sonar/common/jsonschemas/language-v1.0.0.json:869
 msgid "lang_cpe"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:876
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:911
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3387
+#: sonar/common/jsonschemas/language-v1.0.0.json:873
 msgid "lang_cpf"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:880
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:915
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3391
+#: sonar/common/jsonschemas/language-v1.0.0.json:877
 msgid "lang_cpp"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:884
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:919
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3395
+#: sonar/common/jsonschemas/language-v1.0.0.json:881
 msgid "lang_cre"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:888
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:923
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3399
+#: sonar/common/jsonschemas/language-v1.0.0.json:885
 msgid "lang_crh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:892
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:927
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3403
+#: sonar/common/jsonschemas/language-v1.0.0.json:889
 msgid "lang_crp"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:896
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:931
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3407
+#: sonar/common/jsonschemas/language-v1.0.0.json:893
 msgid "lang_csb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:900
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:935
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3411
+#: sonar/common/jsonschemas/language-v1.0.0.json:897
 msgid "lang_cus"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:904
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:939
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3415
+#: sonar/common/jsonschemas/language-v1.0.0.json:901
 msgid "lang_cze"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:908
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:943
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3419
+#: sonar/common/jsonschemas/language-v1.0.0.json:905
 msgid "lang_dak"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:912
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:947
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3423
+#: sonar/common/jsonschemas/language-v1.0.0.json:909
 msgid "lang_dan"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:916
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:951
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3427
+#: sonar/common/jsonschemas/language-v1.0.0.json:913
 msgid "lang_dar"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:920
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:955
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3431
+#: sonar/common/jsonschemas/language-v1.0.0.json:917
 msgid "lang_day"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:924
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:959
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3435
+#: sonar/common/jsonschemas/language-v1.0.0.json:921
 msgid "lang_del"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:928
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:963
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3439
+#: sonar/common/jsonschemas/language-v1.0.0.json:925
 msgid "lang_den"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:932
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:967
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3443
+#: sonar/common/jsonschemas/language-v1.0.0.json:929
 msgid "lang_dgr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:936
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:971
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3447
+#: sonar/common/jsonschemas/language-v1.0.0.json:933
 msgid "lang_din"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:940
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:975
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3451
+#: sonar/common/jsonschemas/language-v1.0.0.json:937
 msgid "lang_div"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:944
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:979
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3455
+#: sonar/common/jsonschemas/language-v1.0.0.json:941
 msgid "lang_doi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:948
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:983
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3459
+#: sonar/common/jsonschemas/language-v1.0.0.json:945
 msgid "lang_dra"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:952
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:987
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3463
+#: sonar/common/jsonschemas/language-v1.0.0.json:949
 msgid "lang_dsb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:956
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:991
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3467
+#: sonar/common/jsonschemas/language-v1.0.0.json:953
 msgid "lang_dua"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:960
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:995
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3471
+#: sonar/common/jsonschemas/language-v1.0.0.json:957
 msgid "lang_dum"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:964
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:999
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3475
+#: sonar/common/jsonschemas/language-v1.0.0.json:961
 msgid "lang_dut"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:968
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1003
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3479
+#: sonar/common/jsonschemas/language-v1.0.0.json:965
 msgid "lang_dyu"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:972
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1007
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3483
+#: sonar/common/jsonschemas/language-v1.0.0.json:969
 msgid "lang_dzo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:976
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1011
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3487
+#: sonar/common/jsonschemas/language-v1.0.0.json:973
 msgid "lang_efi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:980
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1015
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3491
+#: sonar/common/jsonschemas/language-v1.0.0.json:977
 msgid "lang_egy"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:984
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1019
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3495
+#: sonar/common/jsonschemas/language-v1.0.0.json:981
 msgid "lang_eka"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:988
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1023
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3499
+#: sonar/common/jsonschemas/language-v1.0.0.json:985
 msgid "lang_elx"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:992
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1027
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3503
+#: sonar/common/jsonschemas/language-v1.0.0.json:989
 msgid "lang_eng"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:997
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1032
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3508
+#: sonar/common/jsonschemas/language-v1.0.0.json:994
 msgid "lang_enm"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1001
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1036
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3512
+#: sonar/common/jsonschemas/language-v1.0.0.json:998
 msgid "lang_epo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1005
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1040
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3516
+#: sonar/common/jsonschemas/language-v1.0.0.json:1002
 msgid "lang_est"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1009
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1044
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3520
+#: sonar/common/jsonschemas/language-v1.0.0.json:1006
 msgid "lang_ewe"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1013
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1048
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3524
+#: sonar/common/jsonschemas/language-v1.0.0.json:1010
 msgid "lang_ewo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1017
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1052
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3528
+#: sonar/common/jsonschemas/language-v1.0.0.json:1014
 msgid "lang_fan"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1021
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1056
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3532
+#: sonar/common/jsonschemas/language-v1.0.0.json:1018
 msgid "lang_fao"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1025
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1060
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3536
+#: sonar/common/jsonschemas/language-v1.0.0.json:1022
 msgid "lang_fat"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1029
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1064
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3540
+#: sonar/common/jsonschemas/language-v1.0.0.json:1026
 msgid "lang_fij"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1033
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1068
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3544
+#: sonar/common/jsonschemas/language-v1.0.0.json:1030
 msgid "lang_fil"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1037
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1072
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3548
+#: sonar/common/jsonschemas/language-v1.0.0.json:1034
 msgid "lang_fin"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1041
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1076
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3552
+#: sonar/common/jsonschemas/language-v1.0.0.json:1038
 msgid "lang_fiu"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1045
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1080
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3556
+#: sonar/common/jsonschemas/language-v1.0.0.json:1042
 msgid "lang_fon"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1049
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1084
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3560
+#: sonar/common/jsonschemas/language-v1.0.0.json:1046
 msgid "lang_fre"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1054
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1089
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3565
+#: sonar/common/jsonschemas/language-v1.0.0.json:1051
 msgid "lang_frm"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1058
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1093
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3569
+#: sonar/common/jsonschemas/language-v1.0.0.json:1055
 msgid "lang_fro"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1062
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1097
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3573
+#: sonar/common/jsonschemas/language-v1.0.0.json:1059
 msgid "lang_frr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1066
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1101
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3577
+#: sonar/common/jsonschemas/language-v1.0.0.json:1063
 msgid "lang_frs"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1070
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1105
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3581
+#: sonar/common/jsonschemas/language-v1.0.0.json:1067
 msgid "lang_fry"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1074
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1109
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3585
+#: sonar/common/jsonschemas/language-v1.0.0.json:1071
 msgid "lang_ful"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1078
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1113
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3589
+#: sonar/common/jsonschemas/language-v1.0.0.json:1075
 msgid "lang_fur"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1082
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1117
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3593
+#: sonar/common/jsonschemas/language-v1.0.0.json:1079
 msgid "lang_gaa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1086
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1121
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3597
+#: sonar/common/jsonschemas/language-v1.0.0.json:1083
 msgid "lang_gay"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1090
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1125
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3601
+#: sonar/common/jsonschemas/language-v1.0.0.json:1087
 msgid "lang_gba"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1094
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1129
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3605
+#: sonar/common/jsonschemas/language-v1.0.0.json:1091
 msgid "lang_gem"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1098
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1133
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3609
+#: sonar/common/jsonschemas/language-v1.0.0.json:1095
 msgid "lang_geo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1102
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1137
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3613
+#: sonar/common/jsonschemas/language-v1.0.0.json:1099
 msgid "lang_ger"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1107
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1142
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3618
+#: sonar/common/jsonschemas/language-v1.0.0.json:1104
 msgid "lang_gez"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1111
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1146
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3622
+#: sonar/common/jsonschemas/language-v1.0.0.json:1108
 msgid "lang_gil"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1115
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1150
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3626
+#: sonar/common/jsonschemas/language-v1.0.0.json:1112
 msgid "lang_gla"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1119
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1154
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3630
+#: sonar/common/jsonschemas/language-v1.0.0.json:1116
 msgid "lang_gle"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1123
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1158
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3634
+#: sonar/common/jsonschemas/language-v1.0.0.json:1120
 msgid "lang_glg"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1127
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1162
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3638
+#: sonar/common/jsonschemas/language-v1.0.0.json:1124
 msgid "lang_glv"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1131
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1166
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3642
+#: sonar/common/jsonschemas/language-v1.0.0.json:1128
 msgid "lang_gmh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1135
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1170
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3646
+#: sonar/common/jsonschemas/language-v1.0.0.json:1132
 msgid "lang_goh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1139
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1174
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3650
+#: sonar/common/jsonschemas/language-v1.0.0.json:1136
 msgid "lang_gon"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1143
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1178
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3654
+#: sonar/common/jsonschemas/language-v1.0.0.json:1140
 msgid "lang_gor"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1147
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1182
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3658
+#: sonar/common/jsonschemas/language-v1.0.0.json:1144
 msgid "lang_got"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1151
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1186
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3662
+#: sonar/common/jsonschemas/language-v1.0.0.json:1148
 msgid "lang_grb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1155
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1190
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3666
+#: sonar/common/jsonschemas/language-v1.0.0.json:1152
 msgid "lang_grc"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1159
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1194
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3670
+#: sonar/common/jsonschemas/language-v1.0.0.json:1156
 msgid "lang_gre"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1163
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1198
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3674
+#: sonar/common/jsonschemas/language-v1.0.0.json:1160
 msgid "lang_grn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1167
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1202
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3678
+#: sonar/common/jsonschemas/language-v1.0.0.json:1164
 msgid "lang_gsw"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1171
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1206
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3682
+#: sonar/common/jsonschemas/language-v1.0.0.json:1168
 msgid "lang_guj"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1175
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1210
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3686
+#: sonar/common/jsonschemas/language-v1.0.0.json:1172
 msgid "lang_gwi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1179
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1214
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3690
+#: sonar/common/jsonschemas/language-v1.0.0.json:1176
 msgid "lang_hai"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1183
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1218
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3694
+#: sonar/common/jsonschemas/language-v1.0.0.json:1180
 msgid "lang_hat"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1187
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1222
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3698
+#: sonar/common/jsonschemas/language-v1.0.0.json:1184
 msgid "lang_hau"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1191
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1226
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3702
+#: sonar/common/jsonschemas/language-v1.0.0.json:1188
 msgid "lang_haw"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1195
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1230
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3706
+#: sonar/common/jsonschemas/language-v1.0.0.json:1192
 msgid "lang_heb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1199
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1234
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3710
+#: sonar/common/jsonschemas/language-v1.0.0.json:1196
 msgid "lang_her"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1203
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1238
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3714
+#: sonar/common/jsonschemas/language-v1.0.0.json:1200
 msgid "lang_hil"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1207
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1242
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3718
+#: sonar/common/jsonschemas/language-v1.0.0.json:1204
 msgid "lang_him"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1211
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1246
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3722
+#: sonar/common/jsonschemas/language-v1.0.0.json:1208
 msgid "lang_hin"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1215
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1250
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3726
+#: sonar/common/jsonschemas/language-v1.0.0.json:1212
 msgid "lang_hit"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1219
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1254
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3730
+#: sonar/common/jsonschemas/language-v1.0.0.json:1216
 msgid "lang_hmn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1223
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1258
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3734
+#: sonar/common/jsonschemas/language-v1.0.0.json:1220
 msgid "lang_hmo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1227
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1262
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3738
+#: sonar/common/jsonschemas/language-v1.0.0.json:1224
 msgid "lang_hrv"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1231
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1266
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3742
+#: sonar/common/jsonschemas/language-v1.0.0.json:1228
 msgid "lang_hsb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1235
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1270
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3746
+#: sonar/common/jsonschemas/language-v1.0.0.json:1232
 msgid "lang_hun"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1239
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1274
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3750
+#: sonar/common/jsonschemas/language-v1.0.0.json:1236
 msgid "lang_hup"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1243
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1278
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3754
+#: sonar/common/jsonschemas/language-v1.0.0.json:1240
 msgid "lang_iba"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1247
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1282
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3758
+#: sonar/common/jsonschemas/language-v1.0.0.json:1244
 msgid "lang_ibo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1251
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1286
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3762
+#: sonar/common/jsonschemas/language-v1.0.0.json:1248
 msgid "lang_ice"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1255
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1290
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3766
+#: sonar/common/jsonschemas/language-v1.0.0.json:1252
 msgid "lang_ido"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1259
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1294
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3770
+#: sonar/common/jsonschemas/language-v1.0.0.json:1256
 msgid "lang_iii"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1263
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1298
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3774
+#: sonar/common/jsonschemas/language-v1.0.0.json:1260
 msgid "lang_ijo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1267
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1302
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3778
+#: sonar/common/jsonschemas/language-v1.0.0.json:1264
 msgid "lang_iku"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1271
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1306
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3782
+#: sonar/common/jsonschemas/language-v1.0.0.json:1268
 msgid "lang_ile"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1275
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1310
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3786
+#: sonar/common/jsonschemas/language-v1.0.0.json:1272
 msgid "lang_ilo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1279
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1314
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3790
+#: sonar/common/jsonschemas/language-v1.0.0.json:1276
 msgid "lang_ina"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1283
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1318
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3794
+#: sonar/common/jsonschemas/language-v1.0.0.json:1280
 msgid "lang_inc"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1287
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1322
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3798
+#: sonar/common/jsonschemas/language-v1.0.0.json:1284
 msgid "lang_ind"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1291
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1326
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3802
+#: sonar/common/jsonschemas/language-v1.0.0.json:1288
 msgid "lang_ine"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1295
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1330
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3806
+#: sonar/common/jsonschemas/language-v1.0.0.json:1292
 msgid "lang_inh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1299
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1334
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3810
+#: sonar/common/jsonschemas/language-v1.0.0.json:1296
 msgid "lang_ipk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1303
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1338
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3814
+#: sonar/common/jsonschemas/language-v1.0.0.json:1300
 msgid "lang_ira"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1307
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1342
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3818
+#: sonar/common/jsonschemas/language-v1.0.0.json:1304
 msgid "lang_iro"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1311
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1346
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3822
+#: sonar/common/jsonschemas/language-v1.0.0.json:1308
 msgid "lang_ita"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1316
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1351
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3827
+#: sonar/common/jsonschemas/language-v1.0.0.json:1313
 msgid "lang_jav"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1320
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1355
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3831
+#: sonar/common/jsonschemas/language-v1.0.0.json:1317
 msgid "lang_jbo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1324
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1359
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3835
+#: sonar/common/jsonschemas/language-v1.0.0.json:1321
 msgid "lang_jpn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1328
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1363
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3839
+#: sonar/common/jsonschemas/language-v1.0.0.json:1325
 msgid "lang_jpr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1332
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1367
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3843
+#: sonar/common/jsonschemas/language-v1.0.0.json:1329
 msgid "lang_jrb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1336
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1371
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3847
+#: sonar/common/jsonschemas/language-v1.0.0.json:1333
 msgid "lang_kaa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1340
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1375
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3851
+#: sonar/common/jsonschemas/language-v1.0.0.json:1337
 msgid "lang_kab"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1344
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1379
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3855
+#: sonar/common/jsonschemas/language-v1.0.0.json:1341
 msgid "lang_kac"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1348
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1383
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3859
+#: sonar/common/jsonschemas/language-v1.0.0.json:1345
 msgid "lang_kal"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1352
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1387
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3863
+#: sonar/common/jsonschemas/language-v1.0.0.json:1349
 msgid "lang_kam"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1356
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1391
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3867
+#: sonar/common/jsonschemas/language-v1.0.0.json:1353
 msgid "lang_kan"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1360
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1395
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3871
+#: sonar/common/jsonschemas/language-v1.0.0.json:1357
 msgid "lang_kar"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1364
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1399
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3875
+#: sonar/common/jsonschemas/language-v1.0.0.json:1361
 msgid "lang_kas"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1368
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1403
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3879
+#: sonar/common/jsonschemas/language-v1.0.0.json:1365
 msgid "lang_kau"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1372
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1407
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3883
+#: sonar/common/jsonschemas/language-v1.0.0.json:1369
 msgid "lang_kaw"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1376
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1411
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3887
+#: sonar/common/jsonschemas/language-v1.0.0.json:1373
 msgid "lang_kaz"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1380
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1415
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3891
+#: sonar/common/jsonschemas/language-v1.0.0.json:1377
 msgid "lang_kbd"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1384
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1419
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3895
+#: sonar/common/jsonschemas/language-v1.0.0.json:1381
 msgid "lang_kha"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1388
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1423
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3899
+#: sonar/common/jsonschemas/language-v1.0.0.json:1385
 msgid "lang_khi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1392
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1427
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3903
+#: sonar/common/jsonschemas/language-v1.0.0.json:1389
 msgid "lang_khm"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1396
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1431
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3907
+#: sonar/common/jsonschemas/language-v1.0.0.json:1393
 msgid "lang_kho"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1400
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1435
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3911
+#: sonar/common/jsonschemas/language-v1.0.0.json:1397
 msgid "lang_kik"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1404
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1439
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3915
+#: sonar/common/jsonschemas/language-v1.0.0.json:1401
 msgid "lang_kin"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1408
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1443
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3919
+#: sonar/common/jsonschemas/language-v1.0.0.json:1405
 msgid "lang_kir"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1412
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1447
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3923
+#: sonar/common/jsonschemas/language-v1.0.0.json:1409
 msgid "lang_kmb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1416
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1451
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3927
+#: sonar/common/jsonschemas/language-v1.0.0.json:1413
 msgid "lang_kok"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1420
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1455
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3931
+#: sonar/common/jsonschemas/language-v1.0.0.json:1417
 msgid "lang_kom"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1424
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1459
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3935
+#: sonar/common/jsonschemas/language-v1.0.0.json:1421
 msgid "lang_kon"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1428
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1463
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3939
+#: sonar/common/jsonschemas/language-v1.0.0.json:1425
 msgid "lang_kor"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1432
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1467
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3943
+#: sonar/common/jsonschemas/language-v1.0.0.json:1429
 msgid "lang_kos"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1436
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1471
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3947
+#: sonar/common/jsonschemas/language-v1.0.0.json:1433
 msgid "lang_kpe"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1440
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1475
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3951
+#: sonar/common/jsonschemas/language-v1.0.0.json:1437
 msgid "lang_krc"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1444
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1479
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3955
+#: sonar/common/jsonschemas/language-v1.0.0.json:1441
 msgid "lang_krl"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1448
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1483
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3959
+#: sonar/common/jsonschemas/language-v1.0.0.json:1445
 msgid "lang_kro"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1452
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1487
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3963
+#: sonar/common/jsonschemas/language-v1.0.0.json:1449
 msgid "lang_kru"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1456
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1491
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3967
+#: sonar/common/jsonschemas/language-v1.0.0.json:1453
 msgid "lang_kua"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1460
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1495
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3971
+#: sonar/common/jsonschemas/language-v1.0.0.json:1457
 msgid "lang_kum"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1464
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1499
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3975
+#: sonar/common/jsonschemas/language-v1.0.0.json:1461
 msgid "lang_kur"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1468
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1503
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3979
+#: sonar/common/jsonschemas/language-v1.0.0.json:1465
 msgid "lang_kut"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1472
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1507
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3983
+#: sonar/common/jsonschemas/language-v1.0.0.json:1469
 msgid "lang_lad"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1476
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1511
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3987
+#: sonar/common/jsonschemas/language-v1.0.0.json:1473
 msgid "lang_lah"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1480
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1515
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3991
+#: sonar/common/jsonschemas/language-v1.0.0.json:1477
 msgid "lang_lam"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1484
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1519
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3995
+#: sonar/common/jsonschemas/language-v1.0.0.json:1481
 msgid "lang_lao"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1488
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1523
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:3999
+#: sonar/common/jsonschemas/language-v1.0.0.json:1485
 msgid "lang_lat"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1492
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1527
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4003
+#: sonar/common/jsonschemas/language-v1.0.0.json:1489
 msgid "lang_lav"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1496
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1531
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4007
+#: sonar/common/jsonschemas/language-v1.0.0.json:1493
 msgid "lang_lez"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1500
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1535
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4011
+#: sonar/common/jsonschemas/language-v1.0.0.json:1497
 msgid "lang_lim"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1504
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1539
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4015
+#: sonar/common/jsonschemas/language-v1.0.0.json:1501
 msgid "lang_lin"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1508
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1543
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4019
+#: sonar/common/jsonschemas/language-v1.0.0.json:1505
 msgid "lang_lit"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1512
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1547
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4023
+#: sonar/common/jsonschemas/language-v1.0.0.json:1509
 msgid "lang_lol"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1516
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1551
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4027
+#: sonar/common/jsonschemas/language-v1.0.0.json:1513
 msgid "lang_loz"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1520
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1555
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4031
+#: sonar/common/jsonschemas/language-v1.0.0.json:1517
 msgid "lang_ltz"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1524
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1559
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4035
+#: sonar/common/jsonschemas/language-v1.0.0.json:1521
 msgid "lang_lua"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1528
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1563
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4039
+#: sonar/common/jsonschemas/language-v1.0.0.json:1525
 msgid "lang_lub"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1532
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1567
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4043
+#: sonar/common/jsonschemas/language-v1.0.0.json:1529
 msgid "lang_lug"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1536
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1571
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4047
+#: sonar/common/jsonschemas/language-v1.0.0.json:1533
 msgid "lang_lui"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1540
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1575
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4051
+#: sonar/common/jsonschemas/language-v1.0.0.json:1537
 msgid "lang_lun"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1544
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1579
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4055
+#: sonar/common/jsonschemas/language-v1.0.0.json:1541
 msgid "lang_luo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1548
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1583
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4059
+#: sonar/common/jsonschemas/language-v1.0.0.json:1545
 msgid "lang_lus"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1552
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1587
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4063
+#: sonar/common/jsonschemas/language-v1.0.0.json:1549
 msgid "lang_mac"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1556
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1591
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4067
+#: sonar/common/jsonschemas/language-v1.0.0.json:1553
 msgid "lang_mad"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1560
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1595
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4071
+#: sonar/common/jsonschemas/language-v1.0.0.json:1557
 msgid "lang_mag"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1564
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1599
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4075
+#: sonar/common/jsonschemas/language-v1.0.0.json:1561
 msgid "lang_mah"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1568
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1603
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4079
+#: sonar/common/jsonschemas/language-v1.0.0.json:1565
 msgid "lang_mai"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1572
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1607
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4083
+#: sonar/common/jsonschemas/language-v1.0.0.json:1569
 msgid "lang_mak"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1576
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1611
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4087
+#: sonar/common/jsonschemas/language-v1.0.0.json:1573
 msgid "lang_mal"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1580
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1615
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4091
+#: sonar/common/jsonschemas/language-v1.0.0.json:1577
 msgid "lang_man"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1584
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1619
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4095
+#: sonar/common/jsonschemas/language-v1.0.0.json:1581
 msgid "lang_mao"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1588
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1623
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4099
+#: sonar/common/jsonschemas/language-v1.0.0.json:1585
 msgid "lang_map"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1592
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1627
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4103
+#: sonar/common/jsonschemas/language-v1.0.0.json:1589
 msgid "lang_mar"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1596
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1631
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4107
+#: sonar/common/jsonschemas/language-v1.0.0.json:1593
 msgid "lang_mas"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1600
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1635
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4111
+#: sonar/common/jsonschemas/language-v1.0.0.json:1597
 msgid "lang_may"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1604
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1639
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4115
+#: sonar/common/jsonschemas/language-v1.0.0.json:1601
 msgid "lang_mdf"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1608
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1643
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4119
+#: sonar/common/jsonschemas/language-v1.0.0.json:1605
 msgid "lang_mdr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1612
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1647
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4123
+#: sonar/common/jsonschemas/language-v1.0.0.json:1609
 msgid "lang_men"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1616
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1651
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4127
+#: sonar/common/jsonschemas/language-v1.0.0.json:1613
 msgid "lang_mga"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1620
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1655
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4131
+#: sonar/common/jsonschemas/language-v1.0.0.json:1617
 msgid "lang_mic"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1624
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1659
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4135
+#: sonar/common/jsonschemas/language-v1.0.0.json:1621
 msgid "lang_min"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1628
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1663
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4139
+#: sonar/common/jsonschemas/language-v1.0.0.json:1625
 msgid "lang_mis"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1632
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1667
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4143
+#: sonar/common/jsonschemas/language-v1.0.0.json:1629
 msgid "lang_mkh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1636
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1671
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4147
+#: sonar/common/jsonschemas/language-v1.0.0.json:1633
 msgid "lang_mlg"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1640
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1675
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4151
+#: sonar/common/jsonschemas/language-v1.0.0.json:1637
 msgid "lang_mlt"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1644
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1679
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4155
+#: sonar/common/jsonschemas/language-v1.0.0.json:1641
 msgid "lang_mnc"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1648
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1683
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4159
+#: sonar/common/jsonschemas/language-v1.0.0.json:1645
 msgid "lang_mni"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1652
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1687
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4163
+#: sonar/common/jsonschemas/language-v1.0.0.json:1649
 msgid "lang_mno"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1656
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1691
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4167
+#: sonar/common/jsonschemas/language-v1.0.0.json:1653
 msgid "lang_moh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1660
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1695
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4171
+#: sonar/common/jsonschemas/language-v1.0.0.json:1657
 msgid "lang_mon"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1664
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1699
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4175
+#: sonar/common/jsonschemas/language-v1.0.0.json:1661
 msgid "lang_mos"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1668
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1703
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4179
+#: sonar/common/jsonschemas/language-v1.0.0.json:1665
 msgid "lang_mul"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1672
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1707
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4183
+#: sonar/common/jsonschemas/language-v1.0.0.json:1669
 msgid "lang_mun"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1676
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1711
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4187
+#: sonar/common/jsonschemas/language-v1.0.0.json:1673
 msgid "lang_mus"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1680
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1715
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4191
+#: sonar/common/jsonschemas/language-v1.0.0.json:1677
 msgid "lang_mwl"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1684
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1719
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4195
+#: sonar/common/jsonschemas/language-v1.0.0.json:1681
 msgid "lang_mwr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1688
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1723
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4199
+#: sonar/common/jsonschemas/language-v1.0.0.json:1685
 msgid "lang_myn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1692
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1727
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4203
+#: sonar/common/jsonschemas/language-v1.0.0.json:1689
 msgid "lang_myv"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1696
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1731
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4207
+#: sonar/common/jsonschemas/language-v1.0.0.json:1693
 msgid "lang_nah"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1700
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1735
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4211
+#: sonar/common/jsonschemas/language-v1.0.0.json:1697
 msgid "lang_nai"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1704
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1739
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4215
+#: sonar/common/jsonschemas/language-v1.0.0.json:1701
 msgid "lang_nap"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1708
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1743
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4219
+#: sonar/common/jsonschemas/language-v1.0.0.json:1705
 msgid "lang_nau"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1712
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1747
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4223
+#: sonar/common/jsonschemas/language-v1.0.0.json:1709
 msgid "lang_nav"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1716
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1751
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4227
+#: sonar/common/jsonschemas/language-v1.0.0.json:1713
 msgid "lang_nbl"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1720
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1755
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4231
+#: sonar/common/jsonschemas/language-v1.0.0.json:1717
 msgid "lang_nde"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1724
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1759
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4235
+#: sonar/common/jsonschemas/language-v1.0.0.json:1721
 msgid "lang_ndo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1728
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1763
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4239
+#: sonar/common/jsonschemas/language-v1.0.0.json:1725
 msgid "lang_nds"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1732
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1767
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4243
+#: sonar/common/jsonschemas/language-v1.0.0.json:1729
 msgid "lang_nep"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1736
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1771
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4247
+#: sonar/common/jsonschemas/language-v1.0.0.json:1733
 msgid "lang_new"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1740
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1775
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4251
+#: sonar/common/jsonschemas/language-v1.0.0.json:1737
 msgid "lang_nia"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1744
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1779
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4255
+#: sonar/common/jsonschemas/language-v1.0.0.json:1741
 msgid "lang_nic"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1748
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1783
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4259
+#: sonar/common/jsonschemas/language-v1.0.0.json:1745
 msgid "lang_niu"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1752
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1787
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4263
+#: sonar/common/jsonschemas/language-v1.0.0.json:1749
 msgid "lang_nno"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1756
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1791
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4267
+#: sonar/common/jsonschemas/language-v1.0.0.json:1753
 msgid "lang_nob"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1760
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1795
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4271
+#: sonar/common/jsonschemas/language-v1.0.0.json:1757
 msgid "lang_nog"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1764
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1799
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4275
+#: sonar/common/jsonschemas/language-v1.0.0.json:1761
 msgid "lang_non"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1768
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1803
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4279
+#: sonar/common/jsonschemas/language-v1.0.0.json:1765
 msgid "lang_nor"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1772
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1807
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4283
+#: sonar/common/jsonschemas/language-v1.0.0.json:1769
 msgid "lang_nqo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1776
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1811
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4287
+#: sonar/common/jsonschemas/language-v1.0.0.json:1773
 msgid "lang_nso"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1780
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1815
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4291
+#: sonar/common/jsonschemas/language-v1.0.0.json:1777
 msgid "lang_nub"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1784
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1819
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4295
+#: sonar/common/jsonschemas/language-v1.0.0.json:1781
 msgid "lang_nwc"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1788
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1823
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4299
+#: sonar/common/jsonschemas/language-v1.0.0.json:1785
 msgid "lang_nya"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1792
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1827
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4303
+#: sonar/common/jsonschemas/language-v1.0.0.json:1789
 msgid "lang_nym"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1796
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1831
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4307
+#: sonar/common/jsonschemas/language-v1.0.0.json:1793
 msgid "lang_nyn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1800
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1835
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4311
+#: sonar/common/jsonschemas/language-v1.0.0.json:1797
 msgid "lang_nyo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1804
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1839
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4315
+#: sonar/common/jsonschemas/language-v1.0.0.json:1801
 msgid "lang_nzi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1808
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1843
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4319
+#: sonar/common/jsonschemas/language-v1.0.0.json:1805
 msgid "lang_oci"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1812
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1847
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4323
+#: sonar/common/jsonschemas/language-v1.0.0.json:1809
 msgid "lang_oji"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1816
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1851
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4327
+#: sonar/common/jsonschemas/language-v1.0.0.json:1813
 msgid "lang_ori"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1820
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1855
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4331
+#: sonar/common/jsonschemas/language-v1.0.0.json:1817
 msgid "lang_orm"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1824
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1859
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4335
+#: sonar/common/jsonschemas/language-v1.0.0.json:1821
 msgid "lang_osa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1828
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1863
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4339
+#: sonar/common/jsonschemas/language-v1.0.0.json:1825
 msgid "lang_oss"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1832
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1867
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4343
+#: sonar/common/jsonschemas/language-v1.0.0.json:1829
 msgid "lang_ota"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1836
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1871
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4347
+#: sonar/common/jsonschemas/language-v1.0.0.json:1833
 msgid "lang_oto"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1840
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1875
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4351
+#: sonar/common/jsonschemas/language-v1.0.0.json:1837
 msgid "lang_paa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1844
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1879
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4355
+#: sonar/common/jsonschemas/language-v1.0.0.json:1841
 msgid "lang_pag"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1848
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1883
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4359
+#: sonar/common/jsonschemas/language-v1.0.0.json:1845
 msgid "lang_pal"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1852
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1887
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4363
+#: sonar/common/jsonschemas/language-v1.0.0.json:1849
 msgid "lang_pam"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1856
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1891
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4367
+#: sonar/common/jsonschemas/language-v1.0.0.json:1853
 msgid "lang_pan"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1860
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1895
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4371
+#: sonar/common/jsonschemas/language-v1.0.0.json:1857
 msgid "lang_pap"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1864
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1899
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4375
+#: sonar/common/jsonschemas/language-v1.0.0.json:1861
 msgid "lang_pau"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1868
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1903
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4379
+#: sonar/common/jsonschemas/language-v1.0.0.json:1865
 msgid "lang_peo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1872
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1907
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4383
+#: sonar/common/jsonschemas/language-v1.0.0.json:1869
 msgid "lang_per"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1876
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1911
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4387
+#: sonar/common/jsonschemas/language-v1.0.0.json:1873
 msgid "lang_phi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1880
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1915
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4391
+#: sonar/common/jsonschemas/language-v1.0.0.json:1877
 msgid "lang_phn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1884
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1919
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4395
+#: sonar/common/jsonschemas/language-v1.0.0.json:1881
 msgid "lang_pli"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1888
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1923
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4399
+#: sonar/common/jsonschemas/language-v1.0.0.json:1885
 msgid "lang_pol"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1892
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1927
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4403
+#: sonar/common/jsonschemas/language-v1.0.0.json:1889
 msgid "lang_pon"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1896
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1931
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4407
+#: sonar/common/jsonschemas/language-v1.0.0.json:1893
 msgid "lang_por"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1900
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1935
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4411
+#: sonar/common/jsonschemas/language-v1.0.0.json:1897
 msgid "lang_pra"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1904
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1939
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4415
+#: sonar/common/jsonschemas/language-v1.0.0.json:1901
 msgid "lang_pro"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1908
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1943
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4419
+#: sonar/common/jsonschemas/language-v1.0.0.json:1905
 msgid "lang_pus"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1912
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1947
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4423
+#: sonar/common/jsonschemas/language-v1.0.0.json:1909
 msgid "lang_que"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1916
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1951
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4427
+#: sonar/common/jsonschemas/language-v1.0.0.json:1913
 msgid "lang_raj"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1920
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1955
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4431
+#: sonar/common/jsonschemas/language-v1.0.0.json:1917
 msgid "lang_rap"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1924
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1959
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4435
+#: sonar/common/jsonschemas/language-v1.0.0.json:1921
 msgid "lang_rar"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1928
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1963
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4439
+#: sonar/common/jsonschemas/language-v1.0.0.json:1925
 msgid "lang_roa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1932
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1967
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4443
+#: sonar/common/jsonschemas/language-v1.0.0.json:1929
 msgid "lang_roh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1936
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1971
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4447
+#: sonar/common/jsonschemas/language-v1.0.0.json:1933
 msgid "lang_rom"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1940
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1975
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4451
+#: sonar/common/jsonschemas/language-v1.0.0.json:1937
 msgid "lang_rum"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1944
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1979
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4455
+#: sonar/common/jsonschemas/language-v1.0.0.json:1941
 msgid "lang_run"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1948
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1983
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4459
+#: sonar/common/jsonschemas/language-v1.0.0.json:1945
 msgid "lang_rup"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1952
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1987
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4463
+#: sonar/common/jsonschemas/language-v1.0.0.json:1949
 msgid "lang_rus"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1956
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1991
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4467
+#: sonar/common/jsonschemas/language-v1.0.0.json:1953
 msgid "lang_sad"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1960
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1995
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4471
+#: sonar/common/jsonschemas/language-v1.0.0.json:1957
 msgid "lang_sag"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1964
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:1999
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4475
+#: sonar/common/jsonschemas/language-v1.0.0.json:1961
 msgid "lang_sah"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1968
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2003
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4479
+#: sonar/common/jsonschemas/language-v1.0.0.json:1965
 msgid "lang_sai"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1972
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2007
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4483
+#: sonar/common/jsonschemas/language-v1.0.0.json:1969
 msgid "lang_sal"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1976
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2011
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4487
+#: sonar/common/jsonschemas/language-v1.0.0.json:1973
 msgid "lang_sam"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1980
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2015
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4491
+#: sonar/common/jsonschemas/language-v1.0.0.json:1977
 msgid "lang_san"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1984
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2019
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4495
+#: sonar/common/jsonschemas/language-v1.0.0.json:1981
 msgid "lang_sas"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1988
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2023
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4499
+#: sonar/common/jsonschemas/language-v1.0.0.json:1985
 msgid "lang_sat"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1992
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2027
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4503
+#: sonar/common/jsonschemas/language-v1.0.0.json:1989
 msgid "lang_scn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:1996
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2031
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4507
+#: sonar/common/jsonschemas/language-v1.0.0.json:1993
 msgid "lang_sco"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2000
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2035
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4511
+#: sonar/common/jsonschemas/language-v1.0.0.json:1997
 msgid "lang_sel"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2004
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2039
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4515
+#: sonar/common/jsonschemas/language-v1.0.0.json:2001
 msgid "lang_sem"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2008
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2043
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4519
+#: sonar/common/jsonschemas/language-v1.0.0.json:2005
 msgid "lang_sga"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2012
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2047
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4523
+#: sonar/common/jsonschemas/language-v1.0.0.json:2009
 msgid "lang_sgn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2016
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2051
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4527
+#: sonar/common/jsonschemas/language-v1.0.0.json:2013
 msgid "lang_shn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2020
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2055
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4531
+#: sonar/common/jsonschemas/language-v1.0.0.json:2017
 msgid "lang_sid"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2024
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2059
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4535
+#: sonar/common/jsonschemas/language-v1.0.0.json:2021
 msgid "lang_sin"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2028
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2063
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4539
+#: sonar/common/jsonschemas/language-v1.0.0.json:2025
 msgid "lang_sio"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2032
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2067
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4543
+#: sonar/common/jsonschemas/language-v1.0.0.json:2029
 msgid "lang_sit"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2036
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2071
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4547
+#: sonar/common/jsonschemas/language-v1.0.0.json:2033
 msgid "lang_sla"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2040
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2075
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4551
+#: sonar/common/jsonschemas/language-v1.0.0.json:2037
 msgid "lang_slo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2044
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2079
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4555
+#: sonar/common/jsonschemas/language-v1.0.0.json:2041
 msgid "lang_slv"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2048
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2083
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4559
+#: sonar/common/jsonschemas/language-v1.0.0.json:2045
 msgid "lang_sma"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2052
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2087
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4563
+#: sonar/common/jsonschemas/language-v1.0.0.json:2049
 msgid "lang_sme"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2056
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2091
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4567
+#: sonar/common/jsonschemas/language-v1.0.0.json:2053
 msgid "lang_smi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2060
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2095
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4571
+#: sonar/common/jsonschemas/language-v1.0.0.json:2057
 msgid "lang_smj"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2064
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2099
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4575
+#: sonar/common/jsonschemas/language-v1.0.0.json:2061
 msgid "lang_smn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2068
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2103
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4579
+#: sonar/common/jsonschemas/language-v1.0.0.json:2065
 msgid "lang_smo"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2072
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2107
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4583
+#: sonar/common/jsonschemas/language-v1.0.0.json:2069
 msgid "lang_sms"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2076
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2111
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4587
+#: sonar/common/jsonschemas/language-v1.0.0.json:2073
 msgid "lang_sna"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2080
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2115
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4591
+#: sonar/common/jsonschemas/language-v1.0.0.json:2077
 msgid "lang_snd"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2084
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2119
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4595
+#: sonar/common/jsonschemas/language-v1.0.0.json:2081
 msgid "lang_snk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2088
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2123
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4599
+#: sonar/common/jsonschemas/language-v1.0.0.json:2085
 msgid "lang_sog"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2092
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2127
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4603
+#: sonar/common/jsonschemas/language-v1.0.0.json:2089
 msgid "lang_som"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2096
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2131
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4607
+#: sonar/common/jsonschemas/language-v1.0.0.json:2093
 msgid "lang_son"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2100
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2135
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4611
+#: sonar/common/jsonschemas/language-v1.0.0.json:2097
 msgid "lang_sot"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2104
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2139
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4615
+#: sonar/common/jsonschemas/language-v1.0.0.json:2101
 msgid "lang_spa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2108
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2143
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4619
+#: sonar/common/jsonschemas/language-v1.0.0.json:2105
 msgid "lang_srd"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2112
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2147
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4623
+#: sonar/common/jsonschemas/language-v1.0.0.json:2109
 msgid "lang_srn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2116
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2151
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4627
+#: sonar/common/jsonschemas/language-v1.0.0.json:2113
 msgid "lang_srp"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2120
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2155
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4631
+#: sonar/common/jsonschemas/language-v1.0.0.json:2117
 msgid "lang_srr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2124
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2159
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4635
+#: sonar/common/jsonschemas/language-v1.0.0.json:2121
 msgid "lang_ssa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2128
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2163
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4639
+#: sonar/common/jsonschemas/language-v1.0.0.json:2125
 msgid "lang_ssw"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2132
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2167
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4643
+#: sonar/common/jsonschemas/language-v1.0.0.json:2129
 msgid "lang_suk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2136
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2171
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4647
+#: sonar/common/jsonschemas/language-v1.0.0.json:2133
 msgid "lang_sun"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2140
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2175
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4651
+#: sonar/common/jsonschemas/language-v1.0.0.json:2137
 msgid "lang_sus"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2144
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2179
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4655
+#: sonar/common/jsonschemas/language-v1.0.0.json:2141
 msgid "lang_sux"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2148
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2183
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4659
+#: sonar/common/jsonschemas/language-v1.0.0.json:2145
 msgid "lang_swa"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2152
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2187
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4663
+#: sonar/common/jsonschemas/language-v1.0.0.json:2149
 msgid "lang_swe"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2156
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2191
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4667
+#: sonar/common/jsonschemas/language-v1.0.0.json:2153
 msgid "lang_syc"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2160
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2195
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4671
+#: sonar/common/jsonschemas/language-v1.0.0.json:2157
 msgid "lang_syr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2164
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2199
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4675
+#: sonar/common/jsonschemas/language-v1.0.0.json:2161
 msgid "lang_tah"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2168
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2203
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4679
+#: sonar/common/jsonschemas/language-v1.0.0.json:2165
 msgid "lang_tai"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2172
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2207
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4683
+#: sonar/common/jsonschemas/language-v1.0.0.json:2169
 msgid "lang_tam"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2176
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2211
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4687
+#: sonar/common/jsonschemas/language-v1.0.0.json:2173
 msgid "lang_tat"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2180
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2215
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4691
+#: sonar/common/jsonschemas/language-v1.0.0.json:2177
 msgid "lang_tel"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2184
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2219
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4695
+#: sonar/common/jsonschemas/language-v1.0.0.json:2181
 msgid "lang_tem"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2188
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2223
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4699
+#: sonar/common/jsonschemas/language-v1.0.0.json:2185
 msgid "lang_ter"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2192
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2227
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4703
+#: sonar/common/jsonschemas/language-v1.0.0.json:2189
 msgid "lang_tet"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2196
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2231
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4707
+#: sonar/common/jsonschemas/language-v1.0.0.json:2193
 msgid "lang_tgk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2200
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2235
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4711
+#: sonar/common/jsonschemas/language-v1.0.0.json:2197
 msgid "lang_tgl"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2204
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2239
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4715
+#: sonar/common/jsonschemas/language-v1.0.0.json:2201
 msgid "lang_tha"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2208
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2243
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4719
+#: sonar/common/jsonschemas/language-v1.0.0.json:2205
 msgid "lang_tib"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2212
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2247
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4723
+#: sonar/common/jsonschemas/language-v1.0.0.json:2209
 msgid "lang_tig"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2216
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2251
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4727
+#: sonar/common/jsonschemas/language-v1.0.0.json:2213
 msgid "lang_tir"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2220
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2255
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4731
+#: sonar/common/jsonschemas/language-v1.0.0.json:2217
 msgid "lang_tiv"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2224
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2259
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4735
+#: sonar/common/jsonschemas/language-v1.0.0.json:2221
 msgid "lang_tkl"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2228
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2263
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4739
+#: sonar/common/jsonschemas/language-v1.0.0.json:2225
 msgid "lang_tlh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2232
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2267
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4743
+#: sonar/common/jsonschemas/language-v1.0.0.json:2229
 msgid "lang_tli"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2236
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2271
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4747
+#: sonar/common/jsonschemas/language-v1.0.0.json:2233
 msgid "lang_tmh"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2240
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2275
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4751
+#: sonar/common/jsonschemas/language-v1.0.0.json:2237
 msgid "lang_tog"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2244
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2279
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4755
+#: sonar/common/jsonschemas/language-v1.0.0.json:2241
 msgid "lang_ton"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2248
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2283
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4759
+#: sonar/common/jsonschemas/language-v1.0.0.json:2245
 msgid "lang_tpi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2252
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2287
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4763
+#: sonar/common/jsonschemas/language-v1.0.0.json:2249
 msgid "lang_tsi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2256
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2291
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4767
+#: sonar/common/jsonschemas/language-v1.0.0.json:2253
 msgid "lang_tsn"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2260
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2295
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4771
+#: sonar/common/jsonschemas/language-v1.0.0.json:2257
 msgid "lang_tso"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2264
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2299
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4775
+#: sonar/common/jsonschemas/language-v1.0.0.json:2261
 msgid "lang_tuk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2268
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2303
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4779
+#: sonar/common/jsonschemas/language-v1.0.0.json:2265
 msgid "lang_tum"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2272
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2307
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4783
+#: sonar/common/jsonschemas/language-v1.0.0.json:2269
 msgid "lang_tup"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2276
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2311
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4787
+#: sonar/common/jsonschemas/language-v1.0.0.json:2273
 msgid "lang_tur"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2280
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2315
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4791
+#: sonar/common/jsonschemas/language-v1.0.0.json:2277
 msgid "lang_tut"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2284
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2319
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4795
+#: sonar/common/jsonschemas/language-v1.0.0.json:2281
 msgid "lang_tvl"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2288
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2323
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4799
+#: sonar/common/jsonschemas/language-v1.0.0.json:2285
 msgid "lang_twi"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2292
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2327
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4803
+#: sonar/common/jsonschemas/language-v1.0.0.json:2289
 msgid "lang_tyv"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2296
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2331
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4807
+#: sonar/common/jsonschemas/language-v1.0.0.json:2293
 msgid "lang_udm"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2300
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2335
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4811
+#: sonar/common/jsonschemas/language-v1.0.0.json:2297
 msgid "lang_uga"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2304
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2339
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4815
+#: sonar/common/jsonschemas/language-v1.0.0.json:2301
 msgid "lang_uig"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2308
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2343
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4819
+#: sonar/common/jsonschemas/language-v1.0.0.json:2305
 msgid "lang_ukr"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2312
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2347
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4823
+#: sonar/common/jsonschemas/language-v1.0.0.json:2309
 msgid "lang_umb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2316
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2351
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4827
+#: sonar/common/jsonschemas/language-v1.0.0.json:2313
 msgid "lang_und"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2320
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2355
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4831
+#: sonar/common/jsonschemas/language-v1.0.0.json:2317
 msgid "lang_urd"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2324
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2359
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4835
+#: sonar/common/jsonschemas/language-v1.0.0.json:2321
 msgid "lang_uzb"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2328
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2363
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4839
+#: sonar/common/jsonschemas/language-v1.0.0.json:2325
 msgid "lang_vai"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2332
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2367
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4843
+#: sonar/common/jsonschemas/language-v1.0.0.json:2329
 msgid "lang_ven"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2336
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2371
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4847
+#: sonar/common/jsonschemas/language-v1.0.0.json:2333
 msgid "lang_vie"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2340
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2375
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4851
+#: sonar/common/jsonschemas/language-v1.0.0.json:2337
 msgid "lang_vol"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2344
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2379
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4855
+#: sonar/common/jsonschemas/language-v1.0.0.json:2341
 msgid "lang_vot"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2348
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2383
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4859
+#: sonar/common/jsonschemas/language-v1.0.0.json:2345
 msgid "lang_wak"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2352
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2387
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4863
+#: sonar/common/jsonschemas/language-v1.0.0.json:2349
 msgid "lang_wal"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2356
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2391
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4867
+#: sonar/common/jsonschemas/language-v1.0.0.json:2353
 msgid "lang_war"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2360
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2395
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4871
+#: sonar/common/jsonschemas/language-v1.0.0.json:2357
 msgid "lang_was"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2364
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2399
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4875
+#: sonar/common/jsonschemas/language-v1.0.0.json:2361
 msgid "lang_wel"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2368
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2403
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4879
+#: sonar/common/jsonschemas/language-v1.0.0.json:2365
 msgid "lang_wen"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2372
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2407
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4883
+#: sonar/common/jsonschemas/language-v1.0.0.json:2369
 msgid "lang_wln"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2376
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2411
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4887
+#: sonar/common/jsonschemas/language-v1.0.0.json:2373
 msgid "lang_wol"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2380
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2415
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4891
+#: sonar/common/jsonschemas/language-v1.0.0.json:2377
 msgid "lang_xal"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2384
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2419
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4895
+#: sonar/common/jsonschemas/language-v1.0.0.json:2381
 msgid "lang_xho"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2388
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2423
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4899
+#: sonar/common/jsonschemas/language-v1.0.0.json:2385
 msgid "lang_yao"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2392
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2427
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4903
+#: sonar/common/jsonschemas/language-v1.0.0.json:2389
 msgid "lang_yap"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2396
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2431
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4907
+#: sonar/common/jsonschemas/language-v1.0.0.json:2393
 msgid "lang_yid"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2400
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2435
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4911
+#: sonar/common/jsonschemas/language-v1.0.0.json:2397
 msgid "lang_yor"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2404
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2439
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4915
+#: sonar/common/jsonschemas/language-v1.0.0.json:2401
 msgid "lang_ypk"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2408
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2443
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4919
+#: sonar/common/jsonschemas/language-v1.0.0.json:2405
 msgid "lang_zap"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2412
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2447
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4923
+#: sonar/common/jsonschemas/language-v1.0.0.json:2409
 msgid "lang_zbl"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2416
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2451
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4927
+#: sonar/common/jsonschemas/language-v1.0.0.json:2413
 msgid "lang_zen"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2420
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2455
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4931
+#: sonar/common/jsonschemas/language-v1.0.0.json:2417
 msgid "lang_zha"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2424
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2459
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4935
+#: sonar/common/jsonschemas/language-v1.0.0.json:2421
 msgid "lang_znd"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2428
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2463
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4939
+#: sonar/common/jsonschemas/language-v1.0.0.json:2425
 msgid "lang_zul"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2432
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2467
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4943
+#: sonar/common/jsonschemas/language-v1.0.0.json:2429
 msgid "lang_zun"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2436
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2471
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4947
+#: sonar/common/jsonschemas/language-v1.0.0.json:2433
 msgid "lang_zxx"
 msgstr ""
 
-#: sonar/common/jsonschemas/language-v1.0.0.json:2440
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:2475
-#: sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json:4951
+#: sonar/common/jsonschemas/language-v1.0.0.json:2437
 msgid "lang_zza"
 msgstr ""
 
@@ -5702,12 +4807,11 @@ msgstr ""
 msgid "mainTeam"
 msgstr ""
 
-#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:923
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1743
+#: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:1034
 msgid "name"
 msgstr ""
 
-#: sonar/modules/documents/views.py:172
+#: sonar/modules/documents/views.py:178
 msgid "no."
 msgstr ""
 
@@ -5715,11 +4819,11 @@ msgstr ""
 msgid "other files"
 msgstr ""
 
-#: sonar/modules/documents/views.py:176
+#: sonar/modules/documents/views.py:182
 msgid "p."
 msgstr ""
 
-#: sonar/config.py:546
+#: sonar/config.py:570
 msgid "pid"
 msgstr ""
 
@@ -5783,7 +4887,7 @@ msgstr ""
 msgid "startDate"
 msgstr ""
 
-#: sonar/config.py:547
+#: sonar/config.py:571
 msgid "status"
 msgstr ""
 
@@ -5797,15 +4901,55 @@ msgstr ""
 
 #: sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json:489
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:808
-#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1615
+#: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1627
 msgid "uri"
 msgstr ""
 
-#: sonar/config.py:548
+#: sonar/config.py:572
 msgid "user"
 msgstr ""
 
-#: sonar/modules/documents/views.py:168
+#: sonar/translations/manual_translations.txt:59
+msgid "validation_action_approve"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:61
+msgid "validation_action_ask_for_changes"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:58
+msgid "validation_action_publish"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:60
+msgid "validation_action_reject"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:57
+msgid "validation_action_save"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:54
+msgid "validation_status_ask_for_changes"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:50
+msgid "validation_status_in_progress"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:53
+msgid "validation_status_rejected"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:51
+msgid "validation_status_to_validate"
+msgstr ""
+
+#: sonar/translations/manual_translations.txt:52
+msgid "validation_status_validated"
+msgstr ""
+
+#: sonar/modules/documents/views.py:174
 msgid "vol."
 msgstr ""
 
@@ -5925,5 +5069,20 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "\\u200bSwiss National Science Foundation"
+#~ msgstr ""
+
+#~ msgid "Editors"
+#~ msgstr ""
+
+#~ msgid "In the format \\"
+#~ msgstr "I formatet \\"
+
+#~ msgid "Not OA / Rights reserved"
+#~ msgstr ""
+
+#~ msgid "Other OA / license undefined"
+#~ msgstr ""
+
+#~ msgid "Specific collections"
 #~ msgstr ""
 


### PR DESCRIPTION
German translated at 88.1% (979 of 1111 strings)
French translated at 86.8% (965 of 1111 strings)
English translated at 86.8% (965 of 1111 strings)
Italian translated at 86.6% (963 of 1111 strings)
Esperanto translated at 46.5% (517 of 1111 strings)
Norwegian Bokmål translated at 9.6% (107 of 1111 strings)

Co-authored-by: Nicolas Prongué <n.prongue@outlook.com>
Co-authored-by: iGor milhit <igor.milhit@rero.ch>
Translate-URL: https://hosted.weblate.org/projects/rero_plus/sonar/
Translation: RERO+/sonar