### PR TITLE
documents: permissions delete for documents with registred URN

### DIFF
--- a/sonar/modules/documents/urn.py
+++ b/sonar/modules/documents/urn.py
@@ -98,9 +98,13 @@ class Urn:
                         object_uuid=record.id,
                         status=PIDStatus.NEW,
                     )
-                    record["identifiedBy"].append(
-                        {"type": "bf:Urn", "value": urn_code}
-                    )
+                    if "identifiedBy" in record:
+                        record["identifiedBy"].append(
+                            {"type": "bf:Urn", "value": urn_code}
+                        )
+                    else:
+                        record["identifiedBy"] = \
+                            [{"type": "bf:Urn", "value": urn_code}]
                 except PIDAlreadyExists:
                     current_app.logger.error(
                         'generated urn already exist for document: '
@@ -176,7 +180,6 @@ class Urn:
         if pid := PersistentIdentifier.get(cls.urn_pid_type, urn):
             pid.status = PIDStatus.REGISTERED
             db.session.commit()
-
 
     @classmethod
     def get_documents_to_generate_urns(cls):

--- a/tests/api/documents/test_documents_files_permissions.py
+++ b/tests/api/documents/test_documents_files_permissions.py
@@ -17,6 +17,7 @@
 
 """Test documents files permissions."""
 
+from io import BytesIO
 
 from flask import url_for
 from flask_security import url_for_security
@@ -46,7 +47,6 @@ def test_update_delete(client, superuser, admin, moderator,
             assert res.status_code == status
 
 
-
 def test_read_metadata(client, superuser, admin, moderator,
               submitter, user, document_with_file):
     """Test read files permissions."""
@@ -73,6 +73,7 @@ def test_read_metadata(client, superuser, admin, moderator,
             client.get(url_for_security('logout'))
         res = client.get(url_files)
         assert res.status_code == status
+
 
 def test_read_content(client, superuser, admin, moderator,
               submitter, user, user_without_org, document_with_file):
@@ -120,3 +121,32 @@ def test_read_content(client, superuser, admin, moderator,
             client.get(url_for_security('logout'))
         res = client.get(url_file_content)
         assert res.status_code == status
+
+
+def test_file_of_document_with_urn_delete(client, superuser,
+                                          minimal_thesis_document):
+    """Test delete file of document with registered URN identifier."""
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+
+    # Add pdf file to document
+    minimal_thesis_document.files['test.pdf'] = BytesIO(b'File content')
+    minimal_thesis_document.files['test.pdf']['type'] = 'file'
+    minimal_thesis_document.commit()
+
+    url_file_content = url_for(
+        'invenio_records_files.doc_object_api',
+        pid_value=minimal_thesis_document['pid'], key='test.pdf')
+    res = client.delete(url_file_content)
+    assert res.status_code == 403
+
+    # Add png file to document
+    minimal_thesis_document.files['test.png'] = BytesIO(b'File content')
+    minimal_thesis_document.files['test.png']['type'] = 'file'
+    minimal_thesis_document.commit()
+
+    url_file_content = url_for(
+        'invenio_records_files.doc_object_api',
+        pid_value=minimal_thesis_document['pid'], key='test.png')
+    res = client.delete(url_file_content)
+    assert res.status_code == 204

--- a/tests/api/documents/test_documents_permissions.py
+++ b/tests/api/documents/test_documents_permissions.py
@@ -18,6 +18,7 @@
 """Test documents permissions."""
 
 import json
+from io import BytesIO
 
 import mock
 from flask import url_for
@@ -390,3 +391,18 @@ def test_delete(client, document, make_document, make_user, superuser, admin,
     assert res.status_code == 204
     assert PersistentIdentifier.get('ark', ark_id).status == \
         PIDStatus.DELETED
+
+
+def test_document_with_urn_delete(client, superuser, minimal_thesis_document):
+    """Test delete document with registered URN identifier."""
+    # Add file to document
+    minimal_thesis_document.files['test.pdf'] = BytesIO(b'File content')
+    minimal_thesis_document.files['test.pdf']['type'] = 'file'
+    minimal_thesis_document.commit()
+
+    # Logged as superuser
+    login_user_via_session(client, email=superuser['email'])
+    pid = minimal_thesis_document['pid']
+    res = client.delete(url_for('invenio_records_rest.doc_item',
+                                pid_value=pid))
+    assert res.status_code == 403


### PR DESCRIPTION
 Add permissions for documents with registered URN:

-  prevent deleting documents with registered URN
-  prevent deleting pdf files of documents with registered URN

This PR is a copy of https://github.com/rero/sonar/pull/898.

Co-Authored-by: Valeria Granata <valeria@chaw.com>

## Why are you opening this PR?

issue https://github.com/rero/sonar/issues/849

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
