### PR TITLE
deposit: allow to set document visibility

### DIFF
--- a/sonar/common/jsonschemas/masked-v1.0.0.json
+++ b/sonar/common/jsonschemas/masked-v1.0.0.json
@@ -1,0 +1,30 @@
+{
+  "title": "Visibility",
+  "type": "string",
+  "enum": [
+    "not_masked",
+    "masked_for_all",
+    "masked_for_external_ips"
+  ],
+  "description": "A masked document is visible in the professional interface, but not in the public interface.",
+  "default": "not_masked",
+  "form": {
+    "options": [
+      {
+        "label": "Public",
+        "value": "not_masked"
+      },
+      {
+        "label": "Private",
+        "value": "masked_for_all"
+      },
+      {
+        "label": "Restricted to the organisation",
+        "value": "masked_for_external_ips"
+      }
+    ],
+    "expressionProperties": {
+      "templateOptions.required": "true"
+    }
+  }
+}

--- a/sonar/modules/deposits/api.py
+++ b/sonar/modules/deposits/api.py
@@ -419,6 +419,9 @@ class DepositRecord(SonarRecord):
             if user and user.is_submitter and user.get('subdivision'):
                 metadata['subdivisions'] = [user['subdivision']]
 
+        # Masked
+        if self['diffusion'].get('masked') is not None:
+            metadata['masked'] = self['diffusion']['masked']
         document = DocumentRecord.create(metadata,
                                          dbcommit=True,
                                          with_bucket=True)

--- a/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
+++ b/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
@@ -6,6 +6,7 @@
   "required": [
     "pid"
   ],
+  "additionalProperties": false,
   "properties": {
     "$schema": {
       "type": "string",
@@ -1295,6 +1296,12 @@
     "diffusion": {
       "type": "object",
       "additionalProperties": false,
+      "propertiesOrder": [
+        "license",
+        "oa_status",
+        "masked",
+        "subdivisions"
+      ],
       "properties": {
         "license": {
           "$ref": "license-v1.0.0.json"
@@ -1334,6 +1341,9 @@
               ]
             }
           }
+        },
+        "masked": {
+          "$ref":"masked-v1.0.0.json"
         }
       },
       "required": [

--- a/sonar/modules/deposits/mappings/v7/deposits/deposit-v1.0.0.json
+++ b/sonar/modules/deposits/mappings/v7/deposits/deposit-v1.0.0.json
@@ -346,6 +346,9 @@
                 }
               }
             }
+          },
+          "masked": {
+            "type": "keyword"
           }
         }
       },

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -1834,34 +1834,7 @@
       }
     },
     "masked": {
-      "title": "Masked",
-      "type": "string",
-      "enum": [
-        "not_masked",
-        "masked_for_all",
-        "masked_for_external_ips"
-      ],
-      "description": "A masked document is visible in the professional interface, but not in the public interface.",
-      "default": "not_masked",
-      "form": {
-        "options": [
-          {
-            "label": "Not masked",
-            "value": "not_masked"
-          },
-          {
-            "label": "Masked for all",
-            "value": "masked_for_all"
-          },
-          {
-            "label": "Masked for external IP addresses",
-            "value": "masked_for_external_ips"
-          }
-        ],
-        "expressionProperties": {
-          "templateOptions.required": "true"
-        }
-      }
+      "$ref":"masked-v1.0.0.json"
     },
     "subdivisions": {
       "title": "Subdivisions",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -609,6 +609,7 @@ def deposit_json(collection, subdivision):
                 '$ref':
                 f'https://sonar.ch/api/subdivisions/{subdivision["pid"]}'
             }],
+            'masked': 'not_masked'
         },
         'status':
         'in_progress',

--- a/tests/ui/deposits/test_deposits_api.py
+++ b/tests/ui/deposits/test_deposits_api.py
@@ -223,3 +223,4 @@ def test_create_document(app, db, project, client, deposit, submitter,
     deposit['diffusion'].pop('subdivisions', None)
     document = deposit.create_document()
     assert document['subdivisions'][0] == submitter['subdivision']
+    assert document['masked'] == deposit['diffusion']['masked']


### PR DESCRIPTION
* Puts the masked property in a common JSONSchema file.
* Copy the masked property from the deposit to the document.
* Fixes deposit JSONSchema where the `additionalProperties` was missing.
* Closes rero#640.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
