### PR TITLE
documents: fill out custom fields for ROAR during RERO DOC import

### DIFF
--- a/sonar/dedicated/templates/dedicated/hepvs/home.html
+++ b/sonar/dedicated/templates/dedicated/hepvs/home.html
@@ -1,4 +1,4 @@
-<p>FREDI est l'acronyme de "Forschung – Recherche – Entwicklung – Développement – Innova(z)tion" la nouvelle
+<p>FREDI est l'acronyme de "Forschung – Recherche – Entwicklung – Développement – Innovation" la nouvelle
   plateforme de dépôt des productions scientifiques et professionnelles en Open Access ainsi que des projets de
   recherche de la Haute école pédagogique du Valais. De plus, selon la logique d'amélioration continue, la plateforme
   FREDI permet de centraliser l'intégralité des données des projets de recherche à des fins d'optimisation du système

--- a/sonar/modules/documents/dojson/rerodoc/model.py
+++ b/sonar/modules/documents/dojson/rerodoc/model.py
@@ -68,6 +68,24 @@ def marc21_to_type_and_organisation(self, key, value):
         if organisation == 'unisi':
             organisation = 'usi'
 
+        # Specific transformation for `hep bejune`, in order to fill out
+        # custom fields `Filière` (`customField1`) and `Titre obtenu`
+        # (`customField2`)
+        if organisation == 'hepbejune' and value.get('f'):
+            document_subtype = value.get('f').lower()
+            customField1 = ''
+            customField2 = ''
+            if document_subtype == 'diss_bachelor':
+                customField1 = 'Enseignement primaire'
+                customField2 = 'Bachelor of Arts in Pre-Primary and Primary Education'
+            elif  document_subtype == 'diss_master':
+                customField1 = 'Enseignement secondaire'
+                customField2 = 'Master of Arts or of Science in Secondary Education'
+            if customField1:
+                self['customField1'] = [customField1]
+            if customField2:
+                self['customField2'] = [customField2]
+
         # Specific transformation for `bpuge` and `mhnge`, because the real
         # acronym is `vge`.
         subdivision_name = None

--- a/sonar/modules/documents/loaders/schemas/rerodoc.py
+++ b/sonar/modules/documents/loaders/schemas/rerodoc.py
@@ -53,6 +53,9 @@ class RerodocSchema(Marc21Schema):
     usageAndAccessPolicy = fields.Dict()
     files = fields.List(fields.Dict())
     subdivisions = fields.List(fields.Dict())
+    customField1 = fields.List(fields.String())
+    customField2 = fields.List(fields.String())
+    customField3 = fields.List(fields.String())
 
     @pre_dump
     def process(self, obj, **kwargs):

--- a/sonar/modules/documents/rest.py
+++ b/sonar/modules/documents/rest.py
@@ -82,7 +82,7 @@ def aggregations():
                 aggregations_list[aggregations_list.index(
                     f'customField{i}')] = {
                         'key':
-                        f'customField{1}',
+                        f'customField{i}',
                         'name':
                         get_language_value(
                             organisation[f'documentsCustomField{i}']['label'])


### PR DESCRIPTION
* adds specific transformation to RERO DOC import for ROAR,
  in order to fill out custom fields `Filière` (`customField1`)
  and `Titre obtenu` (`customField2`)
* fixes bug in customField facet label definition
* fixes typo in FREDI description

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
