### PR TITLE
homepage: custom description for organisations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,8 @@ setup(
             'pdf_extractor = \
                 sonar.modules.pdf_extractor.views.client:blueprint',
             'validation = sonar.modules.validation.views:blueprint',
-            'collections = sonar.modules.collections.views:blueprint'
+            'collections = sonar.modules.collections.views:blueprint',
+            'dedicated = sonar.dedicated.views:blueprint'
         ],
         'invenio_base.api_blueprints': [
             'pdf_extractor = sonar.modules.pdf_extractor.views.api:blueprint',

--- a/sonar/config_sonar.py
+++ b/sonar/config_sonar.py
@@ -74,6 +74,7 @@ SONAR_APP_HEG_DATA_DIRECTORY = './data/heg'
 
 SONAR_APP_ORGANISATION_CONFIG = {
     'hepvs': {
+        'home_template': 'dedicated/hepvs/home.html',
         'projects': True
     }
 }

--- a/sonar/dedicated/templates/dedicated/hepvs/home.html
+++ b/sonar/dedicated/templates/dedicated/hepvs/home.html
@@ -1,0 +1,19 @@
+<p>FREDI est l'acronyme de "Forschung – Recherche – Entwicklung – Développement – Innova(z)tion" la nouvelle
+  plateforme de dépôt des productions scientifiques et professionnelles en Open Access ainsi que des projets de
+  recherche de la Haute école pédagogique du Valais. De plus, selon la logique d'amélioration continue, la plateforme
+  FREDI permet de centraliser l'intégralité des données des projets de recherche à des fins d'optimisation du système
+  d'assurance qualité pour le domaine Recherche & Développement.</p>
+<p class="m-0"><a href="#" class="toggle-display" data-target="long-description">En savoir plus&hellip;</a></p>
+<p id="long-description" class="d-none mt-4">
+  Les résultats des travaux de recherche au sein d'équipes interdisciplinaires sont partagés avec l'ensemble du système
+  scolaire valaisan, de la communauté scientifique et professionnelle nationale et internationale. La HEP-VS joue un
+  rôle prépondérant dans la production des connaissances. Pour ce faire, elle met en place un outil pour les
+  utilisateurs et utilisatrices afin de rendre visible la production de savoirs théoriques et pratiques de l'institution
+  et les projets de recherche. La base de données de la plateforme FREDI regroupe l'ensemble des productions
+  scientifiques et professionnelles réalisées par les différentes équipes de recherche de l'institution. Dans la
+  perspective stratégique de la circularité des savoirs, la mise à disposition de ses publications et projets de
+  recherche est utile pour la communauté scientifique, mais aussi pour l'ensemble des acteurs et actrices du terrain. Ce
+  rôle et cet engagement de notre institution est une volonté de diffuser à l'échelle nationale et internationale la
+  littérature scientifique produite en son sein avec un accès public ou sous embargo afin que toutes personnes
+  intéressées par ces recherches puissent y accéder.
+</p>

--- a/sonar/dedicated/views.py
+++ b/sonar/dedicated/views.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Dedicated organisations views."""
+
+from flask import Blueprint
+
+blueprint = Blueprint('dedicated', __name__, template_folder='templates')

--- a/sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json
+++ b/sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json
@@ -70,7 +70,8 @@
         "type": "textarea",
         "templateOptions": {
           "rows": 10
-        }
+        },
+        "hideExpression": "!field.model.isShared"
       }
     },
     "platformName": {
@@ -78,6 +79,10 @@
       "type": "string",
       "minLength": 1,
       "form": {
+        "type": "markdown",
+        "templateOptions": {
+          "rows": 5
+        },
         "hideExpression": "!field.model.isDedicated"
       }
     },
@@ -89,7 +94,7 @@
         "label": {
           "title": "Labels",
           "type": "array",
-          "minItems": 1,
+          "default": [],
           "items": {
             "title": "Label",
             "type": "object",
@@ -136,7 +141,7 @@
         "label": {
           "title": "Labels",
           "type": "array",
-          "minItems": 1,
+          "default": [],
           "items": {
             "title": "Label",
             "type": "object",
@@ -183,7 +188,7 @@
         "label": {
           "title": "Labels",
           "type": "array",
-          "minItems": 1,
+          "default": [],
           "items": {
             "title": "Label",
             "type": "object",
@@ -289,8 +294,8 @@
     "description",
     "isShared",
     "isDedicated",
-    "platformName",
     "allowedIps",
+    "platformName",
     "documentsCustomField1",
     "documentsCustomField2",
     "documentsCustomField3"

--- a/sonar/theme/templates/sonar/frontpage.html
+++ b/sonar/theme/templates/sonar/frontpage.html
@@ -41,11 +41,15 @@ along with this program. If not, see
             class="img-fluid" alt="{{ 'SONAR logo' }}">
           {% endif %}
         </a>
-        {% if g.get('organisation', {}).get('isDedicated') and g.get('organisation', {}).get('platformName') %}
-        <h1 class="mt-4 mb-0">{{ g.organisation['platformName'] }}</h1>
-        {% endif%}
       </div>
     </div>
+    {% if g.get('organisation', {}).get('isDedicated') and g.get('organisation', {}).get('platformName') %}
+    <div class="row justify-content-center">
+      <div class="col text-center">
+        <div class="mt-4 mb-0">{{ g.organisation['platformName'] | markdown_filter | safe }}</div>
+      </div>
+    </div>
+    {% endif%}
     <div class="row justify-content-center">
       <div class="col-lg-8 text-right my-4">
         <form class="justify-content-end"
@@ -80,11 +84,15 @@ along with this program. If not, see
 {%- block body %}
 <div class="row justify-content-between">
   {% if g.get('organisation', {}).get('isDedicated') %}
+  <div class="col-12">
+    {% if config.get('SONAR_APP_ORGANISATION_CONFIG', {}).get(g.organisation.pid, {}).get('home_template') %}
+    {% include config['SONAR_APP_ORGANISATION_CONFIG'][g.organisation.pid]['home_template'] %}
+    {% else %}
     {% if g.organisation.get('description') %}
-    <div class="col-12">
-      {{ g.organisation.description | markdown_filter | safe }}
-    </div>
+    {{ g.organisation.description | markdown_filter | safe }}
     {% endif %}
+    {% endif %}
+  </div>
   {% else %}
   <div class="col-lg-7">
     <h5 class="home-text">

--- a/sonar/theme/templates/sonar/page.html
+++ b/sonar/theme/templates/sonar/page.html
@@ -144,8 +144,29 @@ along with this program. If not, see
   {%- block javascript %}
   <script>
     document.addEventListener("DOMContentLoaded", function () {
+      // Toggle display
+      const toggleDisplay = document.getElementsByClassName('toggle-display');
+      Array.prototype.forEach.call(toggleDisplay, function (el, i) {
+        el.addEventListener('click', function (event) {
+          const targetElement = document.getElementById(el.dataset.target);
+          if (targetElement) {
+            if (targetElement.className.search('d-none') !== -1) {
+              targetElement.classList.remove('d-none')
+            } else {
+              targetElement.classList.add('d-none')
+            }
+          }
+          event.preventDefault();
+        });
+      });
+
       document.addEventListener('click', function (event) {
         let link = event.target;
+
+        // Don't do anything if .toggle-display, the process is just above.
+        if (link.matches('.toggle-display')) {
+          return;
+        }
 
         const dropdowns = document.getElementsByClassName('dropdown-menu show');
 


### PR DESCRIPTION
* Adds the possibility to define a custom template for the homepage of a dedicated organisation.
* Creates a blueprint for dedicated templates.
* Configures homepage template for HEPVS.
* Hides `allowedIps` in editor if the organisation is not shared.
* Hides label for custom fields by default.
* Moves field `platformName` after `allowedIps`.
* Closes #583.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>