### PR TITLE
documents: fix import document indexing

### DIFF
--- a/sonar/modules/documents/cli/rerodoc.py
+++ b/sonar/modules/documents/cli/rerodoc.py
@@ -55,8 +55,6 @@ def update_file_permissions(permissions_file, chunk_size):
         :param ids: List of records to save
         """
         db.session.commit()
-        indexer.bulk_index(ids)
-        indexer.process_bulk_queue()
 
     try:
         with open(permissions_file.name, 'r') as file:
@@ -133,6 +131,7 @@ def update_file_permissions(permissions_file, chunk_size):
 
                     record.commit()
                     db.session.flush()
+                    record.reindex()
                     ids.append(str(record.id))
 
                     current_app.logger.warning(

--- a/sonar/modules/documents/tasks.py
+++ b/sonar/modules/documents/tasks.py
@@ -84,6 +84,7 @@ def import_records(records_to_import):
 
             # Pushing record to database, not yet persisted into DB
             db.session.flush()
+            record.reindex()
 
             # Add ID for bulk index in elasticsearch
             ids.append(str(record.id))
@@ -99,7 +100,5 @@ def import_records(records_to_import):
 
     # Commit and index records
     db.session.commit()
-    indexer.bulk_index(ids)
-    indexer.process_bulk_queue()
 
     return ids


### PR DESCRIPTION
The bulk index does not take into account a specific record class, thus the dumpers are not used. A non bulk indexing is used instead.

Co-authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
