### PR TITLE
documents: fix controlledAffiliation clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v1.8.2](https://github.com/rero/sonar/tree/v1.8.2) (2022-11-24)
+
+[Full Changelog](https://github.com/rero/sonar/compare/v1.8.1...v1.8.2)
+
+**Bug fixes:**
+
+* Controlled affiliation should be cleared when affiliation is modified to empty or unrecognized value [\#807](https://github.com/rero/sonar/issues/807)
+* The editor or API should prevent bad character encodings [\#867](https://github.com/rero/sonar/issues/867)
+
 ## [v1.8.1](https://github.com/rero/sonar/tree/v1.8.1) (2022-10-20)
 
 [Full Changelog](https://github.com/rero/sonar/compare/v1.8.0...v1.8.1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "SONAR"
-version = "1.8.1"
+version = "1.8.2"
 description = "SONAR is an archive of scholarly publications. It intends to collect, promote and preserve the publications of authors affiliated with Swiss public research institutions."
 authors = ["RERO <software@rero.ch>"]
 license = "GNU Affero General Public License v3.0"

--- a/sonar/modules/documents/api.py
+++ b/sonar/modules/documents/api.py
@@ -121,9 +121,11 @@ class DocumentRecord(SonarRecord):
         affiliation_resolver = AffiliationResolver()
         for contributor in data.get('contribution', []):
             if contributor.get('affiliation'):
-                controlled_affiliations = affiliation_resolver.resolve(
-                    contributor['affiliation'])
-                if controlled_affiliations:
+                # remove existing controlled affiliation
+                with contextlib.suppress(KeyError):
+                    del contributor['controlledAffiliation']
+                if controlled_affiliations := affiliation_resolver.resolve(
+                        contributor['affiliation']):
                     contributor[
                         'controlledAffiliation'] = controlled_affiliations
 

--- a/sonar/modules/documents/api.py
+++ b/sonar/modules/documents/api.py
@@ -120,14 +120,14 @@ class DocumentRecord(SonarRecord):
         """
         affiliation_resolver = AffiliationResolver()
         for contributor in data.get('contribution', []):
+            # remove existing controlled affiliation
+            contributor.pop('controlledAffiliation', None)
             if contributor.get('affiliation'):
-                # remove existing controlled affiliation
-                with contextlib.suppress(KeyError):
-                    del contributor['controlledAffiliation']
                 if controlled_affiliations := affiliation_resolver.resolve(
                         contributor['affiliation']):
                     contributor[
                         'controlledAffiliation'] = controlled_affiliations
+
 
 
     @classmethod

--- a/sonar/translations/de/LC_MESSAGES/messages.po
+++ b/sonar/translations/de/LC_MESSAGES/messages.po
@@ -10,17 +10,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
 "Report-Msgid-Bugs-To: nicolas.prongue@rero.ch\n"
-"POT-Creation-Date: 2022-08-30 11:34+0200\n"
-"PO-Revision-Date: 2022-08-30 10:20+0000\n"
+"POT-Creation-Date: 2022-11-24 10:51+0100\n"
+"PO-Revision-Date: 2022-09-07 07:22+0000\n"
 "Last-Translator: Pascal Repond <pascal.repond@rero.ch>\n"
-"Language-Team: German <https://hosted.weblate.org/projects/rero_plus/sonar/"
-"de/>\n"
 "Language: de\n"
+"Language-Team: German "
+"<https://hosted.weblate.org/projects/rero_plus/sonar/de/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.14.1-dev\n"
 "Generated-By: Babel 2.10.1\n"
 
 #: sonar/theme/views.py:102
@@ -769,6 +768,7 @@ msgid "File UUID"
 msgstr "Datei-UUID"
 
 #: sonar/modules/documents/templates/documents/record.html:453
+#: sonar/theme/templates/sonar/macros/macro.html:52
 msgid "File downloads"
 msgstr "Datei-Downloads"
 
@@ -1791,8 +1791,8 @@ msgid ""
 "Select a subdivision (department, institute, faculty, other) if this "
 "publication belongs to it in your organisation."
 msgstr ""
-"Wählen Sie eine Unterteilung (Abteilung, Institut, Fakultät, andere), wenn "
-"diese Veröffentlichung in Ihrer Organisation dazu gehört."
+"Wählen Sie eine Unterteilung (Abteilung, Institut, Fakultät, andere), "
+"wenn diese Veröffentlichung in Ihrer Organisation dazu gehört."
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:616
 msgid "Serie"
@@ -5477,3 +5477,4 @@ msgstr "Schweizerische Nationalfonds"
 #~ msgstr ""
 #~ "Angetrieben von <a href=\"%(link)s\" "
 #~ "target=\"_blank\" rel=\"noopener\">SONAR</a>"
+

--- a/sonar/translations/en/LC_MESSAGES/messages.po
+++ b/sonar/translations/en/LC_MESSAGES/messages.po
@@ -9,17 +9,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
 "Report-Msgid-Bugs-To: nicolas.prongue@rero.ch\n"
-"POT-Creation-Date: 2022-08-30 11:34+0200\n"
-"PO-Revision-Date: 2022-08-30 10:20+0000\n"
+"POT-Creation-Date: 2022-11-24 10:51+0100\n"
+"PO-Revision-Date: 2022-09-07 07:22+0000\n"
 "Last-Translator: Pascal Repond <pascal.repond@rero.ch>\n"
-"Language-Team: English <https://hosted.weblate.org/projects/rero_plus/sonar/"
-"en/>\n"
 "Language: en\n"
+"Language-Team: English "
+"<https://hosted.weblate.org/projects/rero_plus/sonar/en/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.14.1-dev\n"
 "Generated-By: Babel 2.10.1\n"
 
 #: sonar/theme/views.py:102
@@ -768,6 +767,7 @@ msgid "File UUID"
 msgstr "File UUID"
 
 #: sonar/modules/documents/templates/documents/record.html:453
+#: sonar/theme/templates/sonar/macros/macro.html:52
 msgid "File downloads"
 msgstr "File downloads"
 
@@ -1475,7 +1475,6 @@ msgid "Persistent identifier"
 msgstr "Persistent identifier"
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:1258
-#, fuzzy
 msgid "Person"
 msgstr "Person"
 
@@ -1547,7 +1546,7 @@ msgstr ""
 
 #: sonar/theme/templates/sonar/footer.html:56
 msgid "Privacy policy"
-msgstr ""
+msgstr "Privacy policy"
 
 #: sonar/common/jsonschemas/masked-v1.0.0.json:18
 msgid "Private"
@@ -5474,3 +5473,4 @@ msgstr "​Swiss National Science Foundation"
 #~ msgstr ""
 #~ "Powered by <a href=\"%(link)s\" "
 #~ "target=\"_blank\" rel=\"noopener\">SONAR</a>"
+

--- a/sonar/translations/eo/LC_MESSAGES/messages.po
+++ b/sonar/translations/eo/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 1.0.0\n"
 "Report-Msgid-Bugs-To: nicolas.prongue@rero.ch\n"
-"POT-Creation-Date: 2022-08-30 11:34+0200\n"
+"POT-Creation-Date: 2022-11-24 10:51+0100\n"
 "PO-Revision-Date: 2022-04-28 11:09+0000\n"
 "Last-Translator: Nicolas Prongué <n.prongue@outlook.com>\n"
 "Language: eo\n"
@@ -761,6 +761,7 @@ msgid "File UUID"
 msgstr "UUID de dosiero"
 
 #: sonar/modules/documents/templates/documents/record.html:453
+#: sonar/theme/templates/sonar/macros/macro.html:52
 msgid "File downloads"
 msgstr ""
 

--- a/sonar/translations/fr/LC_MESSAGES/messages.po
+++ b/sonar/translations/fr/LC_MESSAGES/messages.po
@@ -11,17 +11,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
 "Report-Msgid-Bugs-To: nicolas.prongue@rero.ch\n"
-"POT-Creation-Date: 2022-08-30 11:34+0200\n"
-"PO-Revision-Date: 2022-08-30 10:20+0000\n"
+"POT-Creation-Date: 2022-11-24 10:51+0100\n"
+"PO-Revision-Date: 2022-09-07 07:22+0000\n"
 "Last-Translator: Pascal Repond <pascal.repond@rero.ch>\n"
-"Language-Team: French <https://hosted.weblate.org/projects/rero_plus/sonar/"
-"fr/>\n"
 "Language: fr\n"
+"Language-Team: French "
+"<https://hosted.weblate.org/projects/rero_plus/sonar/fr/>\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 4.14.1-dev\n"
 "Generated-By: Babel 2.10.1\n"
 
 #: sonar/theme/views.py:102
@@ -768,6 +767,7 @@ msgid "File UUID"
 msgstr "UUID du fichier"
 
 #: sonar/modules/documents/templates/documents/record.html:453
+#: sonar/theme/templates/sonar/macros/macro.html:52
 msgid "File downloads"
 msgstr "Téléchargements du fichier"
 
@@ -5501,3 +5501,4 @@ msgstr "Fonds national suisse de la recherche scientifique"
 #~ msgstr ""
 #~ "Propulsé par <a href=\"%(link)s\" "
 #~ "target=\"_blank\" rel=\"noopener\">SONAR</a>"
+

--- a/sonar/translations/it/LC_MESSAGES/messages.po
+++ b/sonar/translations/it/LC_MESSAGES/messages.po
@@ -10,17 +10,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.4.0\n"
 "Report-Msgid-Bugs-To: nicolas.prongue@rero.ch\n"
-"POT-Creation-Date: 2022-08-30 11:34+0200\n"
+"POT-Creation-Date: 2022-11-24 10:51+0100\n"
 "PO-Revision-Date: 2022-08-30 10:20+0000\n"
 "Last-Translator: Pascal Repond <pascal.repond@rero.ch>\n"
-"Language-Team: Italian <https://hosted.weblate.org/projects/rero_plus/sonar/"
-"it/>\n"
 "Language: it\n"
+"Language-Team: Italian "
+"<https://hosted.weblate.org/projects/rero_plus/sonar/it/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.14.1-dev\n"
 "Generated-By: Babel 2.10.1\n"
 
 #: sonar/theme/views.py:102
@@ -770,6 +769,7 @@ msgid "File UUID"
 msgstr "UUID del file"
 
 #: sonar/modules/documents/templates/documents/record.html:453
+#: sonar/theme/templates/sonar/macros/macro.html:52
 msgid "File downloads"
 msgstr "File downloads"
 
@@ -1790,8 +1790,8 @@ msgid ""
 "Select a subdivision (department, institute, faculty, other) if this "
 "publication belongs to it in your organisation."
 msgstr ""
-"Selezionare una suddivisione (dipartimento, istituto, facoltà, altro) se la "
-"pubblicazione appartiene ad essa nella vostra organizzazione."
+"Selezionare una suddivisione (dipartimento, istituto, facoltà, altro) se "
+"la pubblicazione appartiene ad essa nella vostra organizzazione."
 
 #: sonar/modules/documents/jsonschemas/documents/document-v1.0.0_src.json:616
 msgid "Serie"
@@ -5490,3 +5490,4 @@ msgstr "Fondo nazionale svizzero per la ricerca scientifica"
 #~ msgstr ""
 #~ "Powered by <a href=\"%(link)s\" "
 #~ "target=\"_blank\" rel=\"noopener\">SONAR</a>"
+

--- a/sonar/translations/messages.pot
+++ b/sonar/translations/messages.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: sonar 1.7.0\n"
+"Project-Id-Version: sonar 1.8.1\n"
 "Report-Msgid-Bugs-To: software@rero.ch\n"
-"POT-Creation-Date: 2022-08-30 11:34+0200\n"
+"POT-Creation-Date: 2022-11-24 10:51+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -755,6 +755,7 @@ msgid "File UUID"
 msgstr ""
 
 #: sonar/modules/documents/templates/documents/record.html:453
+#: sonar/theme/templates/sonar/macros/macro.html:52
 msgid "File downloads"
 msgstr ""
 

--- a/sonar/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/sonar/translations/nb_NO/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sonar 0.5.0\n"
 "Report-Msgid-Bugs-To: nicolas.prongue@rero.ch\n"
-"POT-Creation-Date: 2022-08-30 11:34+0200\n"
+"POT-Creation-Date: 2022-11-24 10:51+0100\n"
 "PO-Revision-Date: 2022-02-03 16:16+0000\n"
 "Last-Translator: Nicolas Prongué <n.prongue@outlook.com>\n"
 "Language: nb_NO\n"
@@ -762,6 +762,7 @@ msgid "File UUID"
 msgstr "Fil-UUID"
 
 #: sonar/modules/documents/templates/documents/record.html:453
+#: sonar/theme/templates/sonar/macros/macro.html:52
 msgid "File downloads"
 msgstr ""
 

--- a/sonar/version.py
+++ b/sonar/version.py
@@ -23,4 +23,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.8.1'
+__version__ = '1.8.2'

--- a/tests/ui/documents/test_documents_api.py
+++ b/tests/ui/documents/test_documents_api.py
@@ -198,3 +198,7 @@ def test_affiliations(document):
     data['contribution'][0]['affiliation'] = 'Uni of Geneva and HUG, Uni of Lausanne and CHUV'
     document.update(data)
     assert len(document['contribution'][0]['controlledAffiliation']) == 2
+
+    data['contribution'][0].pop('affiliation', None)
+    document.update(data)
+    assert 'controlledAffiliation' not in document['contribution'][0]

--- a/tests/ui/documents/test_documents_api.py
+++ b/tests/ui/documents/test_documents_api.py
@@ -17,6 +17,8 @@
 
 """Test documents API."""
 
+from copy import deepcopy
+
 from flask import url_for
 from invenio_stats.tasks import aggregate_events, process_events
 
@@ -184,3 +186,15 @@ def test_stats(app, client, document_with_file, es, db, event_queues):
     assert document_with_file.statistics['file-download']['test1.pdf'] == 1
     # the thumbnail should not be in the statistics
     assert not 'test1-pdf.jpg' in document_with_file.statistics['file-download']
+
+
+def test_affiliations(document):
+    """Test controlled affiliation."""
+    data = deepcopy(dict(document))
+    data['contribution'][0]['affiliation'] = 'foo'
+    document.update(data)
+    assert 'controlledAffiliation' not in document['contribution'][0]
+
+    data['contribution'][0]['affiliation'] = 'Uni of Geneva and HUG, Uni of Lausanne and CHUV'
+    document.update(data)
+    assert len(document['contribution'][0]['controlledAffiliation']) == 2


### PR DESCRIPTION
* In case where there is no affiliation, the controlledAffiliation field should also be cleared.

Co-Authored-by: Pascal Repond <pascal.repond@rero.ch>

:warning: When reviewed, I propose to force push this small fix into the 1.8.2 release.