### PR TITLE
swisscovery: remove << and >> characters in the title when importing

### DIFF
--- a/sonar/modules/swisscovery/rest.py
+++ b/sonar/modules/swisscovery/rest.py
@@ -17,6 +17,8 @@
 
 """Swisscovery rest views."""
 
+import re
+
 import requests
 import xmltodict
 from flask import Blueprint, current_app, jsonify, request
@@ -66,8 +68,16 @@ def get_record():
 
     record = SRUSchema().dump(record)
 
+    # Regular expression to remove the << and >> around a value in the title
+    # Ex: <<La>> vie est belle => La vie est belle
+    pattern = re.compile('<<(.+)>>', re.S)
+    for title in record.get('title',[]):
+        for mainTitle in title.get('mainTitle', []):
+            mainTitle['value'] = re.sub(pattern, r'\1', mainTitle['value'])
+
     # Serialize for deposit.
     if format == 'deposit':
         record = DepositDocumentSchema().dump(record)
+
 
     return jsonify(record)

--- a/tests/api/swisscovery/test_swisscovery_rest.py
+++ b/tests/api/swisscovery/test_swisscovery_rest.py
@@ -198,3 +198,11 @@ def test_document_type(client, submitter):
     assert res.status_code == 200
     data = res.json
     assert data['metadata']['documentType'] == 'coar:c_db06'
+
+
+def test_title_remove_char(client, submitter):
+    """Test for the removal of << and >> characters in the title."""
+    login_user_via_session(client, email=submitter['email'])
+    res = client.get(url_for('swisscovery.get_record', query='2070406237'))
+    assert res.status_code == 200
+    assert res.json['title'][0]['mainTitle'][0]['value'] == 'La vie est belle'


### PR DESCRIPTION
* Closes #701.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## How to test?

- Add a deposit and import source swisscovery with identifier: 2070406237

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
