### PR TITLE
orcid: change legacy URL

### DIFF
--- a/sonar/config.py
+++ b/sonar/config.py
@@ -779,8 +779,8 @@ OAUTHCLIENT_REMOTE_APPS['orcid']['signup_handler']['setup'] = \
     'sonar.modules.oauth.orcid:account_setup'
 OAUTHCLIENT_REMOTE_APPS['orcid']['params'].update(
     dict(
-        base_url='https://pub.{domain}/'.format(domain=ORCID_DOMAIN),
-        access_token_url='https://pub.{domain}/oauth/token'.format(
+        base_url='https://{domain}/'.format(domain=ORCID_DOMAIN),
+        access_token_url='https://{domain}/oauth/token'.format(
             domain=ORCID_DOMAIN),
         authorize_url='https://{domain}/oauth/authorize#show_login'.format(
             domain=ORCID_DOMAIN),


### PR DESCRIPTION
ORCID has changed their base URL for oauth. The old URL is a redirect which
is not supported by invenio.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
