### PR TITLE
organisations: fix editor ValidationError

### DIFF
--- a/sonar/modules/organisations/marshmallow/json.py
+++ b/sonar/modules/organisations/marshmallow/json.py
@@ -47,7 +47,7 @@ class OrganisationMetadataSchemaV1(StrictKeysMixin):
     footer = fields.List(fields.Dict())
     isShared = fields.Boolean()
     isDedicated = fields.Boolean()
-    serverName = fields.Str(dump_only=True)
+    serverName = fields.Str()
     allowedIps = SanitizedUnicode()
     platformName = SanitizedUnicode()
     documentsCustomField1 = fields.Dict()


### PR DESCRIPTION
* Fixes the `serverName` field not accepted by the server in the
dedicated organisation editor, preventing to save.

Co-Authored-by: Pascal Repond <pascal.repond@rero.ch>
