### PR TITLE
documents: adapts RERO DOC import for USI publications

### DIFF
--- a/sonar/modules/documents/dojson/rerodoc/overdo.py
+++ b/sonar/modules/documents/dojson/rerodoc/overdo.py
@@ -78,8 +78,11 @@ class Overdo(BaseOverdo):
         :param role_700: String, role found in field 700$e
         :returns: String containing the mapped role or None
         """
-        if role_700 in ['Dir.', 'Codir.']:
+        if role_700 == 'Dir.':
             return 'dgs'
+
+        if role_700 == 'Codir.':
+            return 'dgc'
 
         if role_700 == 'Libr./Impr.':
             return 'prt'

--- a/sonar/modules/documents/loaders/schemas/rerodoc.py
+++ b/sonar/modules/documents/loaders/schemas/rerodoc.py
@@ -47,6 +47,7 @@ class RerodocSchema(Marc21Schema):
     identifiedBy = fields.List(fields.Dict())
     subjects = fields.List(fields.Dict())
     classification = fields.List(fields.Dict())
+    contentNote = fields.List(SanitizedUnicode())
     collections = fields.List(fields.Dict())
     dissertation = fields.Dict()
     otherEdition = fields.List(fields.Dict())

--- a/tests/ui/documents/dojson/rerodoc/test_rerodoc_model.py
+++ b/tests/ui/documents/dojson/rerodoc/test_rerodoc_model.py
@@ -805,7 +805,11 @@ def test_marc21_to_edition_statement(app):
     """
     marc21json = create_record(marc21xml)
     data = overdo.do(marc21json)
-    assert not data.get('editionStatement')
+    assert data.get('editionStatement') == {
+        'editionDesignation': {
+            'value': 'Reproduction numérique'
+        },
+    }
 
     # Multiple --> keep only one value
     marc21xml = """
@@ -2546,7 +2550,15 @@ def test_marc21_to_part_of(app):
     """
     marc21json = create_record(marc21xml)
     data = overdo.do(marc21json)
-    assert not data.get('partOf')
+    assert data.get('partOf') == [{
+        'document': {
+            'contribution': ['Belser, Eva Maria'], 
+            'publication': {
+                'statement': 'Stämpfli Verlag, Bern'
+            }, 
+            'title': 'Mehr oder weniger Staat?'
+        }
+    }]
     assert not data.get('provisionActivity')
 
     # Without empty numbering year
@@ -2584,7 +2596,15 @@ def test_marc21_to_part_of(app):
     """
     marc21json = create_record(marc21xml)
     data = overdo.do(marc21json)
-    assert not data.get('partOf')
+    assert data.get('partOf') == [
+        {'document': {
+            'contribution': ['Belser, Eva Maria'], 
+            'publication': {
+                'statement': 'Stämpfli Verlag, Bern'
+            }, 
+            'title': 'Mehr oder weniger Staat?'
+        }
+    }]
     assert not data.get('provisionActivity')
 
     # Without title


### PR DESCRIPTION
* Adds USI-specific data transformations.
* Applies the appropriate document type for advanced studies theses.
* Fixes edition statement import (MARC field 250).
* Fixes content note import (MARC field 505).
* Fixes co-supervisor import (in MARC field 700).
* Closes #736.

Co-Authored-by: Miguel Moreira <miguel.moreira@rero.ch>

