### PR TITLE
urn: implement registry mechanism

### DIFF
--- a/sonar/modules/documents/api.py
+++ b/sonar/modules/documents/api.py
@@ -389,6 +389,17 @@ class DocumentRecord(SonarRecord):
             return current_ark.resolver_url(self.get('pid'))
 
 
+    @classmethod
+    def get_urn_codes(cls, record):
+        """Get list of urn codes for document.
+
+        :param record: dictionary of document.
+        :returns: list of urns codes.
+        """
+        return [identifier['value'] for identifier in record.get(
+            'identifiedBy', []) if identifier['type'] == 'bf:Urn']
+
+
 class DocumentIndexer(SonarIndexer):
     """Indexing documents in Elasticsearch."""
 

--- a/sonar/modules/documents/cli/urn.py
+++ b/sonar/modules/documents/cli/urn.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2022 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""URN specific CLI commands."""
+
+
+import click
+from flask.cli import with_appcontext
+
+from sonar.modules.documents.urn import Urn
+
+
+@click.group()
+def urn():
+    """URN specific commands."""
+
+
+@urn.command('register-urn-pids')
+@with_appcontext
+def register_urn_identifiers():
+    """Register URN identifiers with status NEW."""
+    urn_codes = Urn.get_unregistered_urns()
+    if count := len(urn_codes):
+        click.secho(f'Found  {count} urns to register', fg='yellow')
+        registered = 0
+        for urn_code in urn_codes:
+            if Urn.register_urn(urn=urn_code):
+                click.secho(
+                    f'\turn code: {urn_code} successfully registered', fg='green')
+                registered += 1
+            else:
+                click.secho(
+                    f'\turn code: {urn_code} still pending', fg='red')
+
+        click.secho(f'Found  {count} urns to register', fg='yellow')
+        click.secho(
+            f'Number URNs successfully registered: {registered}', fg='green')
+        click.secho(
+            f'Number URNs pending: {count-registered}', fg='red')
+    else:
+        click.secho('No urns found to register', fg='yellow')
+

--- a/sonar/modules/documents/extensions.py
+++ b/sonar/modules/documents/extensions.py
@@ -20,6 +20,7 @@
 from invenio_pidstore.models import PersistentIdentifier, PIDStatus
 from invenio_records.extensions import RecordExtension
 
+from sonar.modules.documents.tasks import register_urn_code_from_document
 from sonar.modules.documents.urn import Urn
 
 from ..ark.api import current_ark
@@ -78,4 +79,13 @@ class UrnDocumentExtension(RecordExtension):
 
         :param record: the invenio record instance to be processed.
         """
-        Urn.create_urn(record)
+        # Generate URN codes for documents without URNs.
+        if not record.get_urn_codes(record):
+            Urn.create_urn(record)
+
+    def post_create(self, record):
+        """Called after a record is created.
+
+        :param record: the invenio record instance to be processed.
+        """
+        register_urn_code_from_document.delay(record)

--- a/sonar/modules/documents/models.py
+++ b/sonar/modules/documents/models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Swiss Open Access Repository
-# Copyright (C) 2021 RERO
+# Copyright (C) 2022 RERO
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -15,17 +15,22 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Documents CLI commands."""
 
-import click
+"""Define relation between records and buckets."""
 
-from sonar.modules.documents.cli.rerodoc import rerodoc
-from sonar.modules.documents.cli.urn import urn
+from __future__ import absolute_import
+
+from invenio_db import db
+from invenio_pidstore.models import RecordIdentifier
 
 
-@click.group()
-def documents():
-    """Commands for documents."""
+class UrnIdentifier(RecordIdentifier):
+    """Sequence generator for Urn identifiers."""
 
-documents.add_command(rerodoc)
-documents.add_command(urn)
+    __tablename__ = 'urn_id'
+    __mapper_args__ = {'concrete': True}
+
+    recid = db.Column(
+        db.BigInteger().with_variant(db.Integer, 'sqlite'),
+        primary_key=True, autoincrement=True,
+    )

--- a/sonar/modules/documents/tasks.py
+++ b/sonar/modules/documents/tasks.py
@@ -22,7 +22,19 @@ from flask import current_app
 from invenio_db import db
 from invenio_indexer.api import RecordIndexer
 
-from sonar.modules.documents.api import DocumentRecord
+from sonar.modules.documents.urn import Urn
+
+
+@shared_task(ignore_result=True)
+def register_urn_code_from_document(record):
+    """Register the urn pid for a given document.
+
+    :param record records_to_import: the document.
+    """
+    # TODO: return a reponse when implementing the real registration
+    from sonar.modules.documents.api import DocumentRecord
+    if DocumentRecord.get_urn_codes(record):
+        Urn.register_urn_code_from_document(record)
 
 
 @shared_task(ignore_result=True)
@@ -35,6 +47,7 @@ def import_records(records_to_import):
     :param list records_to_import: List of records to import.
     :returns: List of IDs.
     """
+    from sonar.modules.documents.api import DocumentRecord
     indexer = RecordIndexer()
 
     ids = []

--- a/tests/ui/documents/test_documents_tasks.py
+++ b/tests/ui/documents/test_documents_tasks.py
@@ -24,7 +24,7 @@ from sonar.modules.documents.tasks import import_records
 
 
 @mock.patch(
-    'sonar.modules.documents.tasks.DocumentRecord.get_record_by_identifier')
+    'sonar.modules.documents.api.DocumentRecord.get_record_by_identifier')
 def test_import_records(mock_record_by_identifier, app, document_json,
                         bucket_location):
     """Test import records."""


### PR DESCRIPTION
* Adds a celery task after document creation for urn registry.
* Adds cli to register urn codes.
* Creates a separate identifier for urn codes.

Co-Authored-by: Aly Badr <aly.badr@rero.ch>

