### PR TITLE
search: aggregations order endpoint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,8 @@ setup(
             'translations = sonar.translations.rest:blueprint',
             'suggestions = sonar.suggestions.rest:blueprint',
             'validation = sonar.modules.validation.views:blueprint',
-            'swisscovery = sonar.modules.swisscovery.rest:blueprint'
+            'swisscovery = sonar.modules.swisscovery.rest:blueprint',
+            'documents = sonar.modules.documents.rest:blueprint'
         ],
         'invenio_assets.webpack': [
             'sonar_theme = sonar.theme.webpack:theme'

--- a/sonar/modules/documents/rest.py
+++ b/sonar/modules/documents/rest.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Documents rest views."""
+
+from flask import Blueprint, current_app, jsonify, request
+
+from sonar.modules.organisations.api import OrganisationRecord, \
+    current_organisation
+from sonar.modules.users.api import current_user_record
+from sonar.modules.utils import get_language_value
+
+blueprint = Blueprint('documents', __name__, url_prefix='/documents')
+
+
+@blueprint.route('/aggregations', methods=['GET'])
+def aggregations():
+    """Get aggregations list."""
+    view = request.args.get('view')
+    collection = request.args.get('collection')
+
+    aggregations_list = [
+        'document_type',
+        'controlled_affiliation',
+        'year',
+        'collection',
+        'language',
+        'author',
+        'subject',
+        'organisation',
+        'subdivision',
+        'customField1',
+        'customField2',
+        'customField3',
+    ]
+
+    if view:
+        # Remove organisation in dedicated view
+        if view != current_app.config.get('SONAR_APP_DEFAULT_ORGANISATION'):
+            aggregations_list.remove('organisation')
+    else:
+        # Remove organisation for non superusers.
+        if current_user_record and not current_user_record.is_superuser:
+            aggregations_list.remove('organisation')
+
+    # Remove collection in collection context
+    if collection:
+        aggregations_list.remove('collection')
+
+    # Custom fields
+    if view and view != current_app.config.get(
+            'SONAR_APP_DEFAULT_ORGANISATION'):
+        organisation = OrganisationRecord.get_record_by_pid(view)
+    else:
+        organisation = current_organisation
+
+    for i in range(1, 4):
+        # Remove custom fields if we are in global view, or the fields is not
+        # configured in organisation.
+        if view == current_app.config.get(
+                'SONAR_APP_DEFAULT_ORGANISATION'
+        ) or not organisation or not organisation.get(
+                f'documentsCustomField{i}', {}).get('includeInFacets'):
+            aggregations_list.remove(f'customField{i}')
+        else:
+            # Add the right label
+            if organisation[f'documentsCustomField{i}'].get('label'):
+                aggregations_list[aggregations_list.index(
+                    f'customField{i}')] = {
+                        'key':
+                        f'customField{1}',
+                        'name':
+                        get_language_value(
+                            organisation[f'documentsCustomField{i}']['label'])
+                    }
+
+    # Don't display subdivision in global context
+    if view and view == current_app.config.get(
+            'SONAR_APP_DEFAULT_ORGANISATION'):
+        aggregations_list.remove('subdivision')
+
+    return jsonify(aggregations_list)

--- a/tests/api/documents/test_documents_permissions.py
+++ b/tests/api/documents/test_documents_permissions.py
@@ -56,36 +56,28 @@ def test_list(app, client, make_document, superuser, admin, moderator,
     res = client.get(url_for('invenio_records_rest.doc_list'))
     assert res.status_code == 200
     assert res.json['hits']['total']['value'] == 1
-    assert not res.json['aggregations'].get('organisation')
 
     # Logged as admin
     login_user_via_session(client, email=admin['email'])
     res = client.get(url_for('invenio_records_rest.doc_list'))
     assert res.status_code == 200
     assert res.json['hits']['total']['value'] == 1
-    assert res.json['aggregations']['customField1']['name'] == 'Test'
-    assert not res.json['aggregations'].get('organisation')
 
     # Logged as superuser
     login_user_via_session(client, email=superuser['email'])
     res = client.get(url_for('invenio_records_rest.doc_list'))
     assert res.status_code == 200
     assert res.json['hits']['total']['value'] == 2
-    assert res.json['aggregations'].get('organisation')
 
     # Public search
     res = client.get(url_for('invenio_records_rest.doc_list', view='global'))
     assert res.status_code == 200
     assert res.json['hits']['total']['value'] == 2
-    assert not res.json['aggregations'].get('customField1')
-    assert res.json['aggregations'].get('organisation')
 
     # Public search for organisation
     res = client.get(url_for('invenio_records_rest.doc_list', view='org'))
     assert res.status_code == 200
     assert res.json['hits']['total']['value'] == 1
-    assert res.json['aggregations']['customField1']['name'] == 'Test'
-    assert not res.json['aggregations'].get('organisation')
 
 
 def test_create(client, document_json, superuser, admin, moderator, submitter,

--- a/tests/api/documents/test_documents_query.py
+++ b/tests/api/documents/test_documents_query.py
@@ -35,7 +35,6 @@ def test_collection_query(db, client, document, collection, es_clear):
                 collection_view=collection['pid']))
     assert res.status_code == 200
     assert res.json['hits']['total']['value'] == 1
-    assert not res.json['aggregations'].get('collection')
 
 
 def test_masked_document(db, client, organisation, document, es_clear):

--- a/tests/api/subdivisions/test_subdivisions_documents_facets.py
+++ b/tests/api/subdivisions/test_subdivisions_documents_facets.py
@@ -43,9 +43,3 @@ def test_list(app, db, client, document, subdivision, superuser):
         'name':
         'Subdivision name'
     }]
-
-    # Don't display aggregation in global context
-    res = client.get(url_for('invenio_records_rest.doc_list', view='global'))
-    assert res.status_code == 200
-    assert res.json['hits']['total']['value'] == 1
-    assert 'subdivision' not in res.json['aggregations']


### PR DESCRIPTION
* Adds an endpoint to get the aggregations order for the documents.
* Moves logic for displaying facets into the new endpoint instead of
the search serializer.
* Closes #623.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
