### PR TITLE
record: add record statistics on the public detailed view

### DIFF
--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -38,6 +38,10 @@ along with this program. If not, see
 
 {% set files = record.get_files_list() %}
 
+{% set first_file = files | first %}
+
+{% set stats = record.statistics %}
+
 <section class="mt-3">
   <div class="mb-3">
     <a href="javascript: history.back(-1)">
@@ -48,7 +52,8 @@ along with this program. If not, see
     <div class="col-lg-3 text-center">
       {% if files and files | length > 0 %}
       <div class="mb-4">
-        {{ thumbnail(record, files | first) }}
+        {{ thumbnail(record, first_file,
+        stats['file-download'][first_file['key']] or 0) }}
       </div>
       {% else %}
       <img src="{{ url_for('static', filename='images/no-image.png') }}" alt="{{ title }}" class="img-fluid">
@@ -432,12 +437,27 @@ along with this program. If not, see
     {% for file in files %}
     {% if loop.index > 1 %}
     <div class="col-lg-2 mb-5">
-      {{ thumbnail(record, file) }}
+      {{ thumbnail(record, file, stats['file-download'][file['key']] or 0) }}
     </div>
     {% endif %}
     {% endfor %}
   </div>
   {% endif %}
+
+  <!-- Statistics -->
+  <h5 id="stats" class="mt-5">{{ _('Statistics') }}</h5>
+  <hr class="mb-4 mt-0" />
+  <div class="row">
+    <div class="col">
+      <strong>{{ _('Document views') }}:</strong> {{ stats['record-view'] }}
+      <strong class="mt-2 d-block">{{ _('File downloads') }}:</strong>
+      <ul>
+        {% for key, value in stats['file-download'].items() %}
+        <li>{{ key }}: {{ value }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
 
   <!-- Preview modal -->
   <div class="modal fade" id="previewModal" tabindex="-1" role="dialog" aria-hidden="true">
@@ -484,6 +504,7 @@ along with this program. If not, see
     });
 
     $('.affiliation-tooltip').tooltip();
+    $(".sonar-tooltip").tooltip();
 
     // Show all contributors
     $('#show-more-contributors').click(function (event) {

--- a/sonar/theme/templates/sonar/macros/macro.html
+++ b/sonar/theme/templates/sonar/macros/macro.html
@@ -15,7 +15,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #}
 
-{% macro thumbnail(record, file) %}
+{% macro thumbnail(record, file, n_download) %}
 <div class="text-center">
   {% if file.links.external %}
   {{ thumbnail_image(file.thumbnail, file.label, file.links.external, '_blank') }}
@@ -49,6 +49,9 @@
       <i class="fa fa-download mx-1"></i>
     </a>
     {% endif %}
+    <a href="{{ request.url }}#stats" class="sonar-tooltip" data-toggle="tooltip" data-placement="top" title="Download: {{ n_download }}">
+      <i class="fa fa-bar-chart mx-1"></i>
+    </a>
   </div>
 </div>
 {% endmacro %}

--- a/sonar/theme/templates/sonar/projects/detail.html
+++ b/sonar/theme/templates/sonar/projects/detail.html
@@ -95,6 +95,7 @@
 <script>
   $(document).ready(function () {
     $('.affiliation-tooltip').tooltip();
+    $('.sonar-tooltip').tooltip();
   });
 </script>
 {% endblock javascript %}

--- a/tests/ui/documents/test_documents_receivers.py
+++ b/tests/ui/documents/test_documents_receivers.py
@@ -77,7 +77,7 @@ def test_enrich_document_data(app, db, document, pdf_file):
     enrich_document_data(record=document, index='documents', json=json)
 
     assert len(json['fulltext']) == 1
-    assert json['fulltext'][0].startswith('PHYSICAL REVIEW B 99')
+    assert 'PHYSICAL REVIEW B 99' in json['fulltext'][0]
 
 
 def test_chunks():


### PR DESCRIPTION
* Adds a statistics property to the documents api.
* Adds the number of document view and file downloads on the documents detailed view.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
Co-Authored-by: Valeria Granata <valeria@chaw.com>

## Why are you opening this PR?
Issue: https://github.com/rero/sonar/issues/400

This PR depends on:
https://github.com/rero/sonar-ui/pull/316

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
