### PR TITLE
documents: `masked` property enhancement

### DIFF
--- a/sonar/config.py
+++ b/sonar/config.py
@@ -520,6 +520,8 @@ DEFAULT_AGGREGATION_SIZE = 50
 RECORDS_REST_FACETS = {
     'documents':
     dict(aggs=dict(
+        masked=dict(terms=dict(field='masked',
+                                    size=DEFAULT_AGGREGATION_SIZE)),
         subdivision=dict(terms=dict(field='subdivisions.pid',
                                     size=DEFAULT_AGGREGATION_SIZE)),
         organisation=dict(terms=dict(field='organisation.pid',
@@ -549,6 +551,8 @@ RECORDS_REST_FACETS = {
         customField3=dict(terms=dict(field='customField3.raw',
                                      size=DEFAULT_AGGREGATION_SIZE))),
          filters={
+             'masked':
+             and_term_filter('masked'),
              'subdivision':
              and_term_filter('subdivisions.pid'),
              'organisation':

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -1835,10 +1835,29 @@
     },
     "masked": {
       "title": "Masked",
-      "type": "boolean",
+      "type": "string",
+      "enum": [
+        "not_masked",
+        "masked_for_all",
+        "masked_for_external_ips"
+      ],
       "description": "A masked document is visible in the professional interface, but not in the public interface.",
-      "default": false,
+      "default": "not_masked",
       "form": {
+        "options": [
+          {
+            "label": "Not masked",
+            "value": "not_masked"
+          },
+          {
+            "label": "Masked for all",
+            "value": "masked_for_all"
+          },
+          {
+            "label": "Masked for external IP addresses",
+            "value": "masked_for_external_ips"
+          }
+        ],
         "expressionProperties": {
           "templateOptions.required": "true"
         }

--- a/sonar/modules/documents/mappings/v7/documents/document-v1.0.0.json
+++ b/sonar/modules/documents/mappings/v7/documents/document-v1.0.0.json
@@ -104,6 +104,9 @@
           },
           "name": {
             "type": "text"
+          },
+          "ips": {
+            "type": "keyword"
           }
         }
       },
@@ -584,7 +587,7 @@
         }
       },
       "masked": {
-        "type": "boolean"
+        "type": "keyword"
       },
       "subdivisions": {
         "type": "object",

--- a/sonar/modules/documents/marshmallow/json.py
+++ b/sonar/modules/documents/marshmallow/json.py
@@ -105,7 +105,7 @@ class DocumentMetadataSchemaV1(StrictKeysMixin):
     customField1 = fields.List(fields.String(validate=validate.Length(min=1)))
     customField2 = fields.List(fields.String(validate=validate.Length(min=1)))
     customField3 = fields.List(fields.String(validate=validate.Length(min=1)))
-    masked = fields.Boolean()
+    masked = SanitizedUnicode()
     _bucket = SanitizedUnicode()
     _files = Nested(FileSchemaV1, many=True)
     _oai = fields.Dict()

--- a/sonar/modules/documents/receivers.py
+++ b/sonar/modules/documents/receivers.py
@@ -29,7 +29,7 @@ from flask import current_app
 from sonar.modules.api import SonarRecord
 from sonar.modules.documents.api import DocumentRecord
 from sonar.modules.documents.loaders.schemas.factory import LoaderSchemaFactory
-from sonar.modules.utils import chunks
+from sonar.modules.utils import chunks, get_ips_list
 from sonar.webdav import HegClient
 
 from .api import DocumentRecord
@@ -108,6 +108,14 @@ def enrich_document_data(sender=None,
 
     # Check if record is open access.
     json['isOpenAccess'] = record.is_open_access()
+
+    # Compile allowed IPs in document
+    if json.get('organisation'):
+        if json['organisation'][0].get('allowedIps'):
+            json['organisation'][0]['ips'] = get_ips_list(
+                json['organisation'][0]['allowedIps'].split('\n'))
+        else:
+            json['organisation'][0]['ips'] = []
 
     # No files are present in record
     if not record.files:

--- a/tests/api/documents/test_documents_query.py
+++ b/tests/api/documents/test_documents_query.py
@@ -38,7 +38,7 @@ def test_collection_query(db, client, document, collection, es_clear):
     assert not res.json['aggregations'].get('collection')
 
 
-def test_masked_document(db, client, document, es_clear):
+def test_masked_document(db, client, organisation, document, es_clear):
     """Test masked document."""
     # Not masked (property not exists)
     res = client.get(url_for('invenio_records_rest.doc_list', view='global'))
@@ -46,7 +46,7 @@ def test_masked_document(db, client, document, es_clear):
     assert res.json['hits']['total']['value'] == 1
 
     # Not masked
-    document['masked'] = False
+    document['masked'] = 'not_masked'
     document.commit()
     document.reindex()
     db.session.commit()
@@ -54,11 +54,30 @@ def test_masked_document(db, client, document, es_clear):
     assert res.status_code == 200
     assert res.json['hits']['total']['value'] == 1
 
-    # Masked
-    document['masked'] = True
+    # Masked for all
+    document['masked'] = 'masked_for_all'
     document.commit()
     document.reindex()
     db.session.commit()
     res = client.get(url_for('invenio_records_rest.doc_list', view='global'))
     assert res.status_code == 200
     assert res.json['hits']['total']['value'] == 0
+
+    # Masked for external IPs, IP is not allowed
+    document['masked'] = 'masked_for_external_ips'
+    document.commit()
+    document.reindex()
+    db.session.commit()
+    res = client.get(url_for('invenio_records_rest.doc_list', view='global'))
+    assert res.status_code == 200
+    assert res.json['hits']['total']['value'] == 0
+
+    # Masked for external IPs, IP is allowed
+    organisation['allowedIps'] = '127.0.0.1'
+    organisation.commit()
+    db.session.commit()
+    organisation.reindex()
+    document.reindex()
+    res = client.get(url_for('invenio_records_rest.doc_list', view='global'))
+    assert res.status_code == 200
+    assert res.json['hits']['total']['value'] == 1

--- a/tests/ui/test_utils.py
+++ b/tests/ui/test_utils.py
@@ -100,6 +100,7 @@ def test_get_view_code(app, organisation):
     with app.test_request_context('/notexists'):
         assert get_view_code() == 'global'
 
+
 def test_format_date():
     """Test date formatting."""
     # Just year
@@ -219,3 +220,18 @@ def test_get_language_value(app):
 
     # Non existing locale
     assert get_language_value(values, 'de') == 'Value ENG'
+
+
+def test_get_current_ip(app):
+    """Test get current ip."""
+    with app.test_request_context(
+            environ_base={'X-Forwarded-For': '127.0.0.1'}):
+        assert get_current_ip() == '127.0.0.1'
+
+
+def test_get_ips_list():
+    """Test get IP list."""
+    ranges = ['127.0.0.1', '192.168.1.3-5', '12.13.14.15/32']
+    assert get_ips_list(ranges) == [
+        '12.13.14.15', '127.0.0.1', '192.168.1.3', '192.168.1.4', '192.168.1.5'
+    ]


### PR DESCRIPTION
* Allows to display documents only for allowed IP addresses. This is
done by changing the `masked` property from a boolean to an enum.
* Configures facet for filtering documents with `masked` property.
* Closes #632.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>