### PR TITLE
documents: fix license for RERO DOC publications

### DIFF
--- a/sonar/modules/documents/dojson/rerodoc/model.py
+++ b/sonar/modules/documents/dojson/rerodoc/model.py
@@ -725,7 +725,7 @@ def marc21_to_usage_and_access_policy(self, key, value):
     if not value.get('a'):
         return None
 
-    return {'label': value.get('a'), 'license': 'Other OA / license undefined'}
+    return {'label': value.get('a'), 'license': 'License undefined'}
 
 
 @overdo.over('contribution', '^100..')

--- a/sonar/modules/documents/dojson/rerodoc/overdo.py
+++ b/sonar/modules/documents/dojson/rerodoc/overdo.py
@@ -94,9 +94,7 @@ class Overdo(BaseOverdo):
 
         # Add default license if not set.
         if not result.get('usageAndAccessPolicy'):
-            result['usageAndAccessPolicy'] = {
-                'license': 'Other OA / license undefined'
-            }
+            result['usageAndAccessPolicy'] = {'license': 'License undefined'}
 
         return result
 

--- a/tests/ui/documents/dojson/rerodoc/test_rerodoc_model.py
+++ b/tests/ui/documents/dojson/rerodoc/test_rerodoc_model.py
@@ -1927,7 +1927,7 @@ def test_marc21_to_usage_and_access_policy():
     data = overdo.do(marc21json)
     assert data.get('usageAndAccessPolicy') == {
         'label': 'Springer-Verlag Berlin',
-        'license': 'Other OA / license undefined'
+        'license': 'License undefined'
     }
 
     # Multiple
@@ -1945,7 +1945,7 @@ def test_marc21_to_usage_and_access_policy():
     data = overdo.do(marc21json)
     assert data.get('usageAndAccessPolicy') == {
         'label': 'Usage 2',
-        'license': 'Other OA / license undefined'
+        'license': 'License undefined'
     }
 
     # Without $a
@@ -1957,7 +1957,7 @@ def test_marc21_to_usage_and_access_policy():
     marc21json = create_record(marc21xml)
     data = overdo.do(marc21json)
     assert data.get('usageAndAccessPolicy') == {
-        'license': 'Other OA / license undefined'
+        'license': 'License undefined'
     }
 
     # Without 540
@@ -1967,7 +1967,7 @@ def test_marc21_to_usage_and_access_policy():
     marc21json = create_record(marc21xml)
     data = overdo.do(marc21json)
     assert data.get('usageAndAccessPolicy') == {
-        'license': 'Other OA / license undefined'
+        'license': 'License undefined'
     }
 
 

--- a/tests/ui/documents/test_dc_schema.py
+++ b/tests/ui/documents/test_dc_schema.py
@@ -318,11 +318,11 @@ def test_rights(app, minimal_document):
     assert result['rights'] == ['CC BY-NC-SA']
 
     minimal_document['usageAndAccessPolicy'] = {
-        'license': 'Other OA / license undefined',
+        'license': 'License undefined',
         'label': 'Custom license'
     }
     result = dc_v1.transform_record(minimal_document['pid'], minimal_document)
-    assert result['rights'] == ['Other OA / license undefined, Custom license']
+    assert result['rights'] == ['License undefined, Custom license']
 
     minimal_document.pop('usageAndAccessPolicy', None)
     with app.test_request_context() as req:

--- a/tests/unit/documents/loaders/test_rerodoc_loader.py
+++ b/tests/unit/documents/loaders/test_rerodoc_loader.py
@@ -142,7 +142,7 @@ def test_rerodoc_loader(app, organisation):
             'label':
             '© 2015 The Authors Published by Oxford University Press on '
             'behalf of the Royal Astronomical Society',
-            'license': 'Other OA / license undefined'
+            'license': 'License undefined'
         },
         'abstracts': [{
             'value':

--- a/tests/unit/documents/serializers/test_schemaorg_schema.py
+++ b/tests/unit/documents/serializers/test_schemaorg_schema.py
@@ -301,12 +301,12 @@ def test_license(app, minimal_document):
     assert result['license'] == 'CC BY-NC-SA'
 
     minimal_document['usageAndAccessPolicy'] = {
-        'license': 'Other OA / license undefined',
+        'license': 'License undefined',
         'label': 'Custom license'
     }
     result = schemaorg_v1.transform_record(minimal_document['pid'],
                                            minimal_document)
-    assert result['license'] == 'Other OA / license undefined, Custom license'
+    assert result['license'] == 'License undefined, Custom license'
 
 
 def test_image(app, minimal_document):


### PR DESCRIPTION
Fixes the license value for documents imported from RERO DOC, as the name has changed.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>