### PR TITLE
urn: monitor count of unregistered pids by days

### DIFF
--- a/sonar/config_sonar.py
+++ b/sonar/config_sonar.py
@@ -602,6 +602,11 @@ SONAR_APP_DOCUMENT_URN = {
             'types': ['coar:c_db06'],
             'code': 6,
             'namespace': 'urn:nbn:ch:rero'
+        },
+        'usi': {
+            'types': ['coar:c_db06'],
+            'code': 1,
+            'namespace': 'urn:nbn:ch:rero'
         }
-    }
+    },
 }

--- a/sonar/monitoring/views/__init__.py
+++ b/sonar/monitoring/views/__init__.py
@@ -23,6 +23,7 @@ from flask import Blueprint, abort, jsonify, request
 from flask_security import current_user
 from invenio_search import current_search_client
 
+from sonar.modules.documents.urn import Urn
 from sonar.modules.permissions import superuser_access_permission
 from sonar.monitoring.api.data_integrity import DataIntegrityMonitoring
 from sonar.monitoring.api.database import DatabaseMonitoring
@@ -107,6 +108,20 @@ def elastic_search():
     """
     try:
         info = current_search_client.cluster.health()
+        return jsonify({'data': info})
+    except Exception as exception:
+        return jsonify({'error': str(exception)}), 500
+
+
+@api_blueprint.route('/urn')
+def unregistered_urn():
+    """Count of unregistered urn pids.
+
+    :return: jsonified count information.
+    """
+    try:
+        days = int(args.get('days', 0)) if (args := request.args) else 0
+        info = Urn.get_urn_pids(days=days)
         return jsonify({'data': info})
     except Exception as exception:
         return jsonify({'error': str(exception)}), 500

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -22,8 +22,39 @@ from __future__ import absolute_import, print_function
 import pytest
 from invenio_app.factory import create_api
 
+from sonar.modules.documents.api import DocumentRecord
+
 
 @pytest.fixture(scope='module')
 def create_app():
     """Create test app."""
     return create_api
+
+
+@pytest.fixture()
+def minimal_thesis_document(db, bucket_location, organisation):
+    """Return a minimal thesis document."""
+    record = DocumentRecord.create(
+        {
+            "title": [
+                {
+                    "type": "bf:Title",
+                    "mainTitle": [
+                        {"language": "eng", "value": "Title of the document"}
+                    ],
+                }
+            ],
+            "documentType": "coar:c_db06",
+            "organisation": [
+                {"$ref": "https://sonar.ch/api/organisations/org"}],
+            "identifiedBy": [
+                {"type": "bf:Local", "value": "10.1186"},
+            ],
+        },
+        dbcommit=True,
+        with_bucket=True,
+    )
+    record.commit()
+    db.session.commit()
+    record.reindex()
+    return record

--- a/tests/api/monitoring/test_monitoring_views.py
+++ b/tests/api/monitoring/test_monitoring_views.py
@@ -241,3 +241,20 @@ def test_elastic_search(client, superuser, monkeypatch):
     response = client.get(url_for('monitoring_api.elastic_search'))
     assert response.status_code == 500
     assert response.json == {'error': 'Unknown exception'}
+
+
+def test_unregistered_urn(client, es_clear, organisation, superuser,
+                          monkeypatch, minimal_thesis_document):
+    """Test unregistered urn counts."""
+
+    login_user_via_session(client, email=superuser['email'])
+
+    response = client.get(
+        url_for('monitoring_api.unregistered_urn'))
+    assert response.status_code == 200
+    assert response.json == {'data': 1}
+
+    response = client.get(
+        url_for('monitoring_api.unregistered_urn', days=100))
+    assert response.status_code == 200
+    assert response.json == {'data': 0}

--- a/tests/ui/documents/test_document_urn.py
+++ b/tests/ui/documents/test_document_urn.py
@@ -48,6 +48,7 @@ def minimal_document(db, bucket_location, organisation):
     )
     record.commit()
     db.session.commit()
+    record.reindex()
     return record
 
 


### PR DESCRIPTION
A new api to count documents with unregistered pids
with an optional parameters `days`.

* Completes urn config for two organisations.
* 
Co-Authored-by: Aly Badr <aly.badr@rero.ch>

