### PR TITLE
documents: removes permssions from the search list

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1980,13 +1980,13 @@ tests = ["cachelib (>=0.1)", "invenio-db[mysql,postgresql] (>=1.1.2)", "pytest-b
 
 [[package]]
 name = "invenio-accounts"
-version = "3.5.1"
+version = "3.5.2"
 description = "Invenio user management and authentication."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "invenio-accounts-3.5.1.tar.gz", hash = "sha256:6c005d16c8c18533f233be29bd75264f9bd0a7bc7352a8d05b7779a401461333"},
-    {file = "invenio_accounts-3.5.1-py2.py3-none-any.whl", hash = "sha256:e42f8329a6c3ace69bed4b9c11c4428cc9e68b2abc57a742dcc6f1f736a576e4"},
+    {file = "invenio-accounts-3.5.2.tar.gz", hash = "sha256:bb68f2e62a344b591555c029becbfc5ea36c8399c386205e170c517984aea38b"},
+    {file = "invenio_accounts-3.5.2-py2.py3-none-any.whl", hash = "sha256:79d92d592319584f089f38b0199b4451b1feb7c4dfc060706a4288223fb44a38"},
 ]
 
 [package.dependencies]
@@ -2008,7 +2008,7 @@ admin = ["invenio-admin (>=1.2.1)"]
 mysql = ["invenio-db[mysql] (>=1.0.14)"]
 postgresql = ["invenio-db[postgresql] (>=1.0.14)"]
 sqlite = ["invenio-db (>=1.0.14)"]
-tests = ["invenio-app (>=1.3.3)", "mock (>=1.3.0)", "pytest-black (>=0.3.0)", "pytest-invenio (>=2.1.4)", "sphinx (>=4.2.0,<5)"]
+tests = ["invenio-app (>=1.3.3)", "mock (>=1.3.0)", "pytest-black (>=0.3.0)", "pytest-invenio (>=2.1.4)", "sphinx (>=5,<6.0.0)"]
 
 [[package]]
 name = "invenio-admin"
@@ -6527,4 +6527,4 @@ tests = ["pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.9, <3.10"
-content-hash = "6a5846379dd6bc537ba1be70f9341b7f4031fdf30cde22ab82d67e7f87d63fda"
+content-hash = "08329244dc1f19fb6f7b4bc9e117f5002a61a3ba8d9bc5f4d8902ec5afc126f2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ invenio-theme = ">=2.5.7,<3.0.0"
 
 # Invenio auth bundle
 invenio-access = ">=2.0.0,<3.0.0"
-invenio-accounts = ">=3.0.0,<4.0.0"
+invenio-accounts = ">=3.5.2,<4.0.0"
 invenio-oauth2server = ">=2.0.0,<3.0.0"
 invenio-oauthclient = ">=3.0.0,<4.0.0"
 invenio-userprofiles = "^2.3.1"

--- a/sonar/modules/documents/marshmallow/json.py
+++ b/sonar/modules/documents/marshmallow/json.py
@@ -149,7 +149,7 @@ class DocumentListMetadataSchemaV1(StrictKeysMixin):
     customField3 = fields.List(fields.String(validate=validate.Length(min=1)))
     masked = SanitizedUnicode()
     _bucket = SanitizedUnicode()
-    _files = Nested(FileSchemaV1, many=True)
+    _files = Nested(ThumbnailSchemaV1, many=True)
     _oai = fields.Dict()
     # When loading, if $schema is not provided, it's retrieved by
     # Record.schema property.

--- a/tests/api/documents/test_documents_rest.py
+++ b/tests/api/documents/test_documents_rest.py
@@ -23,6 +23,21 @@ from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 
 
+def test_get(client, document_with_file):
+    """Get REST methods."""
+    res = client.get(url_for('invenio_records_rest.doc_list', view='global'))
+    assert res.status_code == 200
+    assert res.json['hits']['total']['value'] == 1
+    # the search results does not contains permissions
+    assert not res.json['hits']['hits'][0]['metadata']['_files'][0].get("permissions")
+
+    # the item result should contains permissions
+    res = client.get(url_for('invenio_records_rest.doc_item', pid_value=document_with_file['pid']))
+    assert res.status_code == 200
+    assert res.json['metadata']['_files'][0]['permissions'] == {
+        'delete': False, 'read': False,'update': False}
+
+
 def test_put(app, client, document_with_file):
     """Test putting metadata on existing file."""
     # Disable configuration


### PR DESCRIPTION
* Removes the useless files permissions from the search list to speed up the server responses.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
