### PR TITLE
fix(pdf_extractor): flush temp file buffer before pdftotext reads it

### DIFF
--- a/sonar/modules/pdf_extractor/utils.py
+++ b/sonar/modules/pdf_extractor/utils.py
@@ -30,6 +30,7 @@ def extract_text_from_content(content):
     """
     with tempfile.NamedTemporaryFile(mode="w+b", suffix=".pdf") as temp:
         temp.write(content)
+        temp.flush()
         return extract_text_from_file(temp.name)
 
 

--- a/tests/ui/pdf_extractor/test_pdf_extractor_utils.py
+++ b/tests/ui/pdf_extractor/test_pdf_extractor_utils.py
@@ -18,7 +18,16 @@
 import json
 import os
 
-from sonar.modules.pdf_extractor.utils import format_extracted_data
+from sonar.modules.pdf_extractor.utils import extract_text_from_content, format_extracted_data
+
+
+def test_extract_text_from_content(app, pdf_file):
+    """Test that text is correctly extracted from PDF binary content."""
+    with open(pdf_file, "rb") as f:
+        content = f.read()
+    text = extract_text_from_content(content)
+    assert isinstance(text, str)
+    assert len(text) > 0
 
 
 def test_format_extracted_data(app):


### PR DESCRIPTION
Missing flush() caused pdftotext to read an incomplete file, silently failing fulltext extraction for any uploaded PDF. Add a unit test that calls extract_text_from_content with real binary content to prevent regression.