### PR TITLE
help: display with the organization's code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,8 @@ setup(
                 sonar.modules.pdf_extractor.views.client:blueprint',
             'validation = sonar.modules.validation.views:blueprint',
             'collections = sonar.modules.collections.views:blueprint',
-            'dedicated = sonar.dedicated.views:blueprint'
+            'dedicated = sonar.dedicated.views:blueprint',
+            'help = sonar.help.views:blueprint'
         ],
         'invenio_base.api_blueprints': [
             'pdf_extractor = sonar.modules.pdf_extractor.views.api:blueprint',

--- a/sonar/config.py
+++ b/sonar/config.py
@@ -229,7 +229,8 @@ APP_DEFAULT_SECURE_HEADERS = {
             'https://code.jquery.com', 'https://cdnjs.cloudflare.com',
             'https://stackpath.bootstrapcdn.com',
             'https://www.googletagmanager.com',
-            'https://www.google-analytics.com'
+            'https://www.google-analytics.com',
+            'https://cdn.jsdelivr.net'
         ],
         'style-src': [
             "'self'", "'unsafe-inline'", 'https://cdnjs.cloudflare.com',

--- a/sonar/dedicated/__init__.py
+++ b/sonar/dedicated/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2022 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Dedicated module."""

--- a/sonar/ext.py
+++ b/sonar/ext.py
@@ -45,6 +45,7 @@ from sonar.resources.projects.service import \
 from . import config_sonar
 from .route_converters import OrganisationCodeConverter
 
+from flask_wiki.markdown_ext import BootstrapExtension
 
 def utility_processor():
     """Dictionary for passing data to templates."""
@@ -161,7 +162,14 @@ class Sonar():
             :returns: HTML corresponding to markdown
             :rtype: str
             """
-            return markdown.markdown(content)
+            return markdown.markdown(content, extensions=[
+                BootstrapExtension(),
+                'codehilite',
+                'fenced_code',
+                'toc',
+                'meta',
+                'tables'
+            ])
 
     def create_resources(self):
         """Create resources."""

--- a/sonar/help/__init__.py
+++ b/sonar/help/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2021 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Help module."""

--- a/sonar/help/templates/help/page_wiki.html
+++ b/sonar/help/templates/help/page_wiki.html
@@ -1,0 +1,62 @@
+{# -*- coding: utf-8 -*-
+  Swiss Open Access Repository
+  Copyright (C) 2022 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#}
+
+{% extends 'sonar/page_wiki.html' %}
+{% set active_page = "page" %}
+
+{% block navigation %}
+{%- include "help/page_wiki_search_navigation.html" %}
+{%- endblock navigation %}
+
+{% block content %}
+<main class="row mt-4 wiki-page">
+    <article class="col-md-8 offset-md-1">
+        <header class="d-flex flex-column justify-content-lg-between mb-4 pb-2 border-bottom">
+            <header class="wiki-page-header d-flex flex-column flex-lg-row justify-content-lg-between mb-2 mb-lg-0">
+            <h1 class="wiki-page-title mb-0">{{ page.title }}</h1>
+            </header>
+            <footer class="wiki-page-info d-flex flex-column flex-lg-row justify-content-lg-between">
+            {% if page.tags %}
+            <ul class="wiki-page-tags m-0 p-0">
+                {% for tag in page.tags.split(',') %}
+                <li class="badge badge-primary">{{ tag }}</li>
+                {% endfor %}
+            </ul>
+            {% endif %}
+            <div class="text-muted small">
+                <span>{{ _('Created:')}} {{ page.creation_datetime | date_format }} - {{ _('Last updated:')}} {{ page.modification_datetime | date_format }}</span>
+            </div>
+            </footer>
+        </header>
+        <article>
+          {{ page.body.replace('](/help', '](/{view}/help'.format(view=view)) | markdown_filter | safe }}
+        </article>
+    </article>
+    <aside class="col-md-3">
+        <div class="sticky-top pt-3">
+            {% if page.toc %}
+            <h5>{{ _('Table of contents') }}</h5>
+            {{ page.toc }}
+            {% endif %}
+        </div>
+    </aside>
+</main>
+{% endblock %}
+
+{%- block javascript %}
+{{ super() }}
+{%- endblock javascript %}

--- a/sonar/help/templates/help/page_wiki_search.html
+++ b/sonar/help/templates/help/page_wiki_search.html
@@ -1,0 +1,69 @@
+{# -*- coding: utf-8 -*-
+  Swiss Open Access Repository
+  Copyright (C) 2022 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#}
+
+{% from 'bootstrap/form.html' import render_form_row %}
+
+{% extends 'sonar/page_wiki.html' %}
+{% set active_page = "search" %}
+
+{% block navigation %}
+{%- include "help/page_wiki_search_navigation.html" %}
+{%- endblock navigation %}
+
+{% block content %}
+<main class="row mt-4 wiki-page">
+    <article class="col-md-10 offset-md-1">
+        <header>
+            <div class="pb-3">
+                {{ results | length }} {{ ngettext('result', 'results', results | length) }}
+                <a href="{{ url_for('help.search', view=view, q='*') }}" class="btn btn-sm btn-outline-primary ml-2">{{ _("All languages") }}</a>
+            </div>
+        </header>
+        <article>
+            <ul class="list-group list-group-flush">
+                {%- for result in results -%}
+                <li class="list-group-item">
+                    <article class="d-lg-flex justify-content-lg-between">
+                        <article class="mb-2">
+                            <h5 class="m-0">
+                                <a class="mr-2" href="{{ url_for('help.page', view=view, url=result.url) }}">
+                                    {{ result.title }}
+                                </a>
+                            </h5>
+                            <ul class="m-0 p-0">
+                                <li class="badge badge-secondary">
+                                    {{ result.language | upper }}
+                                </li>
+                                {% if result.tags %}
+                                {% for tag in result.tags.split(',') %}
+                                <li class="badge badge-primary">{{ tag }}</li>
+                                {% endfor %}
+                                {% endif %}
+                            </ul>
+                        </article>
+                    </article>
+                </li>
+                {%- endfor -%}
+            </ul>
+        </article>
+    </article>
+</main>
+{% endblock %}
+
+{%- block javascript %}
+{{ super() }}
+{%- endblock javascript %}

--- a/sonar/help/templates/help/page_wiki_search_navigation.html
+++ b/sonar/help/templates/help/page_wiki_search_navigation.html
@@ -1,0 +1,44 @@
+{# -*- coding: utf-8 -*-
+  Swiss Open Access Repository
+  Copyright (C) 2022 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#}
+
+<header class="row">
+  <nav class="navbar navbar-expand-lg navbar-light bg-light col-lg-10 offset-lg-1 justify-content-end">
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav mr-auto">
+          <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('help.index', view=view) }}">{{ _('Home') }}</a>
+          </li>
+      </ul>
+      <form class="form-inline" action="{{ url_for('help.search', view=view) }}">
+          <div class="input-group">
+          <input class="form-control"
+                 type="search" value="{{ query }}"
+                 name="q" placeholder="{{ _('Search') }}"
+                 aria-label="{{ _('Search') }}" />
+          <div class="input-group-append">
+          <button class="btn btn-outline-primary" type="submit">
+              {{ _('Search') }}
+          </button>
+          </div>
+          </div>
+      </form>
+    </div>
+  </nav>
+</header>

--- a/sonar/help/views.py
+++ b/sonar/help/views.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2022 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""help organisation views."""
+
+from flask import Blueprint, current_app, redirect, render_template, request, \
+    url_for
+from flask_wiki.api import current_wiki
+
+blueprint = Blueprint('help',
+                      __name__,
+                      template_folder='templates',
+                      static_folder='static')
+
+
+@blueprint.route('/<org_code:view>/help/', methods=['GET'])
+def index(view):
+    """Help index redirect to home."""
+    return redirect(url_for(
+        'help.page', view=view, url=current_app.config.get('WIKI_HOME')))
+
+
+@blueprint.route('/<org_code:view>/help/<path:url>/', methods=['GET'])
+def page(view, url):
+    """Help page."""
+    page =current_wiki.get_or_404(url)
+    return render_template(
+        'help/page_wiki.html',
+        view=view,
+        page=page)
+
+
+@blueprint.route('/<org_code:view>/help/search', methods=['GET'])
+def search(view):
+    """Help search."""
+    query = request.args.get('q', '')
+    results = current_wiki.search(query)
+    return render_template(
+        'help/page_wiki_search.html',
+        results=results,
+        query=query,
+        view=view
+    )

--- a/sonar/theme/templates/sonar/footer.html
+++ b/sonar/theme/templates/sonar/footer.html
@@ -15,13 +15,14 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #}
 
+{% set organisation = g.get('organisation', {}) %}
 <footer id="footer" class="mt-5">
   <div class="container">
-    {% if g.get('organisation', {}).get('isDedicated') and g.organisation.get('footer') %}
+    {% if organisation.get('isDedicated') and organisation.get('footer') %}
     <div class="row justify-content-center align-items-center bg-light">
       <div class="col py-4 py-lg-5 text-center text-lg-left">
         <div class="d-lg-flex flex-row">
-          {{ g.organisation.footer | language_value | markdown_filter | safe }}
+          {{ organisation.footer | language_value | markdown_filter | safe }}
         </div>
       </div>
     </div>
@@ -30,7 +31,8 @@
       <div class="col py-4 py-lg-5 text-center text-lg-left">
         <div class="d-lg-flex flex-row">
           <div>
-            <a href="{{ url_for('wiki.index') }}">{{ _('Help & Documentation') }}</a>
+            {% set helplink = url_for('help.index', view=organisation.get('pid')) if organisation.get('isDedicated') else url_for('wiki.index') %}
+            <a href="{{ helplink }}">{{ _('Help & Documentation') }}</a>
           </div>
           <div class="d-none d-lg-block mx-3">|</div>
           <div>

--- a/sonar/theme/templates/sonar/page_wiki.html
+++ b/sonar/theme/templates/sonar/page_wiki.html
@@ -37,8 +37,6 @@
 
 {%- block javascript %}
 {{ super() }}
+{{ bootstrap.load_js() }}
 <script type="text/javascript" src="{{ url_for('wiki.static', filename='js/wiki.js') }}"></script>
 {%- endblock javascript %}
-</body>
-
-</html>


### PR DESCRIPTION
The help is displayed with the organization's code
and is no longer directed to the global help.

* Closes #709.
* Closes #712.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## How to test?

- Url for organization help: https://sonar/{view}/help

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
