### PR TITLE
files: fix upload of files with special characters in filename

### DIFF
--- a/sonar/modules/utils.py
+++ b/sonar/modules/utils.py
@@ -18,6 +18,7 @@
 """Utils functions for application."""
 
 import datetime
+import os
 import re
 
 from flask import abort, current_app, g, request
@@ -65,15 +66,14 @@ def change_filename_extension(filename, extension):
     Additionally, the original extension is appended to the filename, to avoid
     conflict with other files having the same name (without extension).
     """
-    matches = re.search(r'(.*)\.(.*)$', filename)
-
-    if matches is None:
+    matches = os.path.splitext(filename)
+    if not matches[1]:
         raise Exception(
             '{filename} is not a valid filename'.format(filename=filename))
 
     return '{name}-{source_extension}.{extension}'.format(
-        name=matches.group(1),
-        source_extension=matches.group(2),
+        name=matches[0],
+        source_extension=matches[1][1:],
         extension=extension)
 
 


### PR DESCRIPTION
* Unicode normalize filenames.
* This PR depends on:
   https://github.com/rero/sonar-ui/pull/324
   https://github.com/rero/ng-core/pull/523
Co-Authored-by: Valeria Granata <valeria@chaw.com>

## Why are you opening this PR?
https://github.com/rero/sonar/issues/861

## How to test / Notes for future debugging
a. Create a deposit with a file and publish it.
b. Create a document with a file (login as superuser)

Examples of filenames to test:
¿Es la unión mística un paradigma para la relación interpersonal? Una respuesta diferenciada en Edith Stein.pdf
L'âme humaine comme "intériorité".pdf
La portée anthropologique du symbole du château chez sainte Thérèse d'Avila.pdf
Le symbole du château. Une proposition d’interprétation relationnelle.pdf
Betschart - 2017 - La portée anthropologique du symbole du château ch.pdf
&%/? éàèê/üäö$£\/(){}*"'`+-!$.pdf

Logged in as superuser in the Administration section:
- Edit document’s metadata (no need to change anything just click on Edit and Save)
- Edit file’s metadata (no need to change anything just click on Edit and Save)
- Add files
- Delete one or more files
- Add new versions of a file
- Delete one or more versions of a file
- Check the download, preview and thumbnail links work.

An example of what could happen is in the screenshot below where the file “Le symbole du château. Une proposition d’interprétation relationnelle.pdf” disappeared from the list and the links for this file do not work any longer.
In this specific case the problem is the right single quotation mark in “d’interprétation” that during the actions above is sometimes encoded into apostrophe.

![test_861](https://user-images.githubusercontent.com/42514476/194038085-98d4ab8e-a4b2-4ed2-ad07-4c738a525759.png)

<img width="289" alt="characters" src="https://user-images.githubusercontent.com/42514476/194038492-efe902a3-579e-43ac-b186-6902203a5fd3.png">

Sometimes after one of the action above several fields in the files metadata disappear (type, label, links, order, restriction, thumbnail) and the files are no more visible. In the example below, the file "La portée anthropologig…e Thérèse d'Avila.pdf" is still visible but the others have disappeared. 

![test_861b](https://user-images.githubusercontent.com/42514476/194059804-99474441-dbbd-47ee-b96d-9314fd9a410a.png)
<img width="516" alt="Screenshot 2022-10-05 at 14 21 44" src="https://user-images.githubusercontent.com/42514476/194060462-47bd8851-14e6-4fcb-a2b6-1972a3118e03.png">

<img width="958" alt="Screenshot 2022-10-05 at 14 22 04" src="https://user-images.githubusercontent.com/42514476/194060485-54967196-886a-4f23-8ec9-4e1055d4ae1c.png">

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
