### PR TITLE
subdivisions: fix moderator access bug

### DIFF
--- a/sonar/modules/api.py
+++ b/sonar/modules/api.py
@@ -324,6 +324,11 @@ class SonarRecord(Record, FilesMixin):
 
         return False
 
+    @property
+    def subdivisions(self):
+        """Getter for subdivisions."""
+        return self.get('subdivisions', [])
+
     def has_subdivision(self, subdivision_pid):
         """Check if record belongs to the subdivision.
 
@@ -336,10 +341,10 @@ class SonarRecord(Record, FilesMixin):
             return True
 
         # No subdivision in record, the document is accessible.
-        if not self.get('subdivisions'):
+        if not self.subdivisions:
             return False
 
-        for subdivision in self['subdivisions']:
+        for subdivision in self.subdivisions:            
             if subdivision_pid == subdivision['pid']:
                 return True
 

--- a/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
+++ b/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
@@ -1266,10 +1266,7 @@
         "masked": {
           "$ref":"masked-v1.0.0.json"
         }
-      },
-      "required": [
-        "license"
-      ]
+      }
     },
     "document": {
       "title": "Document",

--- a/sonar/modules/deposits/query.py
+++ b/sonar/modules/deposits/query.py
@@ -52,10 +52,10 @@ def search_factory(self, search, query_parser=None):
         # subdivision or by owned deposits
         if not user.is_admin and user.is_moderator and user.get('subdivision'):
             user = user.replace_refs()
-            search = search.query(
+            search = search.filter(
                 'bool',
                 should=[
-                    Q('term', subdivision__pid=user['subdivision']['pid']),
+                    Q('term', user__subdivision__pid=user['subdivision']['pid']),
                     Q('term', user__pid=user['pid'])
                 ])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -886,6 +886,23 @@ def subdivision(app, db, es, admin, organisation, subdivision_json):
 
 
 @pytest.fixture()
+def subdivision2(app, db, es, admin, organisation, subdivision_json):
+    """Second subdivision fixture."""
+    json = copy.deepcopy(subdivision_json)
+    json['organisation'] = {
+        '$ref':
+        'https://sonar.ch/api/organisations/{pid}'.format(
+            pid=organisation['pid'])
+    }
+
+    subdivision = SubdivisionRecord.create(json, dbcommit=True)
+    subdivision.commit()
+    subdivision.reindex()
+    db.session.commit()
+    return subdivision
+
+
+@pytest.fixture()
 def bucket_location(app, db):
     """Create a default location for managing files."""
     tmppath = tempfile.mkdtemp()

--- a/tests/ui/deposits/test_deposits_api.py
+++ b/tests/ui/deposits/test_deposits_api.py
@@ -220,7 +220,6 @@ def test_create_document(app, db, project, client, deposit, submitter,
     }]
 
     # Test subdivision
-    deposit['diffusion'].pop('subdivisions', None)
     document = deposit.create_document()
     assert document['subdivisions'][0] == submitter['subdivision']
     assert document['masked'] == deposit['diffusion']['masked']


### PR DESCRIPTION
* Solves a problem that prevented a moderator to see the deposits
  of his/her subdivision in the list of deposits.
* Adds a second subdivision test fixture.
* Closes rero#631.

Co-Authored-by: Miguel Moreira <miguel.moreira@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
