### PR TITLE
documents: subjects search

### DIFF
--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -146,7 +146,7 @@ along with this program. If not, see
         {% for subject in record.subjects %}
         {% for value in subject.label.value %}
         <h5 class="d-inline">
-          <a href="{{ url_for('documents.search', view=view_code, q=value) }}">
+          <a href="{{ url_for('documents.search', view=view_code, q='subjects.label.value:' + value) }}">
             <span class="badge badge-secondary text-light font-weight-light">
               <i class="fa fa-tag mx-1"></i> {{ value }}
             </span></a>


### PR DESCRIPTION
* Searches on `subjects` field instead of all fields when clicking on a subject.
* Closes #367.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>