### PR TITLE
documents: fix abstracts sort

### DIFF
--- a/sonar/modules/documents/views.py
+++ b/sonar/modules/documents/views.py
@@ -213,9 +213,22 @@ def abstracts(record):
         current_i18n.locale.language)
     preferred_languages = get_preferred_languages(language)
 
-    return sorted(
-        record['abstracts'],
-        key=lambda abstract: preferred_languages.index(abstract['language']))
+    abstractLanguage = []
+    abstractCode = []
+    for abstract in record['abstracts']:
+        if abstract['language'] in preferred_languages:
+            abstractLanguage.append(abstract)
+        else:
+            abstractCode.append(abstract)
+    abstractSortedLanguage = sorted(
+        abstractLanguage,
+        key=lambda abstract: preferred_languages.index(abstract['language'])
+    )
+    abstractSortedCode = sorted(
+        abstractCode,
+        key=lambda abstract: abstract['language']
+    )
+    return abstractSortedLanguage + abstractSortedCode
 
 
 @blueprint.app_template_filter()

--- a/tests/ui/documents/test_documents_views.py
+++ b/tests/ui/documents/test_documents_views.py
@@ -231,6 +231,37 @@ def test_abstracts(app):
     # No abstract
     assert views.abstracts({}) == []
 
+    # Abstract with not defined key on preferred languages
+    abstracts = [{
+        'language': 'fre',
+        'value': 'Résumé'
+    }, {
+        'language': 'eng',
+        'value': 'Summary'
+    }, {
+        'language': 'roh',
+        'value': 'Romancio'
+    }]
+    abstracts_sort = views.abstracts({'abstracts': abstracts})
+    assert ['eng', 'fre', 'roh'] == [abs['language'] for abs in abstracts_sort]
+
+    abstracts = [{
+        'language': 'fre',
+        'value': 'Résumé'
+    }, {
+        'language': 'roh',
+        'value': 'Romancio'
+    }, {
+        'language': 'eng',
+        'value': 'Summary'
+    }, {
+        'language': 'kin',
+        'value': 'kin Summary'
+    }]
+    abstracts_sort = views.abstracts({'abstracts': abstracts})
+    assert ['eng', 'fre', 'kin', 'roh'] == [
+        abs['language'] for abs in abstracts_sort]
+
 
 def test_contributors():
     """Test ordering contributors."""


### PR DESCRIPTION
The languages of the abstracts that are not in the preferred
sorting languages are added at the end of the list and sorted
alphabetically by language code.

* Fixes Sentry SONAR-EA.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
