### PR TITLE
fix(stats): display the label instead of the file name

### DIFF
--- a/sonar/modules/documents/api.py
+++ b/sonar/modules/documents/api.py
@@ -17,7 +17,6 @@
 
 """Document Api."""
 
-
 import contextlib
 from datetime import datetime
 from functools import partial
@@ -422,13 +421,16 @@ class DocumentRecord(SonarRecord):
             res["record-view"] = 0
         query_cfg = current_stats.queries["file-download"]
         query = query_cfg.cls(name="file-download", **query_cfg.params)
-        res["file-download"] = {f["key"]: 0 for f in self.get_files_list()}
+        files = self.get_files_list()
+        res["file-download"] = {
+            f["key"]: {"count": 0, "label": f["label"]} for f in files
+        }
         with contextlib.suppress(NotFoundError):
             res_query = query.run(bucket_id=self.bucket_id)
             file_keys = res["file-download"].keys()
             for b in res_query["buckets"]:
                 if b.get("key") in file_keys:
-                    res["file-download"][b["key"]] = int(b["unique_count"])
+                    res["file-download"][b["key"]]["count"] = int(b["unique_count"])
         return res
 
     def get_ark(self):

--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -53,7 +53,7 @@ along with this program. If not, see
       {% if files and files | length > 0 %}
       <div class="mb-4">
         {{ thumbnail(record, first_file,
-        stats['file-download'][first_file['key']] or 0) }}
+        stats['file-download'][first_file['key']]['count'] or 0) }}
       </div>
       {% else %}
       <img src="{{ url_for('static', filename='images/no-image.png') }}" alt="{{ title }}" class="img-fluid">
@@ -445,13 +445,13 @@ along with this program. If not, see
   </div>
 
   {% if files and files | length > 1 %}
-  <h5 id="other_files" class="mt-5">{{ _('Other files') }}</h5>
+  <h5 id="other_files" class="mt-2">{{ _('Other files') }}</h5>
   <hr class="mb-4 mt-0">
   <div class="row">
     {% for file in files %}
       {% if loop.index > 1 %}
         <div class="col-lg-2">
-          {{ thumbnail(record, file, stats['file-download'][file['key']] or 0) }}
+          {{ thumbnail(record, file, stats['file-download'][file['key']]['count'] or 0) }}
           {% if file.label %}
             <div class="text-center">
               {{ file.label }}
@@ -472,7 +472,13 @@ along with this program. If not, see
       <strong class="mt-2 d-block">{{ _('File downloads') }}:</strong>
       <ul>
         {% for key, value in stats['file-download'].items() %}
-        <li>{{ key }}: {{ value }}</li>
+        <li>
+          {% if  value["label"] != key %}
+            <span class="sonar-tooltip" title="{{ key }}">{{ value["label"] }}:</span> {{ value["count"] }}
+          {% else %}
+            <span>{{ value["label"] }}: {{ value["count"] }}</span>
+          {% endif %}
+        </li>
         {% endfor %}
       </ul>
     </div>

--- a/tests/ui/documents/test_documents_api.py
+++ b/tests/ui/documents/test_documents_api.py
@@ -183,8 +183,15 @@ def test_stats(app, client, document_with_file, es, db, event_queues):
     aggregate_events(["file-download-agg", "record-view-agg"])
     es.indices.refresh(index="stats-file-download")
     es.indices.refresh(index="stats-record-view")
+
+    document_with_file.files["test1.pdf"]["label"] = "test1"
+    document_with_file.commit()
+
     assert document_with_file.statistics["record-view"] == 1
-    assert document_with_file.statistics["file-download"]["test1.pdf"] == 1
+    assert document_with_file.statistics["file-download"]["test1.pdf"]["count"] == 1
+    assert (
+        document_with_file.statistics["file-download"]["test1.pdf"]["label"] == "test1"
+    )
     # the thumbnail should not be in the statistics
     assert not "test1-pdf.jpg" in document_with_file.statistics["file-download"]
 
@@ -196,9 +203,9 @@ def test_affiliations(document):
     document.update(data)
     assert "controlledAffiliation" not in document["contribution"][0]
 
-    data["contribution"][0][
-        "affiliation"
-    ] = "Uni of Geneva and HUG, Uni of Lausanne and CHUV"
+    data["contribution"][0]["affiliation"] = (
+        "Uni of Geneva and HUG, Uni of Lausanne and CHUV"
+    )
     document.update(data)
     assert len(document["contribution"][0]["controlledAffiliation"]) == 2
 


### PR DESCRIPTION
* Closes RT476.
* The filename is still displayed in a tooltip.
* Changes the statistics endpoint to return the file name as well as the label.