### PR TITLE
files: fix files permissions

### DIFF
--- a/sonar/config.py
+++ b/sonar/config.py
@@ -288,8 +288,9 @@ RECORDS_UI_ENDPOINTS = {
     },
     'doc_files': {
         'pid_type': 'doc',
+        'record_class': 'sonar.modules.documents.api:DocumentRecord',
         'route': '/documents/<pid_value>/files/<filename>',
-        'view_imp': 'invenio_records_files.utils:file_download_ui',
+        'view_imp': 'sonar.modules.utils:file_download_ui',
         'record_class': 'invenio_records_files.api:Record'
     },
     'depo_previewer': {
@@ -301,7 +302,7 @@ RECORDS_UI_ENDPOINTS = {
     'depo_files': {
         'pid_type': 'depo',
         'route': '/deposits/<pid_value>/files/<filename>',
-        'view_imp': 'invenio_records_files.utils:file_download_ui',
+        'view_imp': 'sonar.modules.utils:file_download_ui',
         'record_class': 'invenio_records_files.api:Record'
     },
     'org_previewer': {
@@ -313,7 +314,7 @@ RECORDS_UI_ENDPOINTS = {
     'org_files': {
         'pid_type': 'org',
         'route': '/organisations/<pid_value>/files/<filename>',
-        'view_imp': 'invenio_records_files.utils:file_download_ui',
+        'view_imp': 'sonar.modules.utils:file_download_ui',
         'record_class': 'invenio_records_files.api:Record'
     },
     'proj': {
@@ -339,7 +340,7 @@ RECORDS_UI_ENDPOINTS = {
     'coll_files': {
         'pid_type': 'coll',
         'route': '/collections/<pid_value>/files/<filename>',
-        'view_imp': 'invenio_records_files.utils:file_download_ui',
+        'view_imp': 'sonar.modules.utils:file_download_ui',
         'record_class': 'invenio_records_files.api:Record'
     },
 }
@@ -800,6 +801,14 @@ applications."""
 
 FILES_REST_PERMISSION_FACTORY = \
     'sonar.modules.permissions.files_permission_factory'
+
+SONAR_APP_FILES_REST_PERMISSION = {
+    'doc': 'sonar.modules.documents.permissions:DocumentFilesPermission',
+    'org': 'sonar.modules.organisations.permissions:OrganisationFilesPermission',
+    'coll': 'sonar.modules.collections.permissions:FilesPermission',
+    'depo': 'sonar.modules.deposits.permissions:DepositFilesPermission'
+}
+"""FilesPermission class to make the invenio files permission more flexible"""
 
 # Database
 # =========================

--- a/sonar/modules/collections/templates/collections/item.html
+++ b/sonar/modules/collections/templates/collections/item.html
@@ -17,7 +17,7 @@ along with this program. If not, see
 #}
 {% set name = collection.name | language_value %}
 <div class="row">
-  {% set thumbnail = collection | record_image_url %}
+  {% set thumbnail = collection | record_image_url('coll') %}
   {% if thumbnail %}
   <div class="col-sm-3">
     <img src="{{ thumbnail }}" alt="{{ name }}" class="img-fluid img-thumbnail">

--- a/sonar/modules/documents/api.py
+++ b/sonar/modules/documents/api.py
@@ -28,7 +28,7 @@ from sonar.affiliations import AffiliationResolver
 from sonar.modules.documents.minters import id_minter
 from sonar.modules.pdf_extractor.utils import extract_text_from_content
 from sonar.modules.utils import change_filename_extension, \
-    create_thumbnail_from_file
+    create_thumbnail_from_file, get_current_ip, is_ip_in_list
 
 from ..api import SonarIndexer, SonarRecord, SonarSearch
 from ..ark.api import current_ark
@@ -358,6 +358,27 @@ class DocumentRecord(SonarRecord):
                 return embargo_date <= datetime.now()
 
         return True
+
+    @property
+    def is_masked(self):
+        """Check if record is masked.
+
+        :returns: True if record is masked
+        :rtype: boolean
+        """
+        if not self.get('masked'):
+            return False
+
+        if self['masked'] == 'masked_for_all':
+            return True
+
+        if self['masked'] == 'masked_for_external_ips' and self.get(
+                'organisation') and not is_ip_in_list(
+                    get_current_ip(), self['organisation'][0].get(
+                        'allowedIps', '').split('\n')):
+            return True
+
+        return False
 
     def get_ark_resolver_url(self):
         """Get the ark resolver url.

--- a/sonar/modules/documents/utils.py
+++ b/sonar/modules/documents/utils.py
@@ -109,14 +109,14 @@ def get_file_links(file, record):
     return links
 
 
-def get_file_restriction(file, organisations):
+def get_file_restriction(file, organisations, for_permission=True):
     """Check if current file can be displayed.
 
     :param file: File dict.
     :param organisations: List of organisations.
+    :param for_permission: True if it is used to compute permissions.
     :returns: Object containing result as boolean and possibly embargo date.
     """
-
     def is_allowed_by_scope():
         """Check if file is fully restricted or only outside organisation.
 
@@ -149,21 +149,20 @@ def get_file_restriction(file, organisations):
 
     not_restricted = {'restricted': False, 'date': None}
 
-    # We are in admin, no restrictions are applied.
-    if not request.args.get('view') and not request.view_args.get(
-            'view') and request.url_rule.rule != '/oai2d':
+    # We are in admin, no restrictions are applied except for permissions.
+    if not for_permission and not request.args.get('view') and\
+            not request.view_args.get('view') and\
+            request.url_rule.rule != '/oai2d':
         return not_restricted
 
     # No specific access or specific access is open access
     if not file.get('access') or file['access'] == 'coar:c_abf2':
         return not_restricted
-
     # Access is embargoed
     if file['access'] == 'coar:c_f1cf':
         # No embargo date
         if not file.get('embargo_date'):
             return not_restricted
-
         try:
             embargo_date = datetime.strptime(file['embargo_date'], '%Y-%m-%d')
         except Exception:

--- a/sonar/modules/documents/views.py
+++ b/sonar/modules/documents/views.py
@@ -30,8 +30,7 @@ from sonar.modules.collections.api import Record as CollectionRecord
 from sonar.modules.documents.utils import has_external_urls_for_files, \
     populate_files_properties
 from sonar.modules.utils import format_date, \
-    get_bibliographic_code_from_language, get_current_ip, get_language_value, \
-    is_ip_in_list
+    get_bibliographic_code_from_language, get_language_value
 
 from .utils import publication_statement_text
 
@@ -71,28 +70,6 @@ def detail(pid, record, template=None, **kwargs):
     :param \*\*kwargs: Additional view arguments based on URL rule.
     :returns: The rendered template.
     """
-
-    def is_masked(record):
-        """Check if record is masked.
-
-        :param record: Record object
-        :returns: True if record is masked
-        :rtype: boolean
-        """
-        if not record.get('masked'):
-            return False
-
-        if record['masked'] == 'masked_for_all':
-            return True
-
-        if record['masked'] == 'masked_for_external_ips' and record.get(
-                'organisation') and not is_ip_in_list(
-                    get_current_ip(), record['organisation'][0].get(
-                        'allowedIps', '').split('\n')):
-            return True
-
-        return False
-
     # Add restriction, link and thumbnail to files
     if record.get('_files'):
         # Check if organisation's record forces to point file to an external
@@ -117,8 +94,8 @@ def detail(pid, record, template=None, **kwargs):
     record = record.replace_refs()
 
     # Record is masked
-    if is_masked(record):
-        abort(404)
+    if record.is_masked:
+        abort(403)
 
     # Send signal when record is viewed
     record_viewed.send(

--- a/sonar/modules/users/permissions.py
+++ b/sonar/modules/users/permissions.py
@@ -31,7 +31,7 @@ class UserPermission(RecordPermission):
         """List permission check.
 
         :param user: Current user record.
-        :param recor: Record to check.
+        :param record: Record to check.
         :returns: True is action can be done.
         """
         if not user:
@@ -44,7 +44,7 @@ class UserPermission(RecordPermission):
         """Create permission check.
 
         :param user: Current user record.
-        :param recor: Record to check.
+        :param record: Record to check.
         :returns: True is action can be done.
         """
         if not user:
@@ -57,7 +57,7 @@ class UserPermission(RecordPermission):
         """Read permission check.
 
         :param user: Current user record.
-        :param recor: Record to check.
+        :param record: Record to check.
         :returns: True is action can be done.
         """
         if not user:
@@ -92,7 +92,7 @@ class UserPermission(RecordPermission):
         """Update permission check.
 
         :param user: Current user record.
-        :param recor: Record to check.
+        :param record: Record to check.
         :returns: True is action can be done.
         """
         # Same rules as read permission.
@@ -103,7 +103,7 @@ class UserPermission(RecordPermission):
         """Delete permission check.
 
         :param user: Current user record.
-        :param recor: Record to check.
+        :param record: Record to check.
         :returns: True is action can be done.
         """
         # At least for admin logged users.

--- a/sonar/theme/templates/sonar/frontpage.html
+++ b/sonar/theme/templates/sonar/frontpage.html
@@ -30,7 +30,7 @@ along with this program. If not, see
         <a
           href="{{ url_for('index', view=view_code if g.get('organisation', {}).get('isDedicated') else config.SONAR_APP_DEFAULT_ORGANISATION) }}">
           {% if g.get('organisation', {}).get('isDedicated') %}
-          {% set thumbnail = g.organisation | record_image_url %}
+          {% set thumbnail = g.organisation | record_image_url('org') %}
           {% if thumbnail %}
           <img src="{{ thumbnail }}" class="img-fluid" alt="{{ 'Organisation logo' }}">
           {% else %}

--- a/sonar/theme/templates/sonar/partial/navbar.html
+++ b/sonar/theme/templates/sonar/partial/navbar.html
@@ -20,7 +20,7 @@ along with this program. If not, see
     {% if page != 'home' %}
     <a class="navbar-brand" href="{{ url_for('index', view=view_code) }}">
       {% if g.get('organisation', {}).get('isDedicated') %}
-      {% set thumbnail = g.organisation | record_image_url %}
+      {% set thumbnail = g.organisation | record_image_url('org') %}
       {% if thumbnail %}
       <img src="{{ thumbnail }}" alt="{{ _('Organisation logo') }}" height="50"
         class="d-inline-block align-top mr-3 my-2" alt="">

--- a/sonar/theme/templates/sonar/partial/organisation.html
+++ b/sonar/theme/templates/sonar/partial/organisation.html
@@ -19,7 +19,7 @@
 <div class="bg-light py-4">
   <div class="container">
     <div class="row justify-content-center">
-      {% set thumbnail = g.organisation | record_image_url %}
+      {% set thumbnail = g.organisation | record_image_url('org') %}
       {% if thumbnail %}
       <div class="col-6 col-lg-2">
         <img src="{{ thumbnail }}" alt="{{ g.organisation.name }}" class="img-fluid">

--- a/sonar/theme/views.py
+++ b/sonar/theme/views.py
@@ -239,32 +239,24 @@ def schemas(record_type):
 
 
 @blueprint.app_template_filter()
-def record_image_url(record, key=None):
+def record_image_url(record, code, key=None):
     """Get image URL for a record.
 
     :param files: Liste of files of the record.
     :param key: The key of the file to be rendered, if no key, takes the first.
     :returns: Image url corresponding to key, or the first one.
     """
-    if not record.get('_files'):
+    if not (record.get('_files') and record.get('pid')):
         return None
-
-    def image_url(file):
-        """Return image URL for a file.
-
-        :param file: File to get the URL from.
-        :returns: URL of the file.
-        """
-        return '/api/files/{bucket}/{key}'.format(key=file['key'],
-                                                  bucket=file['bucket'])
-
     for file in record['_files']:
         if re.match(r'^.*\.(jpe?g|png|gif|svg)$',
                     file['key'],
                     flags=re.IGNORECASE):
             if not key or file['key'] == key:
-                return image_url(file)
-
+                return url_for(
+                    f'invenio_records_ui.{code}_files',
+                    pid_value=record.get('pid'),
+                    filename=file['key'])
     return None
 
 

--- a/tests/api/collections/test_collections_files_permissions.py
+++ b/tests/api/collections/test_collections_files_permissions.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2022 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test collections files permissions."""
+
+
+from flask import url_for
+from flask_security import url_for_security
+from invenio_accounts.testutils import login_user_via_session
+
+
+def test_update_delete(client, superuser, admin, moderator,
+              submitter, user, collection, pdf_file):
+    """Test permissions for uploading and deleting files."""
+    file_name = 'test.pdf'
+    users = [superuser, admin, moderator, submitter, user, None]
+
+    # upload the file
+    url_file_content = url_for(
+        'invenio_records_files.coll_object_api',
+        pid_value=collection.get('pid'), key=file_name)
+    for u, status in zip(users, [200, 200, 404, 404, 404, 404]):
+        if u:
+            login_user_via_session(client, email=u['email'])
+        else:
+            client.get(url_for_security('logout'))
+        res = client.put(url_file_content, input_stream=open(pdf_file, 'rb'))
+        assert res.status_code == status
+        if status == 200:
+            # the delete return status is no content
+            status = 204
+            res = client.delete(url_file_content)
+            assert res.status_code == status
+
+
+def test_read_metadata(client, superuser, admin, moderator,
+              submitter, user, collection_with_file):
+    """Test read files permissions."""
+
+    users = [superuser, admin, moderator, submitter, user, None]
+    url_files = url_for(
+        'invenio_records_files.coll_bucket_api',
+        pid_value=collection_with_file.get('pid'))
+    for u, status in zip(users, [200, 200, 200, 200, 200, 200]):
+        if u:
+            login_user_via_session(client, email=u['email'])
+        else:
+            client.get(url_for_security('logout'))
+        res = client.get(url_files)
+        assert res.status_code == status
+
+
+def test_read_content(client, superuser, admin, moderator,
+              submitter, user, collection_with_file):
+    """Test read collections permissions."""
+
+    file_name = 'test1.pdf'
+    users = [
+        superuser, admin, moderator, submitter, user, None]
+    url_file_content = url_for(
+        'invenio_records_files.coll_object_api',
+        pid_value=collection_with_file.get('pid'),
+    key=file_name)
+    for u, status in zip(users, [200, 200, 200, 200, 200, 200]):
+        if u:
+            login_user_via_session(client, email=u['email'])
+        else:
+            client.get(url_for_security('logout'))
+        res = client.get(url_file_content)
+        assert res.status_code == status

--- a/tests/api/collections/test_collections_files_rest.py
+++ b/tests/api/collections/test_collections_files_rest.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2022 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test REST endpoint for collections."""
+
+
+from flask import url_for
+
+
+def test_get_content(app, client, collection_with_file):
+    """Test get existing file content."""
+    app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
+
+    file_name = 'test1.pdf'
+
+    # get the pdf file
+    url_file_content = url_for(
+        'invenio_records_files.coll_object_api',
+        pid_value=collection_with_file.get('pid'), key=file_name)
+    res = client.get(url_file_content)
+    assert res.status_code == 200
+    assert res.content_type == 'application/octet-stream'
+    assert res.content_length > 0
+
+
+def test_get_metadata(app, client, collection_with_file):
+    """Test get existing file metadata."""
+    app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
+
+    # get all files metadata of a given collection
+    url_files = url_for(
+        'invenio_records_files.coll_bucket_api',
+        pid_value=collection_with_file.get('pid'))
+    res = client.get(url_files)
+    assert res.status_code == 200
+    file_keys = ['test1.pdf']
+    assert set(file_keys) == set(
+        [f.get('key') for f in res.json.get('contents')])
+
+    # get a specific file metadata of a given collection
+    for f_key in file_keys:
+        url_file = url_for(
+            'invenio_records_files.coll_bucket_api',
+            pid_value=collection_with_file.get('pid'), key=f_key)
+        res = client.get(url_file)
+        assert res.status_code == 200
+
+
+def test_put_delete(app, client, collection, pdf_file):
+    """Test create and delete a file."""
+    app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
+    file_name = 'test.pdf'
+
+    # upload the file
+    url_file_content = url_for(
+        'invenio_records_files.coll_object_api', pid_value=collection.get('pid'), key=file_name)
+    res = client.put(url_file_content, input_stream=open(pdf_file, 'rb'))
+    assert res.status_code == 200
+
+    # get the version id
+    url_file = url_for(
+        'invenio_records_files.coll_bucket_api',
+        pid_value=collection.get('pid'), key=file_name)
+    res = client.get(url_file)
+    content = res.json.get('contents')
+
+    assert len(content) == 1
+    content = content.pop()
+    version_id = content.get('version_id')
+
+    # upload a second version
+    url_file_content = url_for(
+        'invenio_records_files.coll_object_api', pid_value=collection.get('pid'), key=file_name)
+    res = client.put(url_file_content, input_stream=open(pdf_file, 'rb'))
+    assert res.status_code == 200
+
+    # get the new version id
+    url_file = url_for(
+        'invenio_records_files.coll_bucket_api',
+        pid_value=collection.get('pid'), key=file_name)
+    res = client.get(url_file)
+    content = res.json.get('contents')
+
+    assert len(content) == 1
+    content = content.pop()
+    assert version_id != content.get('version_id')
+
+    # delete the file
+    url_delete_file_content = url_for(
+        'invenio_records_files.coll_object_api',
+        pid_value=collection.get('pid'), key=file_name)
+    res = client.delete(url_delete_file_content)
+    assert res.status_code == 204
+
+    # the file does not exists anymore
+    res = client.get(url_file_content)
+    assert res.status_code == 404
+
+    # the file does not exists anymore
+    url_file = url_for(
+        'invenio_records_files.coll_bucket_api',
+        pid_value=collection.get('pid'), key=file_name)
+    res = client.get(url_file)
+    assert res.status_code == 200
+    content = res.json.get('contents')
+    # fulltext, thumbnail: file has been removed
+    # TODO: is it the right approach? Do we need to remove files and
+    # the bucket?
+    assert len(content) == 0

--- a/tests/api/deposits/test_deposits_files_permissions.py
+++ b/tests/api/deposits/test_deposits_files_permissions.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2022 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test deposits files permissions."""
+
+
+from flask import url_for
+from flask_security import url_for_security
+from invenio_accounts.testutils import login_user_via_session
+
+
+def test_update_delete(client, superuser, admin, moderator,
+              submitter, user, deposit, pdf_file):
+    """Test permissions for uploading and deleting files."""
+    file_name = 'test.pdf'
+    users = [superuser, admin, moderator, submitter, user, None]
+
+    # upload the file
+    url_file_content = url_for(
+        'invenio_records_files.depo_object_api',
+        pid_value=deposit.get('pid'), key=file_name)
+    for u, status in zip(users, [200, 200, 200, 404, 404, 404]):
+        if u:
+            login_user_via_session(client, email=u['email'])
+        else:
+            client.get(url_for_security('logout'))
+        res = client.put(url_file_content, input_stream=open(pdf_file, 'rb'))
+        assert res.status_code == status
+        if status == 200:
+            # the delete return status is no content
+            status = 204
+            res = client.delete(url_file_content)
+            assert res.status_code == status
+
+
+def test_read_metadata(client, superuser, admin, moderator,
+              submitter, user, deposit):
+    """Test read files permissions."""
+
+    users = [superuser, admin, moderator, submitter, user, None]
+    url_files = url_for(
+        'invenio_records_files.depo_bucket_api',
+        pid_value=deposit.get('pid'))
+    for u, status in zip(users, [200, 200, 200, 404, 404, 404]):
+        if u:
+            login_user_via_session(client, email=u['email'])
+        else:
+            client.get(url_for_security('logout'))
+        res = client.get(url_files)
+        assert res.status_code == status
+
+
+def test_read_content(client, superuser, admin, moderator,
+              submitter, user, deposit):
+    """Test read deposits permissions."""
+
+    file_name = 'main.pdf'
+    users = [
+        superuser, admin, moderator, submitter, user, None]
+    url_file_content = url_for(
+        'invenio_records_files.depo_object_api',
+        pid_value=deposit.get('pid'),
+    key=file_name)
+    for u, status in zip(users, [200, 200, 200, 404, 404, 404]):
+        if u:
+            login_user_via_session(client, email=u['email'])
+        else:
+            client.get(url_for_security('logout'))
+        res = client.get(url_file_content)
+        assert res.status_code == status

--- a/tests/api/deposits/test_deposits_files_rest.py
+++ b/tests/api/deposits/test_deposits_files_rest.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2022 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test REST endpoint for deposits."""
+
+
+from flask import url_for
+
+
+def test_get_content(app, client, deposit):
+    """Test get existing file content."""
+    app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
+
+    file_name = 'main.pdf'
+
+    # get the pdf file
+    url_file_content = url_for(
+        'invenio_records_files.depo_object_api',
+        pid_value=deposit.get('pid'), key=file_name)
+    res = client.get(url_file_content)
+    assert res.status_code == 200
+    assert res.content_type == 'application/octet-stream'
+    assert res.content_length > 0
+
+
+def test_get_metadata(app, client, deposit):
+    """Test get existing file metadata."""
+    app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
+
+    # get all files metadata of a given deposit
+    url_files = url_for(
+        'invenio_records_files.depo_bucket_api',
+        pid_value=deposit.get('pid'))
+    res = client.get(url_files)
+    assert res.status_code == 200
+    file_keys = ['main.pdf', 'additional.pdf']
+    assert set(file_keys) == set(
+        [f.get('key') for f in res.json.get('contents')])
+
+    # get a specific file metadata of a given deposit
+    for f_key in file_keys:
+        url_file = url_for(
+            'invenio_records_files.depo_bucket_api',
+            pid_value=deposit.get('pid'), key=f_key)
+        res = client.get(url_file)
+        assert res.status_code == 200
+
+
+def test_put_delete(app, client, deposit, pdf_file):
+    """Test create and delete a file."""
+    app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
+    file_name = 'test.pdf'
+
+    # upload the file
+    url_file_content = url_for(
+        'invenio_records_files.depo_object_api', pid_value=deposit.get('pid'), key=file_name)
+    res = client.put(url_file_content, input_stream=open(pdf_file, 'rb'))
+    assert res.status_code == 200
+
+    # get the version id
+    url_file = url_for(
+        'invenio_records_files.depo_bucket_api',
+        pid_value=deposit.get('pid'), key=file_name)
+    res = client.get(url_file)
+    content = res.json.get('contents')
+
+    assert len(content) == 3
+    content = content.pop()
+    version_id = content.get('version_id')
+
+    # upload a second version
+    url_file_content = url_for(
+        'invenio_records_files.depo_object_api', pid_value=deposit.get('pid'), key=file_name)
+    res = client.put(url_file_content, input_stream=open(pdf_file, 'rb'))
+    assert res.status_code == 200
+
+    # get the new version id
+    url_file = url_for(
+        'invenio_records_files.depo_bucket_api',
+        pid_value=deposit.get('pid'), key=file_name)
+    res = client.get(url_file)
+    content = res.json.get('contents')
+
+    assert len(content) == 3
+    content = content.pop()
+    assert version_id != content.get('version_id')
+
+    # delete the file
+    url_delete_file_content = url_for(
+        'invenio_records_files.depo_object_api',
+        pid_value=deposit.get('pid'), key=file_name)
+    res = client.delete(url_delete_file_content)
+    assert res.status_code == 204
+
+    # the file does not exists anymore
+    res = client.get(url_file_content)
+    assert res.status_code == 404
+
+    # the file does not exists anymore
+    url_file = url_for(
+        'invenio_records_files.depo_bucket_api',
+        pid_value=deposit.get('pid'), key=file_name)
+    res = client.get(url_file)
+    assert res.status_code == 200
+    content = res.json.get('contents')
+    # fulltext, thumbnail: file has been removed
+    # TODO: is it the right approach? Do we need to remove files and
+    # the bucket?
+    assert len(content) == 2

--- a/tests/api/documents/test_documents_files_permissions.py
+++ b/tests/api/documents/test_documents_files_permissions.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2022 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test documents files permissions."""
+
+
+from flask import url_for
+from flask_security import url_for_security
+from invenio_accounts.testutils import login_user_via_session
+
+
+def test_update_delete(client, superuser, admin, moderator,
+              submitter, user, document, pdf_file):
+    """Test permissions for uploading and deleting files."""
+    file_name = 'test.pdf'
+    users = [superuser, admin, moderator, submitter, user, None]
+
+    # upload the file
+    url_file_content = url_for(
+        'invenio_records_files.doc_object_api', pid_value=document.get('pid'), key=file_name)
+    for u, status in zip(users, [200, 200, 200, 404, 404, 404]):
+        if u:
+            login_user_via_session(client, email=u['email'])
+        else:
+            client.get(url_for_security('logout'))
+        res = client.put(url_file_content, input_stream=open(pdf_file, 'rb'))
+        assert res.status_code == status
+        if status == 200:
+            # the delete return status is no content
+            status = 204
+            res = client.delete(url_file_content)
+            assert res.status_code == status
+
+
+
+def test_read_metadata(client, superuser, admin, moderator,
+              submitter, user, document_with_file):
+    """Test read files permissions."""
+
+    users = [superuser, admin, moderator, submitter, user, None]
+    url_files = url_for(
+        'invenio_records_files.doc_bucket_api',
+        pid_value=document_with_file.get('pid'))
+    for u, status in zip(users, [200, 200, 200, 200, 200, 200]):
+        if u:
+            login_user_via_session(client, email=u['email'])
+        else:
+            client.get(url_for_security('logout'))
+        res = client.get(url_files)
+        assert res.status_code == status
+
+    # Masked document
+    document_with_file['masked'] = 'masked_for_all'
+    document_with_file.commit()
+    for u, status in zip(users, [200, 200, 200, 404, 404, 404]):
+        if u:
+            login_user_via_session(client, email=u['email'])
+        else:
+            client.get(url_for_security('logout'))
+        res = client.get(url_files)
+        assert res.status_code == status
+
+def test_read_content(client, superuser, admin, moderator,
+              submitter, user, user_without_org, document_with_file):
+    """Test read documents permissions."""
+
+    file_name = 'test1.pdf'
+    users = [
+        superuser, admin, moderator, submitter, user, user_without_org, None]
+    url_file_content = url_for(
+        'invenio_records_files.doc_object_api',
+        pid_value=document_with_file.get('pid'),
+    key=file_name)
+    open_access_code = "coar:c_abf2"
+    document_with_file.files[file_name]['access'] = open_access_code
+    document_with_file.commit()
+    for u, status in zip(users, [200, 200, 200, 200, 200, 200, 200]):
+        if u:
+            login_user_via_session(client, email=u['email'])
+        else:
+            client.get(url_for_security('logout'))
+        res = client.get(url_file_content)
+        assert res.status_code == status
+    # Masked document
+    document_with_file['masked'] = 'masked_for_all'
+    document_with_file.commit()
+    for u, status in zip(users, [200, 200, 200, 404, 404, 404, 404]):
+        if u:
+            login_user_via_session(client, email=u['email'])
+        else:
+            client.get(url_for_security('logout'))
+        res = client.get(url_file_content)
+        assert res.status_code == status
+
+    del document_with_file['masked']
+
+    # restricted files
+    restricted_code = "coar:c_16ec"
+    document_with_file.files[file_name]['access'] = restricted_code
+    document_with_file.files[file_name]['restricted_outside_organisation'] = True
+    document_with_file.commit()
+    for u, status in zip(users, [200, 200, 200, 200, 200, 404, 404]):
+        if u:
+            login_user_via_session(client, email=u['email'])
+        else:
+            client.get(url_for_security('logout'))
+        res = client.get(url_file_content)
+        assert res.status_code == status

--- a/tests/api/documents/test_documents_files_rest.py
+++ b/tests/api/documents/test_documents_files_rest.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2022 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test REST endpoint for documents."""
+
+
+from flask import url_for
+
+
+def test_get_content(app, client, document_with_file):
+    """Test get existing file content."""
+    app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
+
+    file_name = 'test1.pdf'
+    fulltext_file_name = 'test1-pdf.txt'
+    thumbnail_file_name = 'test1-pdf.jpg'
+
+    # get the pdf file
+    url_file_content = url_for('invenio_records_files.doc_object_api', pid_value=document_with_file.get('pid'), key=file_name)
+    res = client.get(url_file_content)
+    assert res.status_code == 200
+    assert res.content_type == 'application/octet-stream'
+    assert res.content_length > 0
+
+    url_file_content = url_for('invenio_records_files.doc_object_api', pid_value=document_with_file.get('pid'), key=fulltext_file_name)
+    res = client.get(url_file_content)
+    assert res.status_code == 200
+    assert res.content_type == 'text/plain; charset=utf-8'
+    assert res.content_length > 0
+
+    url_file_content = url_for('invenio_records_files.doc_object_api', pid_value=document_with_file.get('pid'), key=thumbnail_file_name)
+    res = client.get(url_file_content)
+    assert res.status_code == 200
+    assert res.content_type == 'image/jpeg'
+    assert res.content_length > 0
+
+def test_get_metadata(app, client, document_with_file):
+    """Test get existing file metadata."""
+    app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
+
+    # get all files metadata of a given document
+    url_files = url_for(
+        'invenio_records_files.doc_bucket_api',
+        pid_value=document_with_file.get('pid'))
+    res = client.get(url_files)
+    assert res.status_code == 200
+    file_keys = ['test1.pdf', 'test1-pdf.txt', 'test1-pdf.jpg']
+    assert set(file_keys) == set(
+        [f.get('key') for f in res.json.get('contents')])
+
+    # get a specific file metadata of a given document
+    for f_key in file_keys:
+        url_file = url_for(
+            'invenio_records_files.doc_bucket_api',
+            pid_value=document_with_file.get('pid'), key=f_key)
+        res = client.get(url_file)
+        assert res.status_code == 200
+
+
+def test_put_delete(app, client, document, pdf_file):
+    """Test create and delete a file."""
+    app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
+    file_name = 'test.pdf'
+
+    # upload the file
+    url_file_content = url_for(
+        'invenio_records_files.doc_object_api', pid_value=document.get('pid'), key=file_name)
+    res = client.put(url_file_content, input_stream=open(pdf_file, 'rb'))
+    assert res.status_code == 200
+
+    # get the version id
+    url_file = url_for(
+        'invenio_records_files.doc_bucket_api',
+        pid_value=document.get('pid'), key=file_name)
+    res = client.get(url_file)
+    content = res.json.get('contents')
+
+    # file, fulltext, thumbnail
+    assert len(content) == 3
+    content = content.pop()
+    version_id = content.get('version_id')
+
+    # upload a second version
+    url_file_content = url_for(
+        'invenio_records_files.doc_object_api', pid_value=document.get('pid'), key=file_name)
+    res = client.put(url_file_content, input_stream=open(pdf_file, 'rb'))
+    assert res.status_code == 200
+
+    # get the new version id
+    url_file = url_for(
+        'invenio_records_files.doc_bucket_api',
+        pid_value=document.get('pid'), key=file_name)
+    res = client.get(url_file)
+    content = res.json.get('contents')
+
+    # file, fulltext, thumbnail
+    assert len(content) == 3
+    content = content.pop()
+    assert version_id != content.get('version_id')
+
+    # delete the file
+    url_delete_file_content = url_for(
+        'invenio_records_files.doc_object_api', pid_value=document.get('pid'), key=file_name)
+    res = client.delete(url_delete_file_content)
+    assert res.status_code == 204
+
+    # the file does not exists anymore
+    res = client.get(url_file_content)
+    assert res.status_code == 404
+
+    # the file does not exists anymore
+    url_file = url_for(
+        'invenio_records_files.doc_bucket_api',
+        pid_value=document.get('pid'), key=file_name)
+    res = client.get(url_file)
+    assert res.status_code == 200
+    content = res.json.get('contents')
+    # fulltext, thumbnail: file has been removed
+    # TODO: is it the right approach? Do we need to remove files and
+    # the bucket?
+    assert len(content) == 2

--- a/tests/api/organisations/test_organisations_files_permissions.py
+++ b/tests/api/organisations/test_organisations_files_permissions.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2022 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test organisations files permissions."""
+
+
+from flask import url_for
+from flask_security import url_for_security
+from invenio_accounts.testutils import login_user_via_session
+
+
+def test_update_delete(client, superuser, admin, moderator,
+              submitter, user, organisation, pdf_file):
+    """Test permissions for uploading and deleting files."""
+    file_name = 'test.pdf'
+    users = [superuser, admin, moderator, submitter, user, None]
+
+    # upload the file
+    url_file_content = url_for(
+        'invenio_records_files.org_object_api',
+        pid_value=organisation.get('pid'), key=file_name)
+    for u, status in zip(users, [200, 200, 404, 404, 404, 404]):
+        if u:
+            login_user_via_session(client, email=u['email'])
+        else:
+            client.get(url_for_security('logout'))
+        res = client.put(url_file_content, input_stream=open(pdf_file, 'rb'))
+        assert res.status_code == status
+        if status == 200:
+            # the delete return status is no content
+            status = 204
+            res = client.delete(url_file_content)
+            assert res.status_code == status
+
+
+def test_read_metadata(client, superuser, admin, moderator,
+              submitter, user, organisation_with_file):
+    """Test read files permissions."""
+
+    users = [superuser, admin, moderator, submitter, user, None]
+    url_files = url_for(
+        'invenio_records_files.org_bucket_api',
+        pid_value=organisation_with_file.get('pid'))
+    for u, status in zip(users, [200, 200, 200, 200, 200, 200]):
+        if u:
+            login_user_via_session(client, email=u['email'])
+        else:
+            client.get(url_for_security('logout'))
+        res = client.get(url_files)
+        assert res.status_code == status
+
+
+def test_read_content(client, superuser, admin, moderator,
+              submitter, user, organisation_with_file):
+    """Test read organisations permissions."""
+
+    file_name = 'test1.pdf'
+    users = [
+        superuser, admin, moderator, submitter, user, None]
+    url_file_content = url_for(
+        'invenio_records_files.org_object_api',
+        pid_value=organisation_with_file.get('pid'),
+    key=file_name)
+    for u, status in zip(users, [200, 200, 200, 200, 200, 200]):
+        if u:
+            login_user_via_session(client, email=u['email'])
+        else:
+            client.get(url_for_security('logout'))
+        res = client.get(url_file_content)
+        assert res.status_code == status

--- a/tests/api/organisations/test_organisations_files_rest.py
+++ b/tests/api/organisations/test_organisations_files_rest.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2022 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test REST endpoint for organisations."""
+
+
+from flask import url_for
+
+
+def test_get_content(app, client, organisation_with_file):
+    """Test get existing file content."""
+    app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
+
+    file_name = 'test1.pdf'
+
+    # get the pdf file
+    url_file_content = url_for(
+        'invenio_records_files.org_object_api',
+        pid_value=organisation_with_file.get('pid'), key=file_name)
+    res = client.get(url_file_content)
+    assert res.status_code == 200
+    assert res.content_type == 'application/octet-stream'
+    assert res.content_length > 0
+
+
+def test_get_metadata(app, client, organisation_with_file):
+    """Test get existing file metadata."""
+    app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
+
+    # get all files metadata of a given organisation
+    url_files = url_for(
+        'invenio_records_files.org_bucket_api',
+        pid_value=organisation_with_file.get('pid'))
+    res = client.get(url_files)
+    assert res.status_code == 200
+    file_keys = ['test1.pdf']
+    assert set(file_keys) == set(
+        [f.get('key') for f in res.json.get('contents')])
+
+    # get a specific file metadata of a given organisation
+    for f_key in file_keys:
+        url_file = url_for(
+            'invenio_records_files.org_bucket_api',
+            pid_value=organisation_with_file.get('pid'), key=f_key)
+        res = client.get(url_file)
+        assert res.status_code == 200
+
+
+def test_put_delete(app, client, organisation, pdf_file):
+    """Test create and delete a file."""
+    app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
+    file_name = 'test.pdf'
+
+    # upload the file
+    url_file_content = url_for(
+        'invenio_records_files.org_object_api', pid_value=organisation.get('pid'), key=file_name)
+    res = client.put(url_file_content, input_stream=open(pdf_file, 'rb'))
+    assert res.status_code == 200
+
+    # get the version id
+    url_file = url_for(
+        'invenio_records_files.org_bucket_api',
+        pid_value=organisation.get('pid'), key=file_name)
+    res = client.get(url_file)
+    content = res.json.get('contents')
+
+    assert len(content) == 1
+    content = content.pop()
+    version_id = content.get('version_id')
+
+    # upload a second version
+    url_file_content = url_for(
+        'invenio_records_files.org_object_api', pid_value=organisation.get('pid'), key=file_name)
+    res = client.put(url_file_content, input_stream=open(pdf_file, 'rb'))
+    assert res.status_code == 200
+
+    # get the new version id
+    url_file = url_for(
+        'invenio_records_files.org_bucket_api',
+        pid_value=organisation.get('pid'), key=file_name)
+    res = client.get(url_file)
+    content = res.json.get('contents')
+
+    assert len(content) == 1
+    content = content.pop()
+    assert version_id != content.get('version_id')
+
+    # delete the file
+    url_delete_file_content = url_for(
+        'invenio_records_files.org_object_api',
+        pid_value=organisation.get('pid'), key=file_name)
+    res = client.delete(url_delete_file_content)
+    assert res.status_code == 204
+
+    # the file does not exists anymore
+    res = client.get(url_file_content)
+    assert res.status_code == 404
+
+    # the file does not exists anymore
+    url_file = url_for(
+        'invenio_records_files.org_bucket_api',
+        pid_value=organisation.get('pid'), key=file_name)
+    res = client.get(url_file)
+    assert res.status_code == 200
+    content = res.json.get('contents')
+    # fulltext, thumbnail: file has been removed
+    # TODO: is it the right approach? Do we need to remove files and
+    # the bucket?
+    assert len(content) == 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,6 +164,15 @@ def organisation(make_organisation):
     """Create an organisation."""
     return make_organisation('org')
 
+@pytest.fixture()
+def organisation_with_file(organisation, pdf_file):
+    """Create an organisation with a file attached."""
+    with open(pdf_file, 'rb') as file:
+        organisation.add_file(file.read(),
+            'test1.pdf'
+        )
+        organisation.commit()
+    return organisation
 
 @pytest.fixture()
 def roles(base_app, db):
@@ -254,6 +263,12 @@ def user_without_role(app, db):
     db.session.commit()
 
     return user
+
+
+@pytest.fixture()
+def user_without_org(make_user):
+    """Create user without organisation."""
+    return make_user('user', None)
 
 
 @pytest.fixture()
@@ -847,6 +862,17 @@ def collection(app, db, es, admin, organisation, collection_json):
     collection.commit()
     collection.reindex()
     db.session.commit()
+    return collection
+
+
+@pytest.fixture()
+def collection_with_file(collection, pdf_file):
+    """Create a collection with a file attached."""
+    with open(pdf_file, 'rb') as file:
+        collection.add_file(file.read(),
+            'test1.pdf'
+        )
+        collection.commit()
     return collection
 
 

--- a/tests/ui/collections/test_collections_view_permissions.py
+++ b/tests/ui/collections/test_collections_view_permissions.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2022 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test collections files permissions."""
+
+
+from flask import url_for
+from flask_security import url_for_security
+from invenio_accounts.testutils import login_user_via_session
+
+
+def test_read(client, superuser, admin, moderator,
+              submitter, user, collection_with_file):
+    """Test read collections permissions."""
+
+    file_name = 'test1.pdf'
+    users = [
+        superuser, admin, moderator, submitter, user, None]
+    url_file_content = url_for(
+        'invenio_records_ui.coll_files',
+        pid_value=collection_with_file.get('pid'),
+        filename=file_name)
+    for u, status in zip(users, [200, 200, 200, 200, 200, 200]):
+        if u:
+            login_user_via_session(client, email=u['email'])
+        else:
+            client.get(url_for_security('logout'))
+        res = client.get(url_file_content)
+        assert res.status_code == status

--- a/tests/ui/deposits/test_deposits_view_permissions.py
+++ b/tests/ui/deposits/test_deposits_view_permissions.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2022 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test deposits files permissions."""
+
+
+from flask import url_for
+from flask_security import url_for_security
+from invenio_accounts.testutils import login_user_via_session
+
+
+def test_read(client, superuser, admin, moderator,
+              submitter, user, deposit):
+    """Test read deposits permissions."""
+
+    file_name = 'main.pdf'
+    users = [
+        superuser, admin, moderator, submitter, user, None]
+    url_file_content = url_for(
+        'invenio_records_ui.depo_files',
+        pid_value=deposit.get('pid'),
+        filename=file_name)
+    for u, status in zip(users, [200, 200, 200, 404, 404, 404]):
+        if u:
+            login_user_via_session(client, email=u['email'])
+        else:
+            client.get(url_for_security('logout'))
+        res = client.get(url_file_content)
+        assert res.status_code == status

--- a/tests/ui/documents/test_documents_view_permissions.py
+++ b/tests/ui/documents/test_documents_view_permissions.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2022 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test documents files permissions."""
+
+
+from flask import url_for
+from flask_security import url_for_security
+from invenio_accounts.testutils import login_user_via_session
+
+
+def test_read(client, superuser, admin, moderator,
+              submitter, user, user_without_org, document_with_file):
+    """Test read documents permissions."""
+
+    file_name = 'test1.pdf'
+    users = [
+        superuser, admin, moderator, submitter, user, user_without_org, None]
+    url_file_content = url_for(
+        'invenio_records_ui.doc_files',
+        pid_value=document_with_file.get('pid'),
+        filename=file_name)
+    open_access_code = "coar:c_abf2"
+    document_with_file.files[file_name]['access'] = open_access_code
+    document_with_file.commit()
+    for u, status in zip(users, [200, 200, 200, 200, 200, 200, 200]):
+        if u:
+            login_user_via_session(client, email=u['email'])
+        else:
+            client.get(url_for_security('logout'))
+        res = client.get(url_file_content)
+        assert res.status_code == status
+    # Masked document
+    document_with_file['masked'] = 'masked_for_all'
+    document_with_file.commit()
+    for u, status in zip(users, [200, 200, 200, 404, 404, 404, 404]):
+        if u:
+            login_user_via_session(client, email=u['email'])
+        else:
+            client.get(url_for_security('logout'))
+        res = client.get(url_file_content)
+        assert res.status_code == status
+
+    del document_with_file['masked']
+
+    # restricted files
+    restricted_code = "coar:c_16ec"
+    document_with_file.files[file_name]['access'] = restricted_code
+    document_with_file.files[file_name]['restricted_outside_organisation'] = True
+    document_with_file.commit()
+    for u, status in zip(users, [200, 200, 200, 200, 200, 404, 404]):
+        if u:
+            login_user_via_session(client, email=u['email'])
+        else:
+            client.get(url_for_security('logout'))
+        res = client.get(url_file_content)
+        assert res.status_code == status

--- a/tests/ui/organisations/test_organisations_view_permissions.py
+++ b/tests/ui/organisations/test_organisations_view_permissions.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2022 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test organisations files permissions."""
+
+
+from flask import url_for
+from flask_security import url_for_security
+from invenio_accounts.testutils import login_user_via_session
+
+
+def test_read(client, superuser, admin, moderator,
+              submitter, user, organisation_with_file):
+    """Test read organisations permissions."""
+
+    file_name = 'test1.pdf'
+    users = [
+        superuser, admin, moderator, submitter, user, None]
+    url_file_content = url_for(
+        'invenio_records_ui.org_files',
+        pid_value=organisation_with_file.get('pid'),
+        filename=file_name)
+    for u, status in zip(users, [200, 200, 200, 200, 200, 200]):
+        if u:
+            login_user_via_session(client, email=u['email'])
+        else:
+            client.get(url_for_security('logout'))
+        res = client.get(url_file_content)
+        assert res.status_code == status

--- a/tests/ui/test_permissions.py
+++ b/tests/ui/test_permissions.py
@@ -159,14 +159,14 @@ def test_unknown_permission_factory(app, client, superuser, document):
     assert not record_permission_factory(document, 'unknown').can()
 
 
-def test_files_permission_factory(app, client, admin):
+def test_files_permission_factory(app, client, superuser):
     """Test files permission factory."""
     app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
-    assert files_permission_factory().can()
+    assert files_permission_factory(None, 'object-read').can()
 
     app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=False)
-    login_user_via_view(client, email=admin['email'], password='123456')
-    assert files_permission_factory().can()
+    login_user_via_view(client, email=superuser['email'], password='123456')
+    assert files_permission_factory(None, 'object-read').can()
 
 
 def test_admin_permission_factory(app, client, superuser):

--- a/tests/ui/test_views.py
+++ b/tests/ui/test_views.py
@@ -228,22 +228,29 @@ def test_profile(client, user):
     assert res.status_code == 403
 
 
-def test_record_image_url():
+def test_record_image_url(client):
     """Test getting record image url."""
     # No file key
-    assert not record_image_url({})
+    assert not record_image_url({}, 'org')
 
     # No files
-    assert not record_image_url({'_files': []})
+    assert not record_image_url({'_files': []}, 'org')
 
     # No images
-    assert not record_image_url(
-        {'_files': [{
+    assert not record_image_url({'_files': [{
             'bucket': '1234',
             'key': 'test.pdf'
-        }]})
+        }]}, 'org')
+
+    # No pid
+    assert not record_image_url({
+        '_files': [{
+            'bucket': '1234',
+            'key': 'test.pdf'
+        }]}, 'org')
 
     record = {
+        'pid': '1',
         '_files': [{
             'bucket': '1234',
             'key': 'test.jpg'
@@ -254,10 +261,11 @@ def test_record_image_url():
     }
 
     # Take the first file
-    assert record_image_url(record) == '/api/files/1234/test.jpg'
+    assert record_image_url(record, 'org') == '/organisations/1/files/test.jpg'
 
     # Take files corresponding to key
-    assert record_image_url(record, 'test2.jpg') == '/api/files/1234/test2.jpg'
+    assert record_image_url(record, 'org', 'test2.jpg') == \
+        '/organisations/1/files/test2.jpg'
 
 
 def test_rerodoc_redirection(client, document):


### PR DESCRIPTION
* Adds files restriction for documents.
* Adds files restriction for deposits.
* Adds files restriction for organisations.
* Adds files restriction for collections.
* Fixes document restrictions.
* Closes rero#746.

Signed-off-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Closes rero#746.

## How to test?

- As the permission has been touched it is important to test to upload files for document, deposit, organisation and collection with several roles.
- Try to read a file url for a deposit for an anonymous user.
- Try to read restricted files, embargo files and masked document.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
