### PR TITLE
organisation: custom facet implementation for dedicated customers

### DIFF
--- a/sonar/config.py
+++ b/sonar/config.py
@@ -233,7 +233,8 @@ APP_DEFAULT_SECURE_HEADERS = {
         ],
         'style-src': [
             "'self'", "'unsafe-inline'", 'https://cdnjs.cloudflare.com',
-            'https://fonts.googleapis.com'
+            'https://fonts.googleapis.com',
+            'https://maxcdn.bootstrapcdn.com'
         ],
         'font-src': [
             "'self'", "data:", "blob:", "'unsafe-inline'",

--- a/sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json
+++ b/sonar/modules/organisations/jsonschemas/organisations/organisation-v1.0.0_src.json
@@ -312,6 +312,67 @@
         "hideExpression": "!field.parent.model.isDedicated"
       }
     },
+    "publicDocumentFacets": {
+      "title": "Visible facets in the public interface for documents",
+      "type":"array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "document_type",
+          "controlled_affiliation",
+          "year",
+          "collection",
+          "language",
+          "author",
+          "subject",
+          "subdivision"
+        ]
+      },
+      "form": {
+        "type": "multicheckbox",
+        "templateOptions": {
+          "type": "array",
+          "wrappers": [],
+          "translate": true,
+          "options": [
+            {
+              "label": "document_type",
+              "value": "document_type"
+            },
+            {
+              "label": "controlled_affiliation",
+              "value": "controlled_affiliation"
+            },
+            {
+              "label": "year",
+              "value": "year"
+            },
+            {
+              "label": "collection",
+              "value": "collection"
+            },
+            {
+              "label": "language",
+              "value": "language"
+            },
+            {
+              "label": "author",
+              "value": "author"
+            },
+            {
+              "label": "subject",
+              "value": "subject"
+            },
+            {
+              "label": "subdivision",
+              "value": "subdivision"
+            }
+          ]
+        },
+        "hideExpression": "!field.parent.model.isDedicated"
+      }
+    },
     "_bucket": {
       "title": "Bucket UUID",
       "type": "string",
@@ -384,7 +445,8 @@
     "platformName",
     "documentsCustomField1",
     "documentsCustomField2",
-    "documentsCustomField3"
+    "documentsCustomField3",
+    "publicDocumentFacets"
   ],
   "required": [
     "pid",

--- a/sonar/modules/organisations/mappings/v7/organisations/organisation-v1.0.0.json
+++ b/sonar/modules/organisations/mappings/v7/organisations/organisation-v1.0.0.json
@@ -117,6 +117,10 @@
           }
         }
       },
+      "publicDocumentFacets": {
+        "type": "keyword",
+        "index": false
+      },
       "_created": {
         "type": "date"
       },

--- a/sonar/modules/organisations/marshmallow/json.py
+++ b/sonar/modules/organisations/marshmallow/json.py
@@ -52,6 +52,7 @@ class OrganisationMetadataSchemaV1(StrictKeysMixin):
     documentsCustomField1 = fields.Dict()
     documentsCustomField2 = fields.Dict()
     documentsCustomField3 = fields.Dict()
+    publicDocumentFacets = fields.List(fields.String())
     # When loading, if $schema is not provided, it's retrieved by
     # Record.schema property.
     schema = GenFunction(load_only=True,

--- a/sonar/modules/organisations/serializers/schemas/export.py
+++ b/sonar/modules/organisations/serializers/schemas/export.py
@@ -35,6 +35,7 @@ class ExportSchemaV1(Schema):
     documentsCustomField1 = fields.Dict(dump_only=True)
     documentsCustomField2 = fields.Dict(dump_only=True)
     documentsCustomField3 = fields.Dict(dump_only=True)
+    publicDocumentFacets = fields.List(fields.String(dump_only=True))
 
     def get_files(self, obj):
         """Get files."""


### PR DESCRIPTION
* updates security policy to allow maxcdn.bootstrapcdn.com.
* closes rero#702.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

⚠️  **Update ES mapping with the new field in documents**

## Dependency
- Sonar ui: https://github.com/rero/sonar-ui/pull/281

## How to test

- Login with a super user
- Go to the administration interface
- Administration menu > Organization
- Edit a dedicated organization
- Select the desired facets (at the bottom of the window)
- Check on the public interface

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
