### PR TITLE
subdivisions: create resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0.json
 sonar/modules/documents/jsonschemas/documents/document-v1.0.0.json
 sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0.json
 sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json
+sonar/modules/subdivisions/jsonschemas/subdivisions/subdivision-v1.0.0.json
 sonar/resources/projects/jsonschemas/projects/project-v1.0.0.json
 sonar/dedicated/*/*/jsonschemas/*/*/*-v1.0.0.json
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,6 +17,7 @@ exclude sonar/modules/documents/jsonschemas/documents/document-v1.0.0.json
 exclude sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0.json
 exclude sonar/modules/projects/jsonschemas/projects/project-v1.0.0.json
 exclude sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json
+exclude sonar/modules/subdivisions/jsonschemas/subdivisions/subdivision-v1.0.0.json
 
 include *.html
 include *.inv

--- a/babel.ini
+++ b/babel.ini
@@ -37,5 +37,6 @@ extract_messages = $._, jQuery._
 [ignore: **/**/deposit-v1.0.0.json]
 [ignore: **/**/project-v1.0.0.json]
 [ignore: **/**/collection-v1.0.0.json]
+[ignore: **/**/subdivision-v1.0.0.json]
 [json: **.json]
 keys_to_translate = ['^title$', '^label$', '^description$', '^placeholder$', '^.*Message$']

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -92,6 +92,7 @@ invenio utils compile-json ./sonar/modules/organisations/jsonschemas/organisatio
 invenio utils compile-json ./sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json -o ./sonar/modules/documents/jsonschemas/documents/document-v1.0.0.json
 invenio utils compile-json ./sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json -o ./sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0.json
 invenio utils compile-json ./sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json -o ./sonar/modules/collections/jsonschemas/collections/collection-v1.0.0.json
+invenio utils compile-json ./sonar/modules/subdivisions/jsonschemas/subdivisions/subdivision-v1.0.0_src.json -o ./sonar/modules/subdivisions/jsonschemas/subdivisions/subdivision-v1.0.0.json
 invenio utils compile-json ./sonar/resources/projects/jsonschemas/projects/project-v1.0.0_src.json -o ./sonar/resources/projects/jsonschemas/projects/project-v1.0.0.json
 invenio utils compile-json ./sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0_src.json -o ./sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0.json
 

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,7 @@ setup(
             'projects = sonar.resources.projects.jsonschemas',
             'projects_hepvs = sonar.dedicated.hepvs.projects.jsonschemas',
             'collections = sonar.modules.collections.jsonschemas',
+            'subdivisions = sonar.modules.subdivisions.jsonschemas',
             'common = sonar.common.jsonschemas'
         ],
         'invenio_search.mappings': [
@@ -122,7 +123,8 @@ setup(
             'users = sonar.modules.users.mappings',
             'deposits = sonar.modules.deposits.mappings',
             'projects = sonar.resources.projects.mappings',
-            'collections = sonar.modules.collections.mappings'
+            'collections = sonar.modules.collections.mappings',
+            'subdivisions = sonar.modules.subdivisions.mappings'
         ],
         'invenio_search.templates': [
             'base-record = sonar.es_templates:list_es_templates'
@@ -137,7 +139,9 @@ setup(
             'deposit_id = \
                 sonar.modules.deposits.api:deposit_pid_minter',
             'collections_id = \
-                sonar.modules.collections.api:pid_minter'
+                sonar.modules.collections.api:pid_minter',
+            'subdivisions_id = \
+                sonar.modules.subdivisions.api:pid_minter'
         ],
         'invenio_pidstore.fetchers': [
             'document_id = \
@@ -149,14 +153,17 @@ setup(
             'deposit_id = \
                 sonar.modules.deposits.api:deposit_pid_fetcher',
             'collections_id = \
-                sonar.modules.collections.api:pid_fetcher'
+                sonar.modules.collections.api:pid_fetcher',
+            'subdivisions_id = \
+                sonar.modules.subdivisions.api:pid_fetcher',
         ],
         "invenio_records.jsonresolver": [
             "organisation = sonar.modules.organisations.jsonresolvers",
             "user = sonar.modules.users.jsonresolvers",
             "document = sonar.modules.documents.jsonresolvers",
             "project = sonar.resources.projects.jsonresolvers",
-            "collections = sonar.modules.collections.jsonresolvers"
+            "collections = sonar.modules.collections.jsonresolvers",
+            "subdivisions = sonar.modules.subdivisions.jsonresolvers"
         ],
         'invenio_celery.tasks' : [
             'documents = sonar.modules.documents.tasks'

--- a/sonar/config.py
+++ b/sonar/config.py
@@ -44,6 +44,8 @@ from sonar.modules.organisations.permissions import OrganisationPermission
 from sonar.modules.permissions import record_permission_factory, \
     wiki_edit_permission
 from sonar.modules.query import and_term_filter, missing_field_filter
+from sonar.modules.subdivisions.config import \
+    Configuration as SubdivisionConfiguration
 from sonar.modules.users.api import UserRecord, UserSearch
 from sonar.modules.users.permissions import UserPermission
 from sonar.modules.utils import get_current_language
@@ -494,6 +496,9 @@ RECORDS_REST_ENDPOINTS = {
 
 # Add endpoint for collections
 RECORDS_REST_ENDPOINTS['coll'] = CollectionConfiguration.rest_endpoint
+
+# Add endpoint for subdivisions
+RECORDS_REST_ENDPOINTS['subd'] = SubdivisionConfiguration.rest_endpoint
 """REST endpoints."""
 
 DEFAULT_AGGREGATION_SIZE = 50
@@ -502,8 +507,8 @@ DEFAULT_AGGREGATION_SIZE = 50
 RECORDS_REST_FACETS = {
     'documents':
     dict(aggs=dict(
-        sections=dict(terms=dict(field='sections',
-                                     size=DEFAULT_AGGREGATION_SIZE)),
+        subdivision=dict(terms=dict(field='subdivisions.pid',
+                                    size=DEFAULT_AGGREGATION_SIZE)),
         organisation=dict(terms=dict(field='organisation.pid',
                                      size=DEFAULT_AGGREGATION_SIZE)),
         language=dict(
@@ -511,7 +516,7 @@ RECORDS_REST_FACETS = {
         subject=dict(
             terms=dict(field='facet_subjects', size=DEFAULT_AGGREGATION_SIZE)),
         collection=dict(terms=dict(field='collections.pid',
-                                            size=DEFAULT_AGGREGATION_SIZE)),
+                                   size=DEFAULT_AGGREGATION_SIZE)),
         document_type=dict(
             terms=dict(field='documentType', size=DEFAULT_AGGREGATION_SIZE)),
         controlled_affiliation=dict(
@@ -531,8 +536,8 @@ RECORDS_REST_FACETS = {
         customField3=dict(terms=dict(field='customField3.raw',
                                      size=DEFAULT_AGGREGATION_SIZE))),
          filters={
-             'sections':
-             and_term_filter('sections'),
+             'subdivision':
+             and_term_filter('subdivisions.pid'),
              'organisation':
              and_term_filter('organisation.pid'),
              'language':
@@ -562,11 +567,14 @@ RECORDS_REST_FACETS = {
          }),
     'deposits':
     dict(aggs=dict(
+        subdivision=dict(terms=dict(field='diffusion.subdivisions.pid',
+                                    size=DEFAULT_AGGREGATION_SIZE)),
         status=dict(terms=dict(field='status', size=DEFAULT_AGGREGATION_SIZE)),
         user=dict(terms=dict(field='user.pid', size=DEFAULT_AGGREGATION_SIZE)),
         contributor=dict(terms=dict(field='facet_contributors',
                                     size=DEFAULT_AGGREGATION_SIZE))),
          filters={
+             'subdivision': and_term_filter('diffusion.subdivisions.pid'),
              _('pid'): and_term_filter('pid'),
              _('status'): and_term_filter('status'),
              _('user'): and_term_filter('user.pid'),
@@ -584,10 +592,17 @@ RECORDS_REST_FACETS = {
                         }
                     }
                 }
+            },
+            'subdivision': {
+                'terms': {
+                    'field': 'subdivision.pid',
+                    'size': DEFAULT_AGGREGATION_SIZE
+                }
             }
         },
         'filters': {
-            'missing_organisation': missing_field_filter('organisation')
+            'missing_organisation': missing_field_filter('organisation'),
+            'subdivision': and_term_filter('subdivision.pid')
         }
     }
 }

--- a/sonar/json_schemas/deposits_json_schema.py
+++ b/sonar/json_schemas/deposits_json_schema.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Deposits JSON schema class."""
+
+from sonar.modules.users.api import current_user_record
+
+from .json_schema_base import JSONSchemaBase
+
+
+class DepositsJSONSchema(JSONSchemaBase):
+    """JSON schema for deposits."""
+
+    def process(self):
+        """Document JSON schema custom process.
+
+        :returns: The processed schema.
+        """
+        schema = super().process()
+
+        if current_user_record.is_moderator:
+            return schema
+
+        schema['properties']['diffusion']['properties'].pop(
+            'subdivisions', None)
+
+        return schema

--- a/sonar/json_schemas/factory.py
+++ b/sonar/json_schemas/factory.py
@@ -17,6 +17,7 @@
 
 """Factory for JSON schema."""
 
+from .deposits_json_schema import DepositsJSONSchema
 from .documents_json_schema import DocumentsJSONSchema
 from .json_schema_base import JSONSchemaBase
 
@@ -24,7 +25,10 @@ from .json_schema_base import JSONSchemaBase
 class JSONSchemaFactory():
     """Factory for JSON schema."""
 
-    SCHEMAS = {'documents': DocumentsJSONSchema}
+    SCHEMAS = {
+        'documents': DocumentsJSONSchema,
+        'deposits': DepositsJSONSchema
+    }
 
     @staticmethod
     def create(resource_type):

--- a/sonar/modules/api.py
+++ b/sonar/modules/api.py
@@ -109,9 +109,8 @@ class SonarRecord(Record, FilesMixin):
         :param pid_type: PID type.
         :returns: Record class.
         """
-        return current_app.config.get(
-                'RECORDS_REST_ENDPOINTS',
-                {}).get(pid_type, {}).get('record_class')
+        return current_app.config.get('RECORDS_REST_ENDPOINTS',
+                                      {}).get(pid_type, {}).get('record_class')
 
     @classmethod
     def get_all_pids(cls, with_deleted=False):
@@ -121,8 +120,7 @@ class SonarRecord(Record, FilesMixin):
         :returns: A generator iterator.
         """
         query = PersistentIdentifier.query.filter_by(
-            pid_type=cls.provider.pid_type
-        )
+            pid_type=cls.provider.pid_type)
         if not with_deleted:
             query = query.filter_by(status=PIDStatus.REGISTERED)
 
@@ -312,6 +310,41 @@ class SonarRecord(Record, FilesMixin):
             indexer().delete(self)
 
         return self
+
+    def has_organisation(self, organisation_pid):
+        """Check if record belongs to the organisation.
+
+        :param str organisation_pid: Organisation PID
+        :returns: True if record has organisation
+        :rtype: Bool
+        """
+        for org in self.get('organisation', []):
+            if organisation_pid == org['pid']:
+                return True
+
+        return False
+
+    def has_subdivision(self, subdivision_pid):
+        """Check if record belongs to the subdivision.
+
+        :param str subdivision_pid: Subdivision PID
+        :returns: True if record has subdivision
+        :rtype: Bool
+        """
+        # No subdivision passed, means no check to do.
+        if not subdivision_pid:
+            return True
+
+        # No subdivision in record, the document is accessible.
+        if not self.get('subdivisions'):
+            return False
+
+        for subdivision in self['subdivisions']:
+            if subdivision_pid == subdivision['pid']:
+                return True
+
+        # Subdivision not found, record is inaccessible
+        return False
 
 
 class SonarSearch(RecordsSearch):

--- a/sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json
+++ b/sonar/modules/collections/jsonschemas/collections/collection-v1.0.0_src.json
@@ -45,8 +45,21 @@
           "value",
           "language"
         ]
+      },
+      "form": {
+        "validation": {
+          "validators": {
+            "uniqueValueKeysInObject": {
+              "keys": [
+                "language"
+              ]
+            }
+          },
+          "messages": {
+            "uniqueValueKeysInObjectMessage": "Only one value per language is allowed"
+          }
+        }
       }
-
     },
     "description": {
       "title": "Descriptions",

--- a/sonar/modules/collections/permissions.py
+++ b/sonar/modules/collections/permissions.py
@@ -36,7 +36,7 @@ class RecordPermission(BaseRecordPermission):
         :return: True is action can be done
         :rtype: bool
         """
-        return user and user.is_moderator
+        return user and user.is_admin
 
     @classmethod
     def create(cls, user, record=None):
@@ -47,7 +47,7 @@ class RecordPermission(BaseRecordPermission):
         :return: True is action can be done
         :rtype: bool
         """
-        return user and user.is_moderator
+        return cls.list(user, record)
 
     @classmethod
     def read(cls, user, record):
@@ -58,18 +58,15 @@ class RecordPermission(BaseRecordPermission):
         :return: True is action can be done
         :rtype: bool
         """
-        # Only for moderator users
-        if not user or not user.is_moderator:
-            return False
-
-        # Super user is allowed
-        if user.is_superuser:
+        if user and user.is_superuser:
             return True
+
+        if not cls.create(user, record):
+            return False
 
         record = Record.get_record_by_pid(record['pid'])
         record = record.replace_refs()
 
-        # For moderator users, they can read only their own records.
         return current_organisation['pid'] == record['organisation']['pid']
 
     @classmethod

--- a/sonar/modules/deposits/api.py
+++ b/sonar/modules/deposits/api.py
@@ -26,7 +26,7 @@ from flask import g
 from sonar.modules.api import SonarRecord
 from sonar.modules.collections.api import Record as CollectionRecord
 from sonar.modules.documents.api import DocumentRecord
-from sonar.modules.users.api import current_user_record
+from sonar.modules.users.api import UserRecord, current_user_record
 from sonar.proxies import sonar
 
 from ..api import SonarIndexer, SonarRecord, SonarSearch
@@ -365,6 +365,15 @@ class DepositRecord(SonarRecord):
         # Open access status
         if self['diffusion'].get('oa_status'):
             metadata['oa_status'] = self['diffusion']['oa_status']
+
+        # Subdivisions
+        if self['diffusion'].get('subdivisions'):
+            metadata['subdivisions'] = self['diffusion']['subdivisions']
+        else:
+            # Guess from submitter
+            user = UserRecord.get_record_by_ref_link(self['user']['$ref'])
+            if user and user.is_submitter and user.get('subdivision'):
+                metadata['subdivisions'] = [user['subdivision']]
 
         document = DocumentRecord.create(metadata,
                                          dbcommit=True,

--- a/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
+++ b/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
@@ -1114,6 +1114,39 @@
         },
         "oa_status": {
           "$ref": "oa-status-v1.0.0.json"
+        },
+        "subdivisions": {
+          "title": "Subdivisions",
+          "type": "array",
+          "minItems": 0,
+          "items": {
+            "title": "Subdivision",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "$ref": {
+                "type": "string",
+                "pattern": "^https://sonar.ch/api/subdivisions/.*?$",
+                "form": {
+                  "remoteTypeahead": {
+                    "type": "subdivisions",
+                    "field": "name.value.suggest",
+                    "label": "label"
+                  }
+                }
+              }
+            },
+            "required": [
+              "$ref"
+            ]
+          },
+          "form": {
+            "templateOptions": {
+              "wrappers": [
+                "card"
+              ]
+            }
+          }
         }
       },
       "required": [

--- a/sonar/modules/deposits/mappings/v7/deposits/deposit-v1.0.0.json
+++ b/sonar/modules/deposits/mappings/v7/deposits/deposit-v1.0.0.json
@@ -263,6 +263,25 @@
         "properties": {
           "license": {
             "type": "keyword"
+          },
+          "subdivisions": {
+            "type": "object",
+            "properties": {
+              "pid": {
+                "type": "keyword"
+              },
+              "name": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "text"
+                  },
+                  "language": {
+                    "type": "keyword"
+                  }
+                }
+              }
+            }
           }
         }
       },

--- a/sonar/modules/deposits/serializers/__init__.py
+++ b/sonar/modules/deposits/serializers/__init__.py
@@ -23,6 +23,7 @@ from invenio_records_rest.serializers.response import record_responsify, \
     search_responsify
 
 from sonar.modules.serializers import JSONSerializer as _JSONSerializer
+from sonar.modules.subdivisions.api import Record as SubdivisionRecord
 from sonar.modules.users.api import UserRecord
 
 from ..marshmallow import DepositSchemaV1
@@ -40,6 +41,14 @@ class JSONSerializer(_JSONSerializer):
             if user:
                 org_term['name'] = '{last_name}, {first_name}'.format(
                     last_name=user['last_name'], first_name=user['first_name'])
+
+        # Add subdivision name
+        for org_term in results.get('aggregations',
+                                    {}).get('subdivision',
+                                            {}).get('buckets', []):
+            subdivision = SubdivisionRecord.get_record_by_pid(org_term['key'])
+            if subdivision:
+                org_term['name'] = subdivision['name'][0]['value']
 
         return super(JSONSerializer,
                      self).post_process_serialize_search(results, pid_fetcher)

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -249,16 +249,6 @@
         }
       }
     },
-    "sections": {
-      "title": "Sections",
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "title": "Section",
-        "type": "string",
-        "minLength": 1
-      }
-    },
     "documentType": {
       "$ref": "type-v1.0.0.json"
     },
@@ -1847,6 +1837,38 @@
           "templateOptions.required": "true"
         }
       }
+    },
+    "subdivisions": {
+      "title": "Subdivisions",
+      "type": "array",
+      "minItems": 0,
+      "items": {
+        "title": "Subdivision",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "$ref": {
+            "type": "string",
+            "pattern": "^https://sonar.ch/api/subdivisions/.*?$",
+            "form": {
+              "remoteTypeahead": {
+                "type": "subdivisions",
+                "field": "name.value.suggest",
+                "label": "label"
+              }
+            }
+          }
+        },
+        "required": [
+          "$ref"
+        ]
+      },
+      "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        }
+      }
     }
   },
   "propertiesOrder": [
@@ -1866,6 +1888,7 @@
     "provisionActivity",
     "partOf",
     "collections",
+    "subdivisions",
     "extent",
     "formats",
     "notes",

--- a/sonar/modules/documents/loaders/schemas/rerodoc.py
+++ b/sonar/modules/documents/loaders/schemas/rerodoc.py
@@ -52,7 +52,7 @@ class RerodocSchema(Marc21Schema):
     otherEdition = fields.List(fields.Dict())
     usageAndAccessPolicy = fields.Dict()
     files = fields.List(fields.Dict())
-    sections = fields.List(fields.Str())
+    subdivisions = fields.List(fields.Dict())
 
     @pre_dump
     def process(self, obj, **kwargs):

--- a/sonar/modules/documents/mappings/v7/documents/document-v1.0.0.json
+++ b/sonar/modules/documents/mappings/v7/documents/document-v1.0.0.json
@@ -107,9 +107,6 @@
           }
         }
       },
-      "sections": {
-        "type": "keyword"
-      },
       "documentType": {
         "type": "keyword"
       },
@@ -550,7 +547,7 @@
         "type": "text",
         "fields": {
           "raw": {
-            "type":  "keyword"
+            "type": "keyword"
           },
           "suggest": {
             "type": "completion",
@@ -562,7 +559,7 @@
         "type": "text",
         "fields": {
           "raw": {
-            "type":  "keyword"
+            "type": "keyword"
           },
           "suggest": {
             "type": "completion",
@@ -574,7 +571,7 @@
         "type": "text",
         "fields": {
           "raw": {
-            "type":  "keyword"
+            "type": "keyword"
           },
           "suggest": {
             "type": "completion",
@@ -584,6 +581,25 @@
       },
       "masked": {
         "type": "boolean"
+      },
+      "subdivisions": {
+        "type": "object",
+        "properties": {
+          "pid": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "text"
+              },
+              "language": {
+                "type": "keyword"
+              }
+            }
+          }
+        }
       },
       "_created": {
         "type": "date"

--- a/sonar/modules/documents/marshmallow/json.py
+++ b/sonar/modules/documents/marshmallow/json.py
@@ -100,7 +100,7 @@ class DocumentMetadataSchemaV1(StrictKeysMixin):
     usageAndAccessPolicy = fields.Dict()
     projects = fields.List(fields.Dict())
     oa_status = SanitizedUnicode()
-    sections = fields.List(fields.Str())
+    subdivisions = fields.List(fields.Dict())
     harvested = fields.Boolean()
     customField1 = fields.List(fields.String(validate=validate.Length(min=1)))
     customField2 = fields.List(fields.String(validate=validate.Length(min=1)))

--- a/sonar/modules/documents/serializers/__init__.py
+++ b/sonar/modules/documents/serializers/__init__.py
@@ -38,6 +38,7 @@ from sonar.modules.documents.serializers.schemas.schemaorg import SchemaOrgV1
 from sonar.modules.organisations.api import OrganisationRecord, \
     current_organisation
 from sonar.modules.serializers import JSONSerializer as _JSONSerializer
+from sonar.modules.subdivisions.api import Record as SubdivisionRecord
 from sonar.modules.users.api import current_user_record
 from sonar.modules.utils import get_language_value
 
@@ -108,7 +109,12 @@ class JSONSerializer(_JSONSerializer):
                                             {}).get('buckets', []):
             collection = CollectionRecord.get_record_by_pid(org_term['key'])
             if collection:
-                org_term['name'] = collection['name'][0]['value']
+                org_term['name'] = get_language_value(collection['name'])
+
+        # Don't display subdivision in global context
+        if view and view == current_app.config.get(
+                'SONAR_APP_DEFAULT_ORGANISATION'):
+            results['aggregations'].pop('subdivision', {})
 
         return super(JSONSerializer,
                      self).post_process_serialize_search(results, pid_fetcher)

--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -67,6 +67,18 @@ along with this program. If not, see
     </div>
     <div class="col">
       <h1 class="text-primary">{{ title | nl2br | safe }}</h1>
+      <h4 class="m-0">
+        {%- for organisation in record.get('organisation', []) -%}
+        <span class="badge badge-secondary text-light mr-1 font-weight-normal">
+          {{ organisation.name }}
+        </span>
+        {%- endfor -%}
+        {%- for subdivision in record.get('subdivisions', []) -%}
+        <span class="badge badge-secondary text-light mr-1 font-weight-normal">
+          {{ subdivision.name | language_value }}
+        </span>
+        {%- endfor -%}
+      </h4>
 
       <!-- CONTRIBUTORS-->
       {% set contributors = record | contributors %}

--- a/sonar/modules/serializers.py
+++ b/sonar/modules/serializers.py
@@ -24,6 +24,9 @@ from invenio_jsonschemas import current_jsonschemas
 from invenio_records_rest.serializers.json import \
     JSONSerializer as _JSONSerializer
 
+from sonar.modules.subdivisions.api import Record as SubdivisionRecord
+from sonar.modules.utils import get_language_value
+
 
 class JSONSerializer(_JSONSerializer):
     """JSON serializer for SONAR."""
@@ -56,6 +59,14 @@ class JSONSerializer(_JSONSerializer):
 
     def post_process_serialize_search(self, results, pid_fetcher):
         """Post process the search results."""
+        # Add subdivision name
+        for org_term in results.get('aggregations',
+                                    {}).get('subdivision',
+                                            {}).get('buckets', []):
+            subdivision = SubdivisionRecord.get_record_by_pid(org_term['key'])
+            if subdivision:
+                org_term['name'] = get_language_value(subdivision['name'])
+
         return results
 
     def serialize_search(self,

--- a/sonar/modules/subdivisions/__init__.py
+++ b/sonar/modules/subdivisions/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Resource."""

--- a/sonar/modules/subdivisions/api.py
+++ b/sonar/modules/subdivisions/api.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Record API."""
+
+from functools import partial
+
+from ..api import SonarIndexer, SonarRecord, SonarSearch
+from ..fetchers import id_fetcher
+from ..providers import Provider
+from .config import Configuration
+from .minters import id_minter
+
+# provider
+RecordProvider = type('RecordProvider', (Provider, ),
+                      dict(pid_type=Configuration.pid_type))
+# minter
+pid_minter = partial(id_minter, provider=RecordProvider)
+# fetcher
+pid_fetcher = partial(id_fetcher, provider=RecordProvider)
+
+
+class Record(SonarRecord):
+    """Record."""
+
+    minter = pid_minter
+    fetcher = pid_fetcher
+    provider = RecordProvider
+    schema = Configuration.schema
+
+    @classmethod
+    def get_pid_by_hash_key(cls, hash_key):
+        """Get a record by a hash key.
+
+        :param str hash_key: Hash key to find.
+        :returns: The record found.
+        :rtype: SonarRecord.
+        """
+        result = RecordSearch().filter(
+            'term', hashKey=hash_key).source(includes='pid').scan()
+        try:
+            return next(result).pid
+        except StopIteration:
+            return None
+
+
+class RecordSearch(SonarSearch):
+    """Record search."""
+
+    class Meta:
+        """Search only on item index."""
+
+        index = Configuration.index
+        doc_types = []
+
+
+class RecordIndexer(SonarIndexer):
+    """Indexing documents in Elasticsearch."""
+
+    record_cls = Record

--- a/sonar/modules/subdivisions/config.py
+++ b/sonar/modules/subdivisions/config.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Configuration."""
+
+from sonar.modules.permissions import record_permission_factory
+
+# Resource name
+RESOURCE_NAME = 'subdivisions'
+
+# JSON schema name
+JSON_SCHEMA_NAME = RESOURCE_NAME[:-1]
+
+# Module path
+MODULE_PATH = f'sonar.modules.{RESOURCE_NAME}'
+
+# PID type
+PID_TYPE = 'subd'
+
+
+class Configuration:
+    """Resource configuration."""
+
+    index = f'{RESOURCE_NAME}'
+    schema = f'{RESOURCE_NAME}/{JSON_SCHEMA_NAME}-v1.0.0.json'
+    pid_type = PID_TYPE
+    resolver_url = f'/api/{RESOURCE_NAME}/<pid>'
+    rest_endpoint = {
+        'pid_type':
+        PID_TYPE,
+        'pid_minter':
+        f'{RESOURCE_NAME}_id',
+        'pid_fetcher':
+        f'{RESOURCE_NAME}_id',
+        'default_endpoint_prefix':
+        True,
+        'record_class':
+        f'{MODULE_PATH}.api:Record',
+        'search_class':
+        f'{MODULE_PATH}.api:RecordSearch',
+        'indexer_class':
+        f'{MODULE_PATH}.api:RecordIndexer',
+        'search_index':
+        RESOURCE_NAME,
+        'search_type':
+        None,
+        'record_serializers': {
+            'application/json': (f'{MODULE_PATH}.serializers'
+                                 ':json_v1_response'),
+        },
+        'search_serializers': {
+            'application/json': (f'{MODULE_PATH}.serializers'
+                                 ':json_v1_search'),
+        },
+        'record_loaders': {
+            'application/json': (f'{MODULE_PATH}.loaders'
+                                 ':json_v1'),
+        },
+        'list_route':
+        f'/{RESOURCE_NAME}/',
+        'item_route':
+        f'/{RESOURCE_NAME}/<pid({PID_TYPE}, record_class="{MODULE_PATH}.api:Record"):pid_value>',
+        'default_media_type':
+        'application/json',
+        'max_result_window':
+        10000,
+        'search_factory_imp':
+        f'{MODULE_PATH}.query:search_factory',
+        'create_permission_factory_imp':
+        lambda record: record_permission_factory(
+            action='create', cls=f'{MODULE_PATH}.permissions:RecordPermission'
+        ),
+        'read_permission_factory_imp':
+        lambda record: record_permission_factory(
+            action='read',
+            record=record,
+            cls=f'{MODULE_PATH}.permissions:RecordPermission'),
+        'update_permission_factory_imp':
+        lambda record: record_permission_factory(
+            action='update',
+            record=record,
+            cls=f'{MODULE_PATH}.permissions:RecordPermission'),
+        'delete_permission_factory_imp':
+        lambda record: record_permission_factory(
+            action='delete',
+            record=record,
+            cls=f'{MODULE_PATH}.permissions:RecordPermission'),
+        'list_permission_factory_imp':
+        lambda record: record_permission_factory(
+            action='list',
+            record=record,
+            cls=f'{MODULE_PATH}.permissions:RecordPermission')
+    }

--- a/sonar/modules/subdivisions/jsonresolvers.py
+++ b/sonar/modules/subdivisions/jsonresolvers.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""JSON resolvers."""
+
+import jsonresolver
+from invenio_pidstore.resolver import Resolver
+from invenio_records.api import Record
+
+from ...config import JSONSCHEMAS_HOST
+from .config import Configuration
+
+
+@jsonresolver.route(Configuration.resolver_url, host=JSONSCHEMAS_HOST)
+def json_resolver(pid):
+    """Resolve record.
+
+    :param str pid: PID value.
+    :return: Record instance.
+    :rtype: Record
+    """
+    resolver = Resolver(pid_type=Configuration.pid_type,
+                        object_type='rec',
+                        getter=Record.get_record)
+    _, record = resolver.resolve(pid)
+
+    if record.get('$schema'):
+        del record['$schema']
+
+    return record

--- a/sonar/modules/subdivisions/jsonschemas/__init__.py
+++ b/sonar/modules/subdivisions/jsonschemas/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""JSON schemas."""

--- a/sonar/modules/subdivisions/jsonschemas/subdivisions/subdivision-v1.0.0_src.json
+++ b/sonar/modules/subdivisions/jsonschemas/subdivisions/subdivision-v1.0.0_src.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://sonar.ch/schemas/subdivisions/subdivision-v1.0.0.json",
+  "title": "Subdivisions",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "default": "https://sonar.ch/schemas/subdivisions/subdivision-v1.0.0.json"
+    },
+    "pid": {
+      "title": "Identifier",
+      "type": "string",
+      "minLength": 1
+    },
+    "hashKey": {
+      "title": "Hash key",
+      "type": "string",
+      "minLength": 1
+    },
+    "name": {
+      "title": "Names",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "title": "Name",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "value": {
+            "title": "Value",
+            "type": "string",
+            "minLength": 1
+          },
+          "language": {
+            "$ref": "language-v1.0.0.json"
+          }
+        },
+        "propertiesOrder": [
+          "language",
+          "value"
+        ],
+        "required": [
+          "value",
+          "language"
+        ]
+      },
+      "form": {
+        "validation": {
+          "validators": {
+            "uniqueValueKeysInObject": {
+              "keys": [
+                "language"
+              ]
+            }
+          },
+          "messages": {
+            "uniqueValueKeysInObjectMessage": "Only one value per language is allowed"
+          }
+        }
+      }
+    },
+    "organisation": {
+      "title": "Organisation",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "title": "Organisation",
+          "type": "string",
+          "pattern": "^https://sonar.ch/api/organisations/.*?$",
+          "form": {
+            "remoteOptions": {
+              "type": "organisations"
+            }
+          }
+        }
+      },
+      "required": [
+        "$ref"
+      ],
+      "form": {
+        "expressionProperties": {
+          "templateOptions.required": "true"
+        }
+      }
+    }
+  },
+  "propertiesOrder": [
+    "name"
+  ],
+  "required": [
+    "name"
+  ]
+}

--- a/sonar/modules/subdivisions/loaders/__init__.py
+++ b/sonar/modules/subdivisions/loaders/__init__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Loaders."""
+
+from invenio_records_rest.loaders.marshmallow import marshmallow_loader
+
+from ..schemas import RecordMetadataSchema
+
+#: JSON loader using Marshmallow for data validation.
+json_v1 = marshmallow_loader(RecordMetadataSchema)
+
+__all__ = ('json_v1', )

--- a/sonar/modules/subdivisions/mappings/__init__.py
+++ b/sonar/modules/subdivisions/mappings/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Elasticsearch mappings."""

--- a/sonar/modules/subdivisions/mappings/v7/__init__.py
+++ b/sonar/modules/subdivisions/mappings/v7/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Elasticsearch mappings."""

--- a/sonar/modules/subdivisions/mappings/v7/subdivisions/subdivision-v1.0.0.json
+++ b/sonar/modules/subdivisions/mappings/v7/subdivisions/subdivision-v1.0.0.json
@@ -1,0 +1,54 @@
+{
+  "settings": {
+    "number_of_shards": 8,
+    "number_of_replicas": 2,
+    "max_result_window": 20000
+  },
+  "mappings": {
+    "date_detection": false,
+    "numeric_detection": false,
+    "properties": {
+      "$schema": {
+        "type": "keyword"
+      },
+      "pid": {
+        "type": "keyword"
+      },
+      "hashKey": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "object",
+        "properties": {
+          "language": {
+            "type": "keyword"
+          },
+          "value": {
+            "type": "text",
+            "fields": {
+              "suggest": {
+                "type": "text",
+                "analyzer": "autocomplete",
+                "search_analyzer": "standard"
+              }
+            }
+          }
+        }
+      },
+      "organisation": {
+        "type": "object",
+        "properties": {
+          "pid": {
+            "type": "keyword"
+          }
+        }
+      },
+      "_created": {
+        "type": "date"
+      },
+      "_updated": {
+        "type": "date"
+      }
+    }
+  }
+}

--- a/sonar/modules/subdivisions/minters.py
+++ b/sonar/modules/subdivisions/minters.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Minters."""
+
+
+def id_minter(record_uuid, data, provider, pid_key='pid', object_type='rec'):
+    """PID minter.
+
+    :param str record_uuid: UUID of the record
+    :param dict data: Data of the record
+    :param RecordProvider provider: PID provider
+    :param str pid_key: PIF key
+    :param str object_type: Object type
+    :return: PID value
+    :rtype: str
+    """
+    # Create persistent identifier
+    provider = provider.create(object_type=object_type,
+                               object_uuid=record_uuid,
+                               pid_value=data.get(pid_key))
+    pid = provider.pid
+    data[pid_key] = pid.pid_value
+    return pid

--- a/sonar/modules/subdivisions/permissions.py
+++ b/sonar/modules/subdivisions/permissions.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Record permissions."""
+
+from sonar.modules.documents.api import DocumentSearch
+from sonar.modules.organisations.api import current_organisation
+from sonar.modules.permissions import RecordPermission as BaseRecordPermission
+
+from .api import Record
+
+
+class RecordPermission(BaseRecordPermission):
+    """Record permissions."""
+
+    @classmethod
+    def list(cls, user, record=None):
+        """List permission check.
+
+        :param UserRecord user: Current user record
+        :param Record record: Record to check
+        :return: True is action can be done
+        :rtype: bool
+        """
+        return user and user.is_submitter
+
+    @classmethod
+    def create(cls, user, record=None):
+        """Create permission check.
+
+        :param UserRecord user: Current user record
+        :param Record record: Record to check
+        :return: True is action can be done
+        :rtype: bool
+        """
+        return user and user.is_admin
+
+    @classmethod
+    def read(cls, user, record):
+        """Read permission check.
+
+        :param UserRecord user: Current user record
+        :param Record record: Record to check
+        :return: True is action can be done
+        :rtype: bool
+        """
+        # Only for moderator users.
+        if not user or not user.is_submitter:
+            return False
+
+        # Superuser is allowed.
+        if user.is_superuser:
+            return True
+
+        # No organisation.
+        if not current_organisation:
+            return False
+
+        record = Record.get_record_by_pid(record['pid'])
+        record = record.replace_refs()
+
+        return current_organisation['pid'] == record['organisation']['pid']
+
+    @classmethod
+    def update(cls, user, record):
+        """Update permission check.
+
+        :param UserRecord user: Current user record
+        :param Record record: Record to check
+        :return: True is action can be done
+        :rtype: bool
+        """
+        if not cls.read(user, record):
+            return False
+
+        return cls.create(user, record)
+
+    @classmethod
+    def delete(cls, user, record):
+        """Delete permission check.
+
+        :param UserRecord user: Current user record
+        :param Record record: Record to check
+        :return: True if action can be done
+        :rtype: bool
+        """
+        results = DocumentSearch().filter(
+            'term', subdivisions__pid=record['pid']).source(includes=['pid'])
+
+        # Cannot remove subdivision associated to a record
+        if results.count():
+            return False
+
+        if not cls.read(user, record):
+            return False
+
+        return cls.create(user, record)

--- a/sonar/modules/subdivisions/query.py
+++ b/sonar/modules/subdivisions/query.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Query."""
+
+from flask import current_app
+
+from sonar.modules.organisations.api import current_organisation
+from sonar.modules.query import default_search_factory
+from sonar.modules.users.api import current_user_record
+
+
+def search_factory(self, search):
+    """Search factory.
+
+    :param Search search: Search instance
+    :return: Tuple with search instance and URL arguments
+    :rtype: tuple
+    """
+    search, urlkwargs = default_search_factory(self, search)
+
+    if current_app.config.get('SONAR_APP_DISABLE_PERMISSION_CHECKS'):
+        return (search, urlkwargs)
+
+    # Records are not filtered for superusers.
+    if current_user_record.is_superuser:
+        return (search, urlkwargs)
+
+    # For admins, records are filtered by organisation of the current user.
+    search = search.filter('term',
+                           organisation__pid=current_organisation['pid'])
+
+    return (search, urlkwargs)

--- a/sonar/modules/subdivisions/schemas.py
+++ b/sonar/modules/subdivisions/schemas.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Marshmallow schemas."""
+
+from functools import partial
+
+from invenio_records_rest.schemas import StrictKeysMixin
+from invenio_records_rest.schemas.fields import GenFunction, \
+    PersistentIdentifier
+from marshmallow import fields, pre_dump, pre_load
+
+from sonar.modules.serializers import schema_from_context
+from sonar.modules.users.api import current_user_record
+from sonar.modules.utils import get_language_value
+
+from .api import Record
+from .permissions import RecordPermission
+
+schema_from_record = partial(schema_from_context, schema=Record.schema)
+
+
+class RecordMetadataSchema(StrictKeysMixin):
+    """Schema for record metadata."""
+
+    pid = PersistentIdentifier()
+    name = fields.List(fields.Dict(), required=True)
+    organisation = fields.Dict()
+    permissions = fields.Dict(dump_only=True)
+    label = fields.Method('get_label')
+    # When loading, if $schema is not provided, it's retrieved by
+    # Record.schema property.
+    schema = GenFunction(load_only=True,
+                         attribute="$schema",
+                         data_key="$schema",
+                         deserialize=schema_from_record)
+
+    def get_label(self, obj):
+        """Get label."""
+        return get_language_value(obj['name'])
+
+    @pre_load
+    def remove_fields(self, data, **kwargs):
+        """Removes computed fields.
+
+        :param dict data: Record data
+        :return: Modified data
+        :rtype: dict
+        """
+        data.pop('permissions', None)
+        data.pop('label', None)
+
+        return data
+
+    @pre_load
+    def guess_organisation(self, data, **kwargs):
+        """Guess organisation from current logged user.
+
+        :param dict data: Record data
+        :return: Modified data
+        :rtype: dict
+        """
+        # Organisation already attached to project, we do nothing.
+        if data.get('organisation'):
+            return data
+
+        # Store current user organisation in new project.
+        if current_user_record.get('organisation'):
+            data['organisation'] = current_user_record['organisation']
+
+        return data
+
+    @pre_dump
+    def add_permissions(self, item, **kwargs):
+        """Add permissions to record.
+
+        :param dict item: Record data
+        :return: Modified item
+        :rtype: dict
+        """
+        item['permissions'] = {
+            'read': RecordPermission.read(current_user_record, item),
+            'update': RecordPermission.update(current_user_record, item),
+            'delete': RecordPermission.delete(current_user_record, item)
+        }
+
+        return item
+
+
+class RecordSchema(StrictKeysMixin):
+    """Schema for record."""
+
+    metadata = fields.Nested(RecordMetadataSchema)
+    created = fields.Str(dump_only=True)
+    updated = fields.Str(dump_only=True)
+    links = fields.Dict(dump_only=True)
+    id = PersistentIdentifier()
+    explanation = fields.Raw(dump_only=True)

--- a/sonar/modules/subdivisions/serializers/__init__.py
+++ b/sonar/modules/subdivisions/serializers/__init__.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Serializers."""
+
+from invenio_records_rest.serializers.response import record_responsify, \
+    search_responsify
+
+from sonar.modules.serializers import JSONSerializer
+
+from ..schemas import RecordSchema
+
+# Serializers
+# ===========
+#: JSON serializer definition.
+json_v1 = JSONSerializer(RecordSchema)
+
+# Records-REST serializers
+# ========================
+#: JSON record serializer for individual records.
+json_v1_response = record_responsify(json_v1, 'application/json')
+#: JSON record serializer for search results.
+json_v1_search = search_responsify(json_v1, 'application/json')
+
+__all__ = (
+    'json_v1',
+    'json_v1_response',
+    'json_v1_search',
+)

--- a/sonar/modules/users/jsonschemas/users/user-v1.0.0.json
+++ b/sonar/modules/users/jsonschemas/users/user-v1.0.0.json
@@ -130,11 +130,33 @@
           }
         ]
       }
+    },
+    "subdivision": {
+      "title": "Subdivision",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "pattern": "^https://sonar.ch/api/subdivisions/.*?$",
+          "form": {
+            "remoteTypeahead": {
+              "type": "subdivisions",
+              "field": "name.value.suggest",
+              "label": "label"
+            }
+          }
+        }
+      },
+      "required": [
+        "$ref"
+      ]
     }
   },
   "propertiesOrder": [
     "organisation",
     "role",
+    "subdivision",
     "first_name",
     "last_name",
     "email",

--- a/sonar/modules/users/mappings/v7/users/user-v1.0.0.json
+++ b/sonar/modules/users/mappings/v7/users/user-v1.0.0.json
@@ -67,6 +67,25 @@
           }
         }
       },
+      "subdivision": {
+        "type": "object",
+        "properties": {
+          "pid": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "text"
+              },
+              "language": {
+                "type": "keyword"
+              }
+            }
+          }
+        }
+      },
       "_created": {
         "type": "date"
       },

--- a/sonar/modules/users/marshmallow/json.py
+++ b/sonar/modules/users/marshmallow/json.py
@@ -48,6 +48,7 @@ class UserMetadataSchemaV1(StrictKeysMixin):
     organisation = fields.Dict()
     role = SanitizedUnicode()
     full_name = SanitizedUnicode()
+    subdivision = fields.Dict()
     # When loading, if $schema is not provided, it's retrieved by
     # Record.schema property.
     schema = GenFunction(load_only=True,

--- a/sonar/theme/views.py
+++ b/sonar/theme/views.py
@@ -43,6 +43,8 @@ from sonar.modules.deposits.permissions import DepositPermission
 from sonar.modules.documents.permissions import DocumentPermission
 from sonar.modules.organisations.permissions import OrganisationPermission
 from sonar.modules.permissions import can_access_manage_view
+from sonar.modules.subdivisions.permissions import \
+    RecordPermission as SubdivisionPermission
 from sonar.modules.users.api import current_user_record
 from sonar.modules.users.permissions import UserPermission
 from sonar.resources.projects.permissions import RecordPermissionPolicy
@@ -157,6 +159,10 @@ def logged_user():
             'collections': {
                 'add': CollectionPermission.create(user),
                 'list': CollectionPermission.list(user)
+            },
+            'subdivisions': {
+                'add': SubdivisionPermission.create(user),
+                'list': SubdivisionPermission.list(user)
             }
         }
 

--- a/tests/api/collections/test_collections_permissions.py
+++ b/tests/api/collections/test_collections_permissions.py
@@ -54,8 +54,7 @@ def test_list(app, client, make_organisation, make_collection, superuser,
     # Logged as moderator
     login_user_via_session(client, email=moderator['email'])
     res = client.get(url_for('invenio_records_rest.coll_list'))
-    assert res.status_code == 200
-    assert res.json['hits']['total']['value'] == 1
+    assert res.status_code == 403
 
     # Logged as admin
     login_user_via_session(client, email=admin['email'])
@@ -104,7 +103,7 @@ def test_create(client, superuser, admin, moderator, submitter, user):
     res = client.post(url_for('invenio_records_rest.coll_list'),
                       data=json.dumps(data),
                       headers=headers)
-    assert res.status_code == 201
+    assert res.status_code == 403
 
     # Admin
     login_user_via_session(client, email=admin['email'])
@@ -153,7 +152,7 @@ def test_read(client, make_organisation, make_collection, superuser, admin,
     res = client.get(
         url_for('invenio_records_rest.coll_item',
                 pid_value=collection1['pid']))
-    assert res.status_code == 200
+    assert res.status_code == 403
 
     # Logged as admin
     login_user_via_session(client, email=admin['email'])
@@ -233,7 +232,7 @@ def test_update(client, make_organisation, make_collection, superuser, admin,
                              pid_value=collection1['pid']),
                      data=json.dumps(collection1.dumps()),
                      headers=headers)
-    assert res.status_code == 200
+    assert res.status_code == 403
 
     # Logged as admin
     login_user_via_session(client, email=admin['email'])
@@ -251,13 +250,6 @@ def test_update(client, make_organisation, make_collection, superuser, admin,
     assert res.status_code == 403
 
     # Logged as superuser
-    login_user_via_session(client, email=superuser['email'])
-    res = client.put(url_for('invenio_records_rest.coll_item',
-                             pid_value=collection1['pid']),
-                     data=json.dumps(collection1.dumps()),
-                     headers=headers)
-    assert res.status_code == 200
-
     login_user_via_session(client, email=superuser['email'])
     res = client.put(url_for('invenio_records_rest.coll_item',
                              pid_value=collection1['pid']),
@@ -290,7 +282,7 @@ def test_delete(client, db, document, collection, make_organisation,
     login_user_via_session(client, email=moderator['email'])
     res = client.delete(
         url_for('invenio_records_rest.coll_item', pid_value=collection['pid']))
-    assert res.status_code == 204
+    assert res.status_code == 403
 
     make_organisation('org2')
     collection2 = make_collection('org2')

--- a/tests/api/monitoring/test_monitoring_views.py
+++ b/tests/api/monitoring/test_monitoring_views.py
@@ -186,6 +186,12 @@ def test_data_info(client, es_clear, superuser, document, monkeypatch):
                 'es': 0,
                 'db-es': 0,
                 'index': 'collections'
+            },
+            'subd': {
+                'db': 0,
+                'es': 0,
+                'db-es': 0,
+                'index': 'subdivisions'
             }
         }
     }

--- a/tests/api/subdivisions/test_subdivisions_deposits_facets.py
+++ b/tests/api/subdivisions/test_subdivisions_deposits_facets.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test subdivisions facets in deposits."""
+
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+
+
+def test_list(app, db, client, deposit, superuser):
+    """Test subdivision facet."""
+    login_user_via_session(client, email=superuser['email'])
+    res = client.get(url_for('invenio_records_rest.depo_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total']['value'] == 1
+    assert res.json['aggregations']['subdivision']['buckets'] == [{
+        'key':
+        '2',
+        'doc_count':
+        1,
+        'name':
+        'Subdivision name'
+    }]

--- a/tests/api/subdivisions/test_subdivisions_documents_facets.py
+++ b/tests/api/subdivisions/test_subdivisions_documents_facets.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test subdivisions facets in documents."""
+
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+
+
+def test_list(app, db, client, document, subdivision, superuser):
+    document['subdivisions'] = [{
+        '$ref':
+        'https://sonar.ch/api/subdivisions/{pid}'.format(
+            pid=subdivision['pid'])
+    }]
+    document.commit()
+    db.session.commit()
+    document.reindex()
+
+    login_user_via_session(client, email=superuser['email'])
+    res = client.get(url_for('invenio_records_rest.doc_list', view='org'))
+    assert res.status_code == 200
+    assert res.json['hits']['total']['value'] == 1
+    assert res.json['aggregations']['subdivision']['buckets'] == [{
+        'key':
+        '2',
+        'doc_count':
+        1,
+        'name':
+        'Subdivision name'
+    }]
+
+    # Don't display aggregation in global context
+    res = client.get(url_for('invenio_records_rest.doc_list', view='global'))
+    assert res.status_code == 200
+    assert res.json['hits']['total']['value'] == 1
+    assert 'subdivision' not in res.json['aggregations']

--- a/tests/api/subdivisions/test_subdivisions_permissions.py
+++ b/tests/api/subdivisions/test_subdivisions_permissions.py
@@ -1,0 +1,348 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test subdivisions permissions."""
+
+import json
+
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+
+
+def test_list(app, client, make_organisation, make_subdivision, superuser,
+              admin, moderator, submitter, user):
+    """Test list subdivisions permissions."""
+    make_organisation('org2')
+    make_subdivision('org')
+    make_subdivision('org2')
+
+    # Not logged
+    res = client.get(url_for('invenio_records_rest.subd_list'))
+    assert res.status_code == 401
+
+    # Not logged but permission checks disabled
+    app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
+    res = client.get(url_for('invenio_records_rest.subd_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total']['value'] == 2
+    app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=False)
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.get(url_for('invenio_records_rest.subd_list'))
+    assert res.status_code == 403
+
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
+    res = client.get(url_for('invenio_records_rest.subd_list'))
+    assert res.status_code == 200
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.get(url_for('invenio_records_rest.subd_list'))
+    assert res.status_code == 200
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.get(url_for('invenio_records_rest.subd_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total']['value'] == 1
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.get(url_for('invenio_records_rest.subd_list'))
+    assert res.status_code == 200
+    assert res.json['hits']['total']['value'] == 2
+
+
+def test_create(client, superuser, admin, moderator, submitter, user):
+    """Test create subdivisions permissions."""
+    data = {'name': [{'language': 'eng', 'value': 'Name'}]}
+
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+    }
+
+    # Not logged
+    res = client.post(url_for('invenio_records_rest.subd_list'),
+                      data=json.dumps(data),
+                      headers=headers)
+    assert res.status_code == 401
+
+    # User
+    login_user_via_session(client, email=user['email'])
+    res = client.post(url_for('invenio_records_rest.subd_list'),
+                      data=json.dumps(data),
+                      headers=headers)
+    assert res.status_code == 403
+
+    # submitter
+    login_user_via_session(client, email=submitter['email'])
+    res = client.post(url_for('invenio_records_rest.subd_list'),
+                      data=json.dumps(data),
+                      headers=headers)
+    assert res.status_code == 403
+
+    # Moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.post(url_for('invenio_records_rest.subd_list'),
+                      data=json.dumps(data),
+                      headers=headers)
+    assert res.status_code == 403
+
+    # Admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.post(url_for('invenio_records_rest.subd_list'),
+                      data=json.dumps(data),
+                      headers=headers)
+    assert res.status_code == 201
+
+    # Super user
+    login_user_via_session(client, email=superuser['email'])
+    res = client.post(url_for('invenio_records_rest.subd_list'),
+                      data=json.dumps(data),
+                      headers=headers)
+    assert res.status_code == 201
+
+
+def test_read(client, make_organisation, make_subdivision, superuser, admin,
+              moderator, submitter, user):
+    """Test read subdivisions permissions."""
+    make_organisation('org2')
+    subdivision1 = make_subdivision('org')
+    subdivision2 = make_subdivision('org2')
+
+    # Not logged
+    res = client.get(
+        url_for('invenio_records_rest.subd_item',
+                pid_value=subdivision1['pid']))
+    assert res.status_code == 401
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.get(
+        url_for('invenio_records_rest.subd_item',
+                pid_value=subdivision1['pid']))
+    assert res.status_code == 403
+
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
+    res = client.get(
+        url_for('invenio_records_rest.subd_item',
+                pid_value=subdivision1['pid']))
+    assert res.status_code == 200
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.get(
+        url_for('invenio_records_rest.subd_item',
+                pid_value=subdivision1['pid']))
+    assert res.status_code == 200
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.get(
+        url_for('invenio_records_rest.subd_item',
+                pid_value=subdivision1['pid']))
+    assert res.status_code == 200
+    assert res.json['metadata']['permissions'] == {
+        'delete': True,
+        'read': True,
+        'update': True
+    }
+
+    # Logged as admin of other organisation
+    res = client.get(
+        url_for('invenio_records_rest.subd_item',
+                pid_value=subdivision2['pid']))
+    assert res.status_code == 403
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.get(
+        url_for('invenio_records_rest.subd_item',
+                pid_value=subdivision1['pid']))
+    assert res.status_code == 200
+
+    login_user_via_session(client, email=superuser['email'])
+    res = client.get(
+        url_for('invenio_records_rest.subd_item',
+                pid_value=subdivision2['pid']))
+    assert res.status_code == 200
+    assert res.json['metadata']['permissions'] == {
+        'delete': True,
+        'read': True,
+        'update': True
+    }
+
+
+def test_update(client, make_organisation, make_subdivision, superuser, admin,
+                moderator, submitter, user):
+    """Test update subdivisions permissions."""
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+    }
+
+    make_organisation('org2')
+    subdivision1 = make_subdivision('org')
+    subdivision2 = make_subdivision('org2')
+
+    # Not logged
+    res = client.put(url_for('invenio_records_rest.subd_item',
+                             pid_value=subdivision1['pid']),
+                     data=json.dumps(subdivision1.dumps()),
+                     headers=headers)
+    assert res.status_code == 401
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.put(url_for('invenio_records_rest.subd_item',
+                             pid_value=subdivision1['pid']),
+                     data=json.dumps(subdivision1.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
+    res = client.put(url_for('invenio_records_rest.subd_item',
+                             pid_value=subdivision1['pid']),
+                     data=json.dumps(subdivision1.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.put(url_for('invenio_records_rest.subd_item',
+                             pid_value=subdivision1['pid']),
+                     data=json.dumps(subdivision1.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.put(url_for('invenio_records_rest.subd_item',
+                             pid_value=subdivision1['pid']),
+                     data=json.dumps(subdivision1.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+    # Logged as admin of other organisation
+    res = client.put(url_for('invenio_records_rest.subd_item',
+                             pid_value=subdivision2['pid']),
+                     data=json.dumps(subdivision2.dumps()),
+                     headers=headers)
+    assert res.status_code == 403
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.put(url_for('invenio_records_rest.subd_item',
+                             pid_value=subdivision1['pid']),
+                     data=json.dumps(subdivision1.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+    login_user_via_session(client, email=superuser['email'])
+    res = client.put(url_for('invenio_records_rest.subd_item',
+                             pid_value=subdivision1['pid']),
+                     data=json.dumps(subdivision1.dumps()),
+                     headers=headers)
+    assert res.status_code == 200
+
+
+def test_delete(client, db, document, subdivision, make_organisation,
+                make_subdivision, superuser, admin, moderator, submitter,
+                user):
+    """Test delete subdivisions permissions."""
+    # Not logged
+    res = client.delete(
+        url_for('invenio_records_rest.subd_item',
+                pid_value=subdivision['pid']))
+    assert res.status_code == 401
+
+    # Logged as user
+    login_user_via_session(client, email=user['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.subd_item',
+                pid_value=subdivision['pid']))
+    assert res.status_code == 403
+
+    # Logged as submitter
+    login_user_via_session(client, email=submitter['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.subd_item',
+                pid_value=subdivision['pid']))
+    assert res.status_code == 403
+
+    # Logged as moderator
+    login_user_via_session(client, email=moderator['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.subd_item',
+                pid_value=subdivision['pid']))
+    assert res.status_code == 403
+
+    make_organisation('org2')
+    subdivision2 = make_subdivision('org2')
+
+    # Cannot remove subdivision from other organisation
+    res = client.delete(
+        url_for('invenio_records_rest.subd_item',
+                pid_value=subdivision2['pid']))
+    assert res.status_code == 403
+
+    subdivision = make_subdivision('org')
+
+    # Logged as admin
+    login_user_via_session(client, email=admin['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.subd_item',
+                pid_value=subdivision['pid']))
+    assert res.status_code == 204
+
+    subdivision = make_subdivision('org')
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.subd_item',
+                pid_value=subdivision['pid']))
+    assert res.status_code == 204
+
+    # Can remove any subdivision
+    login_user_via_session(client, email=superuser['email'])
+    res = client.delete(
+        url_for('invenio_records_rest.subd_item',
+                pid_value=subdivision2['pid']))
+    assert res.status_code == 204
+
+    subdivision = make_subdivision('org')
+
+    # Cannot remove subdivision as it is linked to document.
+    document['subdivisions'] = [{
+        '$ref':
+        'https://sonar.ch/api/subdivisions/{pid}'.format(
+            pid=subdivision['pid'])
+    }]
+    document.commit()
+    db.session.commit()
+    document.reindex()
+
+    res = client.delete(
+        url_for('invenio_records_rest.subd_item',
+                pid_value=subdivision['pid']))
+    assert res.status_code == 403

--- a/tests/api/subdivisions/test_subdivisions_users_facets.py
+++ b/tests/api/subdivisions/test_subdivisions_users_facets.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test subdivisions facets in users."""
+
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+
+
+def test_list(app, db, client, deposit, superuser, subdivision):
+    """Test subdivision facet."""
+    superuser['subdivision'] = {
+        '$ref':
+        'https://sonar.ch/api/subdivisions/{pid}'.format(
+            pid=subdivision['pid'])
+    }
+    superuser.commit()
+    db.session.commit()
+    superuser.reindex()
+
+    login_user_via_session(client, email=superuser['email'])
+    res = client.get(url_for('invenio_records_rest.user_list'))
+    assert res.status_code == 200
+    assert res.json['aggregations']['subdivision']['buckets'] == [{
+        'key':
+        '2',
+        'doc_count':
+        1,
+        'name':
+        'Subdivision name'
+    }]

--- a/tests/ui/documents/dojson/rerodoc/test_rerodoc_model.py
+++ b/tests/ui/documents/dojson/rerodoc/test_rerodoc_model.py
@@ -133,7 +133,7 @@ def test_marc21_to_type_and_organisation(app, bucket_location,
         '$ref':
         'https://sonar.ch/api/organisations/vge'
     }]
-    assert data['sections'] == ['bge']
+    assert len(data['subdivisions']) == 1
 
     # Specific conversion for mhnge
     marc21xml = """
@@ -150,7 +150,7 @@ def test_marc21_to_type_and_organisation(app, bucket_location,
         '$ref':
         'https://sonar.ch/api/organisations/vge'
     }]
-    assert data['sections'] == ['mhnge']
+    assert len(data['subdivisions']) == 1
 
 
 def test_marc21_to_title_245():


### PR DESCRIPTION
* Creates a new `subdivisions` resource.
* Links subdivisions to documents.
* Links subdivision to users.
* Links subdivision to deposits in diffusion step.
* Creates a subdivision when a section is found in RERO DOC publication.
* Configures a facet to filter deposits by subdivisions.
* Configures a facet to filter users by subdivision.
* Configures a facet to filter documents by subdivision.
* Updates permissions for collections by adding rules for subdivisions.
* Updates permissions for deposits by adding rules for subdivisions.
* Updates permissions for documents by adding rules for subdivisions.
* Adds organisations and subdivisions info in document detail view below the title.
* Translates subdivisions and collections facets.
* Makes the name of a subdivision or collection unique per language.
* Closes #145.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>