### PR TITLE
documents: clear controlled affiliations

### DIFF
--- a/sonar/modules/documents/api.py
+++ b/sonar/modules/documents/api.py
@@ -121,9 +121,11 @@ class DocumentRecord(SonarRecord):
         affiliation_resolver = AffiliationResolver()
         for contributor in data.get('contribution', []):
             if contributor.get('affiliation'):
-                controlled_affiliations = affiliation_resolver.resolve(
-                    contributor['affiliation'])
-                if controlled_affiliations:
+                # remove existing controlled affiliation
+                with contextlib.suppress(KeyError):
+                    del contributor['controlledAffiliation']
+                if controlled_affiliations := affiliation_resolver.resolve(
+                        contributor['affiliation']):
                     contributor[
                         'controlledAffiliation'] = controlled_affiliations
 

--- a/tests/ui/documents/test_documents_api.py
+++ b/tests/ui/documents/test_documents_api.py
@@ -17,6 +17,8 @@
 
 """Test documents API."""
 
+from copy import deepcopy
+
 from flask import url_for
 from invenio_stats.tasks import aggregate_events, process_events
 
@@ -184,3 +186,15 @@ def test_stats(app, client, document_with_file, es, db, event_queues):
     assert document_with_file.statistics['file-download']['test1.pdf'] == 1
     # the thumbnail should not be in the statistics
     assert not 'test1-pdf.jpg' in document_with_file.statistics['file-download']
+
+
+def test_affiliations(document):
+    """Test controlled affiliation."""
+    data = deepcopy(dict(document))
+    data['contribution'][0]['affiliation'] = 'foo'
+    document.update(data)
+    assert 'controlledAffiliation' not in document['contribution'][0]
+
+    data['contribution'][0]['affiliation'] = 'Uni of Geneva and HUG, Uni of Lausanne and CHUV'
+    document.update(data)
+    assert len(document['contribution'][0]['controlledAffiliation']) == 2


### PR DESCRIPTION
* Closes #807.
* Removes controlled affiliations because sometimes a controlled
  affiliation becomes uncontrolled.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
Co-Authored-by:  Pascal Repond <pascal.repond@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
