### PR TITLE
documents: fix projects typehead

### DIFF
--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -1757,6 +1757,7 @@
             "form": {
               "remoteTypeahead": {
                 "type": "projects",
+                "label": "name",
                 "field": "metadata.name.suggest"
               }
             }


### PR DESCRIPTION
* Fixes projects typehead in document editor by adding the label field to display in JSON schema.
* Closes #593.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>