### PR TITLE
celery: add dotenv support

### DIFF
--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -100,7 +100,7 @@ services:
       file: docker-services.yml
       service: app
     restart: "unless-stopped"
-    command: ["celery --app invenio_app.celery worker --loglevel=INFO"]
+    command: ["celery --app sonar.celery worker --loglevel=INFO"]
     image: sonar
     links:
       - cache

--- a/scripts/server
+++ b/scripts/server
@@ -34,7 +34,7 @@ export FLASK_ENV=development
 
 # Start Worker and Server
 section "Start celery worker" "info"
-celery --app invenio_app.celery worker --loglevel INFO --beat & pid_celery=$!
+celery --app sonar.celery worker --loglevel INFO --beat & pid_celery=$!
 message "Done" "success"
 
 # Start web server

--- a/scripts/setup
+++ b/scripts/setup
@@ -62,9 +62,12 @@ if $import; then
     message "Size of import sets is set to \"$size\"" "info"
 fi
 
+# Try to create database and tables if does not exists
+invenio db init create || true
+
 # Purge celery
 section "Purge celery tasks" "info"
-celery --app invenio_app.celery purge -f
+celery --app sonar.celery purge -f
 
 # Clean redis
 section "Clear redis cache" "info"
@@ -76,7 +79,6 @@ if [ $clear_data = false ]; then
     invenio utils export --pid-type org --output-dir "${fixtures_folder}/organisations"
     invenio utils export --pid-type user --output-dir "${fixtures_folder}/users"
 fi
-
 section "Clear files" "info"
 invenio utils clear-files
 

--- a/sonar/celery.py
+++ b/sonar/celery.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2022 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Celery application for Invenio flavours."""
+
+from __future__ import absolute_import, print_function
+
+from dotenv import load_dotenv
+from flask_celeryext import create_celery_app
+from invenio_app.factory import create_ui
+
+# load .env and .flaskenv
+load_dotenv()
+
+celery = create_celery_app(create_ui(
+    SENTRY_TRANSPORT='raven.transport.http.HTTPTransport',
+    RATELIMIT_ENABLED=False,
+))
+"""Celery application for Invenio.
+Overrides SENTRY_TRANSPORT wih synchronous HTTP transport since Celery does not
+deal nicely with the default threaded transport.
+"""
+
+# Trigger an app log message upon import. This makes Sentry logging
+# work with `get_task_logger(__name__)`.
+celery.flask_app.logger.info('Created Celery app')


### PR DESCRIPTION
* Adds dotenv support to celery to make the worker working with a custom
  celery backend from `invenio.cfg`.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
