### PR TITLE
deposits: change validation process emails

### DIFF
--- a/sonar/modules/deposits/templates/deposits/email/approve/en.txt
+++ b/sonar/modules/deposits/templates/deposits/email/approve/en.txt
@@ -1,6 +1,6 @@
-Hi {{ deposit_user.last_name }},
+Hi {{ deposit_user.first_name }},
 
-Your deposit "{{ deposit.metadata.title }}" has been approved by {{ user.first_name }} {{ user.last_name }} ({{ user.email }}).
+Your institution approved your deposit "{{ deposit.metadata.title }}".
 
 {{ _('ID') }}: {{ deposit.pid }}
 {{ _('Date') }}: {{ date }}

--- a/sonar/modules/deposits/templates/deposits/email/ask_for_changes/en.txt
+++ b/sonar/modules/deposits/templates/deposits/email/ask_for_changes/en.txt
@@ -1,6 +1,6 @@
 Hi {{ deposit_user.first_name }},
 
-{{ user.first_name }} {{ user.last_name }} ({{ user.email }}) requests changes on your deposit "{{ deposit.metadata.title }}".
+Your institution requests changes on your deposit "{{ deposit.metadata.title }}".
 
 {{ _('ID') }}: {{ deposit.pid }}
 {{ _('Date') }}: {{ date }}

--- a/sonar/modules/deposits/templates/deposits/email/reject/en.txt
+++ b/sonar/modules/deposits/templates/deposits/email/reject/en.txt
@@ -1,6 +1,6 @@
 Hi {{ deposit_user.first_name }},
 
-We are sorry to inform that your deposit "{{ deposit.metadata.title }}" has been rejected by {{ user.first_name }} {{ user.last_name }} ({{ user.email }}).
+Your institution rejected your deposit "{{ deposit.metadata.title }}".
 
 {{ _('ID') }}: {{ deposit.pid }}
 {{ _('Date') }}: {{ date }}


### PR DESCRIPTION
* Removes moderator information in the emails sent to users during the
deposit process.
* Closes #551.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>