### PR TITLE
documents: Increase the size of the suggested field

### DIFF
--- a/sonar/modules/documents/mappings/v7/documents/document-v1.0.0.json
+++ b/sonar/modules/documents/mappings/v7/documents/document-v1.0.0.json
@@ -416,7 +416,8 @@
                   },
                   "suggest": {
                     "type": "completion",
-                    "analyzer": "default"
+                    "analyzer": "default",
+                    "max_input_length": 100
                   }
                 }
               },
@@ -583,7 +584,8 @@
           },
           "suggest": {
             "type": "completion",
-            "analyzer": "default"
+            "analyzer": "default",
+            "max_input_length": 100
           }
         }
       },
@@ -595,7 +597,8 @@
           },
           "suggest": {
             "type": "completion",
-            "analyzer": "default"
+            "analyzer": "default",
+            "max_input_length": 100
           }
         }
       },
@@ -607,7 +610,8 @@
           },
           "suggest": {
             "type": "completion",
-            "analyzer": "default"
+            "analyzer": "default",
+            "max_input_length": 100
           }
         }
       },

--- a/sonar/modules/users/mappings/v7/users/user-v1.0.0.json
+++ b/sonar/modules/users/mappings/v7/users/user-v1.0.0.json
@@ -25,7 +25,8 @@
         "fields": {
           "suggest": {
             "type": "completion",
-            "analyzer": "default"
+            "analyzer": "default",
+            "max_input_length": 100
           },
           "raw": {
             "type": "keyword",

--- a/sonar/resources/projects/mappings/v7/projects/project-v1.0.0.json
+++ b/sonar/resources/projects/mappings/v7/projects/project-v1.0.0.json
@@ -138,7 +138,8 @@
             "fields": {
               "suggest": {
                 "type": "completion",
-                "analyzer": "default"
+                "analyzer": "default",
+                "max_input_length": 100
               }
             }
           },
@@ -147,7 +148,8 @@
             "fields": {
               "suggest": {
                 "type": "completion",
-                "analyzer": "default"
+                "analyzer": "default",
+                "max_input_length": 100
               }
             }
           },
@@ -156,7 +158,8 @@
             "fields": {
               "suggest": {
                 "type": "completion",
-                "analyzer": "default"
+                "analyzer": "default",
+                "max_input_length": 100
               }
             }
           },


### PR DESCRIPTION
The default size of the suggestion field is 50. It has been increased to 100.

* Closes #853.

⚠️  ES reindexing: documents, projects and users.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>