### PR TITLE
fix: add cascading deletions to improve data consistency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,6 +247,7 @@ subdivisions = "sonar.modules.subdivisions.jsonresolvers"
 documents = "sonar.modules.documents.tasks"
 stats = "sonar.modules.stats.tasks"
 sitemap = "sonar.modules.sitemap.tasks"
+users = "sonar.modules.users.tasks"
 
 [project.entry-points."invenio_admin.views"]
 stats = "sonar.modules.stats.admin:stats_adminview"

--- a/sonar/modules/documents/api.py
+++ b/sonar/modules/documents/api.py
@@ -321,6 +321,23 @@ class DocumentRecord(SonarRecord):
         self.guess_controlled_affiliations(data)
         return super().update(data)
 
+    def delete(self, force=False, dbcommit=False, delindex=False):
+        """Delete record and persistent identifier.
+
+        :param force: True to hard delete record.
+        :param dbcommit: True for validating database transaction.
+        :param delindex: True to remove record from index.
+        """
+        # Remove deposits.
+        from ..deposits.api import DepositRecord, DepositSearch
+
+        query = DepositSearch().filter("term", document__pid=self["pid"])
+        for hit in query.source("pid").scan():
+            deposit = DepositRecord.get_record_by_pid(hit.pid)
+            deposit.delete(force=force, dbcommit=dbcommit, delindex=delindex)
+
+        return super().delete(force=force, dbcommit=dbcommit, delindex=delindex)
+
     def is_open_access(self):
         """Check if current document is open access.
 
@@ -444,3 +461,14 @@ class DocumentIndexer(SonarIndexer):
     record_cls = DocumentRecord
 
     record_dumper = document_indexer_dumper
+
+    def delete(self, record):
+        """Delete a record.
+
+        :param record: Record instance.
+        """
+        from ..deposits.api import DepositSearch
+
+        DepositSearch().filter("term", document__pid=record["pid"]).delete()
+
+        return super().delete(record)

--- a/sonar/modules/users/api.py
+++ b/sonar/modules/users/api.py
@@ -1,5 +1,5 @@
 # Swiss Open Access Repository
-# Copyright (C) 2021 RERO
+# Copyright (C) 2025 RERO
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -169,7 +169,7 @@ class UserRecord(SonarRecord):
         self.sync_roles()
         return self
 
-    def delete(self, force=False, dbcommit=True, delindex=False):
+    def delete(self, force=False, dbcommit=False, delindex=False):
         """Delete record and persistent identifier.
 
         :param force: True to hard delete record.
@@ -178,6 +178,11 @@ class UserRecord(SonarRecord):
         """
         # Remove roles from user account.
         self.remove_roles()
+
+        # Remove deposits.
+        from .tasks import delete_deposits
+
+        delete_deposits.delay(user_pid=self["pid"], force=force, dbcommit=dbcommit, delindex=delindex)
 
         return super().delete(force=force, dbcommit=dbcommit, delindex=delindex)
 
@@ -349,3 +354,14 @@ class UserIndexer(SonarIndexer):
     """Indexing documents in Elasticsearch."""
 
     record_cls = UserRecord
+
+    def delete(self, record):
+        """Delete a record.
+
+        :param record: Record instance.
+        """
+        from ..deposits.api import DepositSearch
+
+        DepositSearch().filter("term", user__pid=record["pid"]).delete()
+
+        return super().delete(record)

--- a/sonar/modules/users/tasks.py
+++ b/sonar/modules/users/tasks.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# Swiss Open Access Repository
+# Copyright (C) 2025 RERO
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Celery tasks for users."""
+
+from celery import shared_task
+
+from ..deposits.api import DepositRecord, DepositSearch
+
+
+@shared_task()
+def delete_deposits(user_pid, force=False, dbcommit=True, delindex=False):
+    """Delete deposits for user.
+
+    :param user_pid: User pid.
+    :param force: True to hard delete record.
+    :param dbcommit: True for validating database transaction.
+    :param delindex: True to remove record from index.
+    :returns: Count of deleted deposits.
+    """
+    query = DepositSearch().filter("term", user__pid=user_pid)
+    count = 0
+    for count, hit in enumerate(query.source("pid").scan()):
+        deposit = DepositRecord.get_record_by_pid(hit.pid)
+        deposit.delete(force=force, dbcommit=dbcommit, delindex=delindex)
+    return count


### PR DESCRIPTION
* Deletes corresponding deposit during document deletion.
* Deletes corresponding deposits during user deletion.
* Prevent deleting a subdivision if it has any linked user or deposit.
* Closes #948.