### PR TITLE
documents: remove organisation tag

### DIFF
--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -67,18 +67,26 @@ along with this program. If not, see
     </div>
     <div class="col">
       <h1 class="text-primary">{{ title | nl2br | safe }}</h1>
+      {% set infoOrgSub = true %}
+      {%- if view != config.SONAR_APP_DEFAULT_ORGANISATION %}
+        {% set infoOrgSub = false if record.get('subdivisions', [])|length == 0 else true %}
+      {%- endif %}
+      {%- if infoOrgSub %}
       <h4 class="m-0">
-        {%- for organisation in record.get('organisation', []) -%}
-        <span class="badge badge-secondary text-light mr-1 font-weight-normal">
-          {{ organisation.name }}
-        </span>
-        {%- endfor -%}
+        {%- if view == config.SONAR_APP_DEFAULT_ORGANISATION %}
+          {%- for organisation in record.get('organisation', []) -%}
+          <span class="badge badge-secondary text-light mr-1 font-weight-normal">
+            {{ organisation.name }}
+          </span>
+          {%- endfor -%}
+        {%- endif %}
         {%- for subdivision in record.get('subdivisions', []) -%}
         <span class="badge badge-secondary text-light mr-1 font-weight-normal">
           {{ subdivision.name | language_value }}
         </span>
         {%- endfor -%}
       </h4>
+      {%- endif %}
 
       <!-- CONTRIBUTORS-->
       {% set contributors = record | contributors %}

--- a/sonar/modules/documents/views.py
+++ b/sonar/modules/documents/views.py
@@ -56,7 +56,8 @@ def search(view):
         collection = CollectionRecord.get_record_by_pid(
             request.args['collection_view'])
 
-    return render_template('sonar/search.html', collection=collection)
+    return render_template('sonar/search.html',
+                           collection=collection, view=view)
 
 
 def detail(pid, record, template=None, **kwargs):
@@ -107,6 +108,7 @@ def detail(pid, record, template=None, **kwargs):
     return render_template(template,
                            pid=pid,
                            record=record,
+                           view=kwargs.get('view'),
                            schema_org_data=schema_org_data,
                            google_scholar_data=google_scholar_data)
 

--- a/sonar/theme/templates/sonar/page.html
+++ b/sonar/theme/templates/sonar/page.html
@@ -21,7 +21,10 @@ along with this program. If not, see
 
 <!DOCTYPE html>
 <html {% if html_css_classes %} class="{{ html_css_classes|join(' ') }}" {% endif %}
-  lang="{{ current_i18n.locale.language|safe }}" dir="{{ current_i18n.locale.text_direction }}">
+  lang="{{ current_i18n.locale.language|safe }}" dir="{{ current_i18n.locale.text_direction }}"
+  {%- block view %}{%- endblock %}
+>
+
 
 <head>
   {% include config.THEME_TRACKINGCODE_TEMPLATE %}

--- a/sonar/theme/templates/sonar/search.html
+++ b/sonar/theme/templates/sonar/search.html
@@ -1,5 +1,6 @@
 {% extends 'sonar/page.html' %}
 
+{%- block view %} data-view="{{ view }}"{%- endblock %}
 {%- block body %}
 {% if collection %}
 {% include 'collections/item.html' %}


### PR DESCRIPTION
Remove the document organisation tag from the public interface
on the brief and detailed view if the display is not on the global view.

* Closes #726.

## Dependencies

- https://github.com/rero/sonar-ui/pull/292

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
