### PR TITLE
swisscovery: import of the contributor's date of birth and death

### DIFF
--- a/sonar/modules/deposits/api.py
+++ b/sonar/modules/deposits/api.py
@@ -376,6 +376,12 @@ class DepositRecord(SonarRecord):
                 'role': [contributor['role']]
             }
 
+            if contributor.get('date_of_birth'):
+                 data['agent']['date_of_birth'] = contributor['date_of_birth']
+
+            if contributor.get('date_of_death'):
+                 data['agent']['date_of_death'] = contributor['date_of_death']
+
             if contributor.get('affiliation'):
                 data['affiliation'] = contributor['affiliation']
 

--- a/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
+++ b/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
@@ -1084,6 +1084,8 @@
         ],
         "propertiesOrder": [
           "name",
+          "date_of_birth",
+          "date_of_death",
           "affiliation",
           "role",
           "orcid"
@@ -1164,6 +1166,16 @@
                 "placeholder": "Example: 1111-2222-3333-4444"
               }
             }
+          },
+          "date_of_birth": {
+            "title": "Date of birth",
+            "type": "string",
+            "minLength": 4
+          },
+          "date_of_death": {
+            "title": "Date of death",
+            "type": "string",
+            "minLength": 4
           }
         }
       },

--- a/sonar/modules/deposits/mappings/v7/deposits/deposit-v1.0.0.json
+++ b/sonar/modules/deposits/mappings/v7/deposits/deposit-v1.0.0.json
@@ -316,6 +316,12 @@
           },
           "orcid": {
             "type": "keyword"
+          },
+          "date_of_birth": {
+            "type": "keyword"
+          },
+          "date_of_death": {
+            "type": "keyword"
           }
         }
       },

--- a/sonar/modules/deposits/serializers/schemas/document.py
+++ b/sonar/modules/deposits/serializers/schemas/document.py
@@ -168,7 +168,17 @@ class DocumentSchema(Schema, RemoveEmptyValuesMixin):
         if not obj.get('contribution'):
             return None
 
-        return [{
-            'name': item['agent']['preferred_name'],
-            'role': item['role'][0]
-        } for item in obj['contribution']]
+        contributors = []
+        for item in obj['contribution']:
+            contributor = {
+                'name': item['agent']['preferred_name'],
+                'role': item['role'][0]
+            }
+            if 'date_of_birth' in item['agent']:
+                contributor['date_of_birth'] = item['agent']['date_of_birth']
+            if 'date_of_death' in item['agent']:
+                contributor['date_of_death'] = item['agent']['date_of_death']
+            contributors.append(contributor)
+
+        return contributors
+

--- a/tests/ui/deposits/test_deposits_documents_schema.py
+++ b/tests/ui/deposits/test_deposits_documents_schema.py
@@ -171,7 +171,9 @@ def test_contribution():
     assert DepositDocumentSchema().dump(document) == {
         'contributors': [{
             'name': 'Thilmany, Christian. Herrmann',
-            'role': 'cre'
+            'role': 'cre',
+            'date_of_birth': '1710',
+            'date_of_death': '1767'
         }]
     }
 


### PR DESCRIPTION
* Adds 2 fields date_of_birth and date_of_death in deposit json schema.
* Updates of the import of these 2 new fields.
* Closes #791.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
