### PR TITLE
documents: add `masked` property

### DIFF
--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -1836,6 +1836,17 @@
       "form": {
         "hide": true
       }
+    },
+    "masked": {
+      "title": "Masked",
+      "type": "boolean",
+      "description": "A masked document is visible in the professional interface, but not in the public interface.",
+      "default": false,
+      "form": {
+        "expressionProperties": {
+          "templateOptions.required": "true"
+        }
+      }
     }
   },
   "propertiesOrder": [
@@ -1866,7 +1877,8 @@
     "oa_status",
     "customField1",
     "customField2",
-    "customField3"
+    "customField3",
+    "masked"
   ],
   "required": [
     "$schema",

--- a/sonar/modules/documents/mappings/v7/documents/document-v1.0.0.json
+++ b/sonar/modules/documents/mappings/v7/documents/document-v1.0.0.json
@@ -582,6 +582,9 @@
           }
         }
       },
+      "masked": {
+        "type": "boolean"
+      },
       "_created": {
         "type": "date"
       },

--- a/sonar/modules/documents/marshmallow/json.py
+++ b/sonar/modules/documents/marshmallow/json.py
@@ -105,6 +105,7 @@ class DocumentMetadataSchemaV1(StrictKeysMixin):
     customField1 = fields.List(fields.String(validate=validate.Length(min=1)))
     customField2 = fields.List(fields.String(validate=validate.Length(min=1)))
     customField3 = fields.List(fields.String(validate=validate.Length(min=1)))
+    masked = fields.Boolean()
     _bucket = SanitizedUnicode()
     _files = Nested(FileSchemaV1, many=True)
     _oai = fields.Dict()

--- a/sonar/modules/documents/query.py
+++ b/sonar/modules/documents/query.py
@@ -81,6 +81,9 @@ def search_factory(self, search, query_parser=None):
 
     # Public search
     if view:
+        # Don't display masked records
+        search = search.filter('bool', must_not={'term': {'masked': True}})
+
         # Filter record by organisation view.
         if view != current_app.config.get('SONAR_APP_DEFAULT_ORGANISATION'):
             search = search.filter('term', organisation__pid=view)


### PR DESCRIPTION
* Adds `marked` property to documents and hides masked documents on the public interface.
* Closes #570.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>