### PR TITLE
organisations: favicon and platform name

### DIFF
--- a/sonar/modules/collections/views.py
+++ b/sonar/modules/collections/views.py
@@ -43,7 +43,8 @@ def index(**kwargs):
     records = RecordSearch().filter('term',
                                     organisation__pid=kwargs['view']).scan()
 
-    return render_template('collections/index.html', records=list(records))
+    return render_template(
+        'collections/index.html', records=list(records), view=kwargs['view'])
 
 
 def detail(pid, record, **kwargs):

--- a/sonar/modules/organisations/utils.py
+++ b/sonar/modules/organisations/utils.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2022 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Utils functions for organisations module."""
+
+import markdown
+from bs4 import BeautifulSoup
+
+
+def platform_name(organisation):
+    """Get platform name."""
+    platform_name = organisation.get('platformName')
+    if platform_name:
+        html = markdown.markdown(platform_name)
+        return ''.join(
+            BeautifulSoup(html).findAll(text=True)).replace('\n', ' - ')

--- a/sonar/modules/users/utils.py
+++ b/sonar/modules/users/utils.py
@@ -17,12 +17,11 @@
 
 """Utils functions for user module."""
 
-import markdown
-from bs4 import BeautifulSoup
 from flask_babelex import _
 from flask_security import url_for_security
 from flask_security.recoverable import generate_reset_password_token
 
+from sonar.modules.organisations.utils import platform_name
 from sonar.modules.utils import send_email
 
 
@@ -35,11 +34,9 @@ def send_welcome_email(user_record, user):
     user_record = user_record.replace_refs()
     code = user_record['organisation'].get('code', '')
     plain_platform_name = 'SONAR'
-    platform_name = user_record['organisation'].get('platformName')
-    if platform_name:
-        html = markdown.markdown(platform_name)
-        plain_platform_name = ''.join(
-            BeautifulSoup(html).findAll(text=True)).replace('\n', ' - ')
+    pname = platform_name(user_record['organisation'])
+    if pname:
+        plain_platform_name = pname
 
     token = generate_reset_password_token(user)
     reset_link = url_for_security(

--- a/sonar/theme/templates/sonar/page.html
+++ b/sonar/theme/templates/sonar/page.html
@@ -18,7 +18,6 @@ along with this program. If not, see
 
 {% set page = page|default('int') %}
 {% set description = _('The SONAR project aims to create a scholarly archive that collects, promotes and preserves the publications of authors affiliated with Swiss public research institutions.') %}
-
 <!DOCTYPE html>
 <html {% if html_css_classes %} class="{{ html_css_classes|join(' ') }}" {% endif %}
   lang="{{ current_i18n.locale.language|safe }}" dir="{{ current_i18n.locale.text_direction }}"
@@ -47,11 +46,25 @@ along with this program. If not, see
   {%- endblock head_meta %}
 
   {%- block head_title %}
-  {%- set title = title or _(config.THEME_SITENAME) or _('Invenio') %}
+  {# Platform name if defined on the organisation #}
+  {%- if  g.organisation and config.SONAR_APP_DEFAULT_ORGANISATION != view %}
+    {%- if title %}
+    {%- set title = title ~ ' | ' ~  g.organisation|organisation_platform_name %}
+    {%- else %}
+    {%- set title = g.organisation|organisation_platform_name %}
+    {%- endif %}
+  {%- else %}
+    {%- set title = title or _(config.THEME_SITENAME) or _('Invenio') %}
+  {%- endif %}
   <title>{{ title }}</title>
   {%- endblock head_title %}
 
   {%- block head_links %}
+  {# show favicon only for dedicated organisation #}
+  {%- set favicon = g.organisation|favicon if g.organisation and g.organisation['isDedicated'] %}
+  {%- if favicon %}
+  <link rel="icon" type="{{ favicon.mimetype }}" href="{{ favicon.url }}">
+  {%- else %}
   <meta name="msapplication-TileColor" content="#ffffff">
   <meta name="msapplication-TileImage" content="/static/ms-icon-144x144.png">
   <meta name="theme-color" content="#ffffff">
@@ -69,10 +82,11 @@ along with this program. If not, see
   <link rel="icon" type="image/png" sizes="96x96" href="/static/favicon-96x96.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/static/favicon-16x16.png">
   <link rel="manifest" href="/static/manifest.json">
+  {%- endif %}
 
   {%- if canonical_url %}
   <link rel="canonical" href="{{ canonical_url }}">
-  {% endif %}
+  {%- endif %}
 
   {%- block head_links_langs %}
   {%- if alternate_urls %}

--- a/tests/unit/organisations/test_organisations_utils.py
+++ b/tests/unit/organisations/test_organisations_utils.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2022 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test organisations utils."""
+
+from sonar.modules.organisations.utils import platform_name
+
+
+def test_platform_name():
+    """Test transformation of platform name."""
+    organisation = {
+        'platformName': '#SiteName\n##Platform'
+    }
+    assert 'SiteName - Platform' == platform_name(organisation)


### PR DESCRIPTION
* Adds the display of the custom favicon for current organisation.
* Adds the organization's platform name to the browser tab.
* Closes #705.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>


## How to test
- Upload favicon.ico to organisation files.
- Check the organisation favicon and name in browser tab.

![favicon_file](https://user-images.githubusercontent.com/48578/152999210-3de39504-e335-4db7-b4d4-0bca0b4debf9.png)

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
