### PR TITLE
jsonschemas: add 2 new document types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,9 @@ sonar_documents = "sonar.modules.documents.config"
 shibboleth_authenticator = "sonar.modules.shibboleth_authenticator.config"
 pdf_extractor = "sonar.modules.pdf_extractor.config"
 
+[tool.poetry.plugins."invenio_db.alembic"]
+sonar = "sonar:alembic"
+
 [tool.poetry.plugins."invenio_i18n.translations"]
 messages = "sonar"
 messages_wiki = "flask_wiki"

--- a/sonar/alembic/3d3309f660e4_init.py
+++ b/sonar/alembic/3d3309f660e4_init.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# SONAR
+# Copyright (C) 2022 RERO+
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Initialize alembic."""
+
+
+# revision identifiers, used by Alembic.
+revision = "3d3309f660e4"
+down_revision = None
+branch_labels = ("sonar",)
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+
+
+def downgrade():
+    """Downgrade database."""

--- a/sonar/alembic/e1eb7549728f_replace_document_type_field_in_documents.py
+++ b/sonar/alembic/e1eb7549728f_replace_document_type_field_in_documents.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+#
+# SONAR
+# Copyright (C) 2022 RERO+
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Replace document type field in documents."""
+from logging import getLogger
+
+from invenio_db import db
+
+from sonar.modules.api import SonarRecord
+from sonar.modules.documents.api import DocumentSearch
+
+# revision identifiers, used by Alembic.
+revision = "e1eb7549728f"
+down_revision = "3d3309f660e4"
+branch_labels = ()
+depends_on = None
+
+LOGGER = getLogger("alembic")
+
+
+def upgrade():
+    """Upgrade database."""
+    migrate_doctype("other", "other_thesis")
+
+
+def downgrade():
+    """Downgrade database."""
+    migrate_doctype("other_thesis", "other")
+
+
+def migrate_doctype(old_value, new_value):
+    """Change doctype in all documents."""
+    # find documents to modify
+    doc_search = DocumentSearch()
+
+    n = 0
+    for hit in doc_search.filter("term", documentType=old_value).scan():
+        # get the record in the database
+        record = SonarRecord.get_record_by_pid(hit.pid)
+        # update the record
+        record["documentType"] = new_value
+        # commit and reindex
+        record.commit()
+        db.session.commit()
+        record.reindex()
+        n += 1
+
+    LOGGER.info(f"{n} documents updated.")

--- a/sonar/common/jsonschemas/type-v1.0.0.json
+++ b/sonar/common/jsonschemas/type-v1.0.0.json
@@ -9,6 +9,8 @@
     "coar:c_18cp",
     "coar:c_6670",
     "coar:c_18co",
+    "coar:R60J-J5BD",
+    "coar:c_ba08",
     "coar:c_f744",
     "coar:c_ddb1",
     "coar:c_3e5a",
@@ -46,7 +48,7 @@
     "coar:c_bdcc",
     "habilitation_thesis",
     "advanced_studies_thesis",
-    "other",
+    "other_thesis",
     "coar:c_8042",
     "coar:c_1843"
   ],
@@ -92,6 +94,10 @@
           {
             "label": "document_type_coar:c_f744",
             "value": "coar:c_f744"
+          },
+          {
+            "label": "document_type_coar:R60J-J5BD",
+            "value": "coar:R60J-J5BD"
           }
         ]
       },
@@ -121,6 +127,10 @@
             "value": "coar:c_dcae04bc"
           }
         ]
+      },
+      {
+        "label": "document_type_coar:c_ba08",
+        "value": "coar:c_ba08"
       },
       {
         "label": "document_type_coar:c_8544",
@@ -253,8 +263,8 @@
             "value": "advanced_studies_thesis"
           },
           {
-            "label": "document_type_other",
-            "value": "other"
+            "label": "document_type_other_thesis",
+            "value": "other_thesis"
           }
         ]
       },

--- a/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
+++ b/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
@@ -680,7 +680,7 @@
             }
           },
           "form": {
-            "hideExpression": "field.parent.model && !['coar:c_3248', 'coar:c_5794', 'coar:c_6670', 'coar:c_3e5a', 'coar:c_beb9', 'coar:c_6501', 'coar:c_816b', 'coar:c_998f', 'coar:c_dcae04bc'].includes(field.parent.model.documentType)",
+            "hideExpression": "field.parent.model && !['coar:c_3248', 'coar:c_5794', 'coar:c_6670', 'coar:c_3e5a', 'coar:c_ba08', 'coar:c_beb9', 'coar:c_6501', 'coar:c_816b', 'coar:c_998f', 'coar:c_dcae04bc'].includes(field.parent.model.documentType)",
             "templateOptions": {
               "wrappers": [
                 "card"
@@ -892,7 +892,7 @@
             "degree"
           ],
           "form": {
-            "hideExpression": "field.parent.model && !['coar:c_46ec', 'coar:c_7a1f', 'coar:c_db06', 'coar:c_bdcc', 'habilitation_thesis', 'advanced_studies_thesis', 'other'].includes(field.parent.model.documentType)",
+            "hideExpression": "field.parent.model && !['coar:c_46ec', 'coar:c_7a1f', 'coar:c_db06', 'coar:c_bdcc', 'habilitation_thesis', 'advanced_studies_thesis', 'other_thesis'].includes(field.parent.model.documentType)",
             "templateOptions": {
               "wrappers": [
                 "card"

--- a/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
+++ b/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0_src.json
@@ -4,7 +4,8 @@
   "title": "SONAR deposit v1.0.0",
   "type": "object",
   "required": [
-    "pid"
+    "pid",
+    "status"
   ],
   "additionalProperties": false,
   "properties": {
@@ -573,7 +574,7 @@
               "type": "string",
               "minLength": 1,
               "form": {
-                "hideExpression": "field.parent.parent.model && !['coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc'].includes(field.parent.parent.model.documentType)",
+                "hideExpression": "field.parent.parent.model && !['coar:c_3248', 'coar:c_3e5a', 'coar:c_ba08', 'coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc', 'coar:c_816b', 'coar:c_5794', 'coar:c_6670', 'coar:c_c94f'].includes(field.parent.parent.model.documentType)",
                 "templateOptions": {
                   "placeholder": "Example: 1, 4-5, …"
                 }
@@ -584,7 +585,7 @@
               "type": "string",
               "minLength": 1,
               "form": {
-                "hideExpression": "field.parent.parent.model && !['coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc'].includes(field.parent.parent.model.documentType)",
+                "hideExpression": "field.parent.parent.model && !['coar:c_3e5a', 'coar:c_ba08', 'coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc', 'coar:c_816b', 'coar:c_5794', 'coar:c_6670', 'coar:c_c94f'].includes(field.parent.parent.model.documentType)",
                 "templateOptions": {
                   "placeholder": "Example: 10, 22-24, …"
                 }

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -1581,7 +1581,7 @@
             "type": "string",
             "minLength": 1,
             "form": {
-              "hideExpression": "!['coar:c_3e5a', 'coar:c_ba08', coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc'].includes(field.parent.parent.parent.model.documentType)"
+              "hideExpression": "!['coar:c_3248', 'coar:c_3e5a', 'coar:c_ba08', 'coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc', 'coar:c_816b', 'coar:c_5794', 'coar:c_6670', 'coar:c_c94f'].includes(field.parent.parent.parent.model.documentType)"
             }
           },
           "numberingIssue": {
@@ -1589,7 +1589,7 @@
             "type": "string",
             "minLength": 1,
             "form": {
-              "hideExpression": "!['coar:c_3e5a', 'coar:c_ba08', 'coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc'].includes(field.parent.parent.parent.model.documentType)"
+              "hideExpression": "!['coar:c_3e5a', 'coar:c_ba08', 'coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc', 'coar:c_816b', 'coar:c_5794', 'coar:c_6670', 'coar:c_c94f'].includes(field.parent.parent.parent.model.documentType)"
             }
           },
           "numberingPages": {

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json
@@ -560,7 +560,7 @@
       },
       "form": {
         "expressionProperties": {
-          "templateOptions.required": "field.parent.model && !['coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc', 'coar:c_3e5a', 'coar:c_5794', 'coar:c_6670'].includes(field.parent.model.documentType)"
+          "templateOptions.required": "field.parent.model && !['coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc', 'coar:c_3e5a', 'coar:c_ba08', coar:c_5794', 'coar:c_6670'].includes(field.parent.model.documentType)"
         }
       }
     },
@@ -1219,7 +1219,7 @@
       "form": {
         "hide": true
       },
-      "hideExpression": "field.parent.model && !['coar:c_46ec', 'coar:c_7a1f', 'coar:c_db06', 'coar:c_bdcc', 'habilitation_thesis', 'advanced_studies_thesis', 'other'].includes(field.parent.model.documentType)"
+      "hideExpression": "field.parent.model && !['coar:c_46ec', 'coar:c_7a1f', 'coar:c_db06', 'coar:c_bdcc', 'habilitation_thesis', 'advanced_studies_thesis', 'other_thesis'].includes(field.parent.model.documentType)"
     },
     "usageAndAccessPolicy": {
       "title": "Usage and access policy",
@@ -1581,7 +1581,7 @@
             "type": "string",
             "minLength": 1,
             "form": {
-              "hideExpression": "!['coar:c_3e5a', 'coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc'].includes(field.parent.parent.parent.model.documentType)"
+              "hideExpression": "!['coar:c_3e5a', 'coar:c_ba08', coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc'].includes(field.parent.parent.parent.model.documentType)"
             }
           },
           "numberingIssue": {
@@ -1589,7 +1589,7 @@
             "type": "string",
             "minLength": 1,
             "form": {
-              "hideExpression": "!['coar:c_3e5a', 'coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc'].includes(field.parent.parent.parent.model.documentType)"
+              "hideExpression": "!['coar:c_3e5a', 'coar:c_ba08', 'coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc'].includes(field.parent.parent.parent.model.documentType)"
             }
           },
           "numberingPages": {
@@ -1879,7 +1879,7 @@
       "form": {
         "hide": true,
         "expressionProperties": {
-          "templateOptions.required": "field.parent.model && ['coar:c_3248', 'coar:c_5794', 'coar:c_6670', 'coar:c_3e5a', 'coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc'].includes(field.parent.model.documentType)"
+          "templateOptions.required": "field.parent.model && ['coar:c_3248', 'coar:c_5794', 'coar:c_6670', 'coar:c_3e5a', 'coar:c_ba08', 'coar:c_beb9', 'coar:c_6501', 'coar:c_998f', 'coar:c_dcae04bc'].includes(field.parent.model.documentType)"
         }
       }
     },

--- a/sonar/modules/documents/serializers/schemas/schemaorg.py
+++ b/sonar/modules/documents/serializers/schemas/schemaorg.py
@@ -69,9 +69,11 @@ TYPE_MAPPING = {
     'coar:c_bdcc': 'Thesis',
     'habilitation_thesis': 'Thesis',
     'advanced_studies_thesis': 'Thesis',
-    'other': 'Thesis',
+    'other_thesis': 'Thesis',
     'coar:c_8042': 'CreativeWork',
-    'coar:c_1843': 'CreativeWork'
+    'coar:c_1843': 'CreativeWork',
+    'coar:R60J-J5BD': 'CreativeWork',
+    'coar:c_ba08': 'Review'
 }
 
 

--- a/tests/ui/users/test_user_jsonresolvers.py
+++ b/tests/ui/users/test_user_jsonresolvers.py
@@ -37,6 +37,7 @@ def test_user_resolver(app, organisation, roles):
     record = DepositRecord.create(
         {'user': {
             '$ref': 'https://sonar.ch/api/users/1'
-        }}, with_bucket=False)
+        },
+        'status': 'in_progress'}, with_bucket=False)
 
     assert record.replace_refs().get('user')['email'] == 'admin@test.com'


### PR DESCRIPTION
* Adds conference object and book review document types for documents
and deposits.
* Changes value and label for document_type_other for better clarity.
* Initializes alembic.
* Includes alembic script for db migration.
* Closes #881.
* Closes #626.
* Makes the `status` deposit field required to prevent submitting
a deposit with no status from the API.

Co-Authored-by: Pascal Repond <pascal.repond@rero.ch>
