### PR TITLE
documents: add permissions for documents with registred URN

### DIFF
--- a/sonar/modules/documents/api.py
+++ b/sonar/modules/documents/api.py
@@ -259,7 +259,8 @@ class DocumentRecord(SonarRecord):
                 'Error during fulltext extraction of {file} of record '
                 '{record}: {error}'.format(file=file.key,
                                            error=exception,
-                                           record=self['identifiedBy']))
+                                           record=self.get(
+                                               'identifiedBy', self['pid'])))
 
     def create_thumbnail(self, file):
         """Create a thumbnail for record.

--- a/sonar/modules/documents/urn.py
+++ b/sonar/modules/documents/urn.py
@@ -98,13 +98,17 @@ class Urn:
                         object_uuid=record.id,
                         status=PIDStatus.NEW,
                     )
-                    record["identifiedBy"].append(
-                        {"type": "bf:Urn", "value": urn_code}
-                    )
+                    if "identifiedBy" in record:
+                        record["identifiedBy"].append(
+                            {"type": "bf:Urn", "value": urn_code}
+                        )
+                    else:
+                        record["identifiedBy"] = \
+                            [{"type": "bf:Urn", "value": urn_code}]
                 except PIDAlreadyExists:
                     current_app.logger.error(
                         'generated urn already exist for document: '
-                            + record.get('pid'))
+                        + record.get('pid'))
 
     @classmethod
     def urn_query(cls, status=None):
@@ -114,9 +118,8 @@ class Urn:
         :returns: Base query.
         """
         return PersistentIdentifier.query\
-                .filter_by(pid_type=cls.urn_pid_type)\
-                .filter_by(status=status)
-
+            .filter_by(pid_type=cls.urn_pid_type)\
+            .filter_by(status=status)
 
     @classmethod
     def get_urn_pids(cls, status=PIDStatus.NEW, days=None):
@@ -137,7 +140,6 @@ class Urn:
                 query = query.filter('range', _created={'lte': date})
             count = query.count()
         return count
-
 
     @classmethod
     def get_unregistered_urns(cls):
@@ -161,8 +163,8 @@ class Urn:
         if DnbUrnService.register_document(record):
             urn_code = DocumentRecord.get_rero_urn_code(record)
             pid = PersistentIdentifier.query\
-                    .filter_by(pid_type=cls.urn_pid_type)\
-                    .filter_by(pid_value=urn_code).first()
+                .filter_by(pid_type=cls.urn_pid_type)\
+                .filter_by(pid_value=urn_code).first()
             if pid and pid.status == PIDStatus.NEW:
                 pid.status = PIDStatus.REGISTERED
                 db.session.commit()
@@ -176,7 +178,6 @@ class Urn:
         if pid := PersistentIdentifier.get(cls.urn_pid_type, urn):
             pid.status = PIDStatus.REGISTERED
             db.session.commit()
-
 
     @classmethod
     def get_documents_to_generate_urns(cls):

--- a/tests/api/documents/test_documents_permissions.py
+++ b/tests/api/documents/test_documents_permissions.py
@@ -18,11 +18,14 @@
 """Test documents permissions."""
 
 import json
+from io import BytesIO
 
 import mock
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 from invenio_pidstore.models import PersistentIdentifier, PIDStatus
+
+from sonar.modules.utils import wait_empty_tasks
 
 
 def test_list(app, client, make_document, superuser, admin, moderator,
@@ -157,7 +160,8 @@ def test_read(client, document, make_user, superuser, admin, moderator,
         magic_mock
     ):
         res = client.get(
-            url_for('invenio_records_rest.doc_item', pid_value=document['pid']))
+            url_for('invenio_records_rest.doc_item',
+                    pid_value=document['pid']))
         assert res.status_code == 401
 
     # Logged as user
@@ -184,7 +188,7 @@ def test_read(client, document, make_user, superuser, admin, moderator,
     }
     assert res.json['metadata']['partOf'][0][
         'text'] == 'Journal du dimanche / Renato, Ferrari ; Albano, Mesta. ' \
-            '- John Doe Publications inc.. - 2020, vol. 6, no. 12, p. 135-139'
+        '- John Doe Publications inc.. - 2020, vol. 6, no. 12, p. 135-139'
     assert res.json['metadata']['provisionActivity'][0]['text'] == {
         'default':
         'Bienne : Impr. Weber, [2006] ; Lausanne ; Rippone : Impr. Coustaud'
@@ -390,3 +394,20 @@ def test_delete(client, document, make_document, make_user, superuser, admin,
     assert res.status_code == 204
     assert PersistentIdentifier.get('ark', ark_id).status == \
         PIDStatus.DELETED
+
+
+def test_document_with_urn_delete(client, superuser, minimal_thesis_document):
+    """Test delete document with registered URN identifier."""
+    # Add file to document
+    minimal_thesis_document.files['test.pdf'] = BytesIO(b'File content')
+    minimal_thesis_document.files['test.pdf']['type'] = 'file'
+    minimal_thesis_document.commit()
+
+    wait_empty_tasks(delay=3, verbose=True)
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    pid = minimal_thesis_document['pid']
+    res = client.delete(url_for('invenio_records_rest.doc_item',
+                                pid_value=pid))
+    assert res.status_code == 403


### PR DESCRIPTION
 Add permissions for documents with registered URN:

- prevent deleting documents with registered URN
- prevent deleting pdf files of documents with registered URN

Co-Authored-by: Valeria Granata <valeria@chaw.com>

## Why are you opening this PR?

issue https://github.com/rero/sonar/issues/849

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
