### PR TITLE
fix(fixtures): scope random links to the document's organisation

### DIFF
--- a/sonar/modules/cli/fixtures.py
+++ b/sonar/modules/cli/fixtures.py
@@ -79,6 +79,15 @@ def replace_user_from_dict(a_dict):
             v = [replace_user_from_dict(el) for el in v if el]
 
 
+def build_pids_by_org(pid_record_pairs, get_org_ref):
+    """Build {org_pid: [pids]} from (pid, record) pairs."""
+    mapping = {}
+    for pid, record in pid_record_pairs:
+        if record and (org_ref := get_org_ref(record)):
+            mapping.setdefault(org_ref.split("/")[-1], []).append(pid)
+    return mapping
+
+
 @fixtures.command("import")
 @click.argument("file", type=click.File("r"))
 @click.argument("doc_type")
@@ -103,17 +112,28 @@ def import_data(file, doc_type, random_files, with_file_support):
     else:
         indexer = obj_or_import_string(config.get("indexer_class"))()
         record_class = obj_or_import_string(config.get("record_class"))
+        # Pre-build org → pids maps so random links stay within the same organisation.
         if doc_type == "doc":
-            subdivision_pids = list(SubdivisionRecord.get_all_pids())
+            subdivision_pids_by_org = build_pids_by_org(
+                ((pid, SubdivisionRecord.get_record_by_pid(pid)) for pid in SubdivisionRecord.get_all_pids()),
+                lambda r: r.get("organisation", {}).get("$ref"),
+            )
         if doc_type in ["doc", "depo"]:
-            collections_pids = list(CollectionRecord.get_all_pids())
+            collections_pids_by_org = build_pids_by_org(
+                ((pid, CollectionRecord.get_record_by_pid(pid)) for pid in CollectionRecord.get_all_pids()),
+                lambda r: r.get("organisation", {}).get("$ref"),
+            )
             project_service = current_app.extensions["sonar"].resources.get("projects").service
-            project_pids = [
-                r.pid_value
-                for r in PersistentIdentifier.query.filter_by(pid_type=project_service.record_cls.pid_type)
-                .filter_by(status=PIDStatus.REGISTERED)
-                .all()
-            ]
+            # Projects use invenio-records-resources: PID → UUID → record (no get_record_by_pid).
+            project_pids_by_org = build_pids_by_org(
+                (
+                    (p.pid_value, project_service.record_cls.get_record(str(p.object_uuid)))
+                    for p in PersistentIdentifier.query.filter_by(pid_type=project_service.record_cls.pid_type)
+                    .filter_by(status=PIDStatus.REGISTERED)
+                    .all()
+                ),
+                lambda r: r.get("metadata", {}).get("organisation", {}).get("$ref"),
+            )
 
     data_documents = json.load(file)
     with click.progressbar(data_documents, label="Loading record...") as bar:
@@ -123,23 +143,38 @@ def import_data(file, doc_type, random_files, with_file_support):
                 if service:
                     service.create(system_identity, record)
                 else:
-                    # create random links to subdivisions, collections and projects
-                    if doc_type == "doc" and random.randint(0, 10) == 0:
+                    # Resolve the organisation PID for this record (used to scope random links below).
+                    if doc_type == "doc":
+                        org_refs = record.get("organisation", [])
+                        org_pid = org_refs[0]["$ref"].split("/")[-1] if org_refs else None
+                    elif doc_type == "depo":
+                        # Deposits carry no direct org field; resolve it via the submitting user.
+                        user_pid = record.get("user", {}).get("$ref", "").split("/")[-1]
+                        user = UserRecord.get_record_by_pid(user_pid) if user_pid else None
+                        org_pid = (
+                            user["organisation"]["$ref"].split("/")[-1] if user and user.get("organisation") else None
+                        )
+                    else:
+                        org_pid = None
+
+                    # Randomly assign org-scoped links (1-in-11 chance each).
+                    if (
+                        doc_type == "doc"
+                        and org_pid
+                        and (org_subs := subdivision_pids_by_org.get(org_pid, []))
+                        and random.randint(0, 10) == 0
+                    ):
                         record["subdivisions"] = [
-                            {"$ref": f"https://sonar.ch/api/subdivisions/{random.choice(subdivision_pids)}"}
+                            {"$ref": f"https://sonar.ch/api/subdivisions/{random.choice(org_subs)}"}
                         ]
-                    if doc_type in ["doc", "depo"]:
-                        data = record
-                        if doc_type == "depo":
-                            data = record["metadata"]
-                        if random.randint(0, 10) == 0:
+                    if doc_type in ["doc", "depo"] and org_pid:
+                        data = record["metadata"] if doc_type == "depo" else record
+                        if (org_cols := collections_pids_by_org.get(org_pid, [])) and random.randint(0, 10) == 0:
                             data["collections"] = [
-                                {"$ref": f"https://sonar.ch/api/collections/{random.choice(collections_pids)}"}
+                                {"$ref": f"https://sonar.ch/api/collections/{random.choice(org_cols)}"}
                             ]
-                        if random.randint(0, 10) == 0:
-                            data["projects"] = [
-                                {"$ref": f"https://sonar.ch/api/projects/{random.choice(project_pids)}"}
-                            ]
+                        if (org_projs := project_pids_by_org.get(org_pid, [])) and random.randint(0, 10) == 0:
+                            data["projects"] = [{"$ref": f"https://sonar.ch/api/projects/{random.choice(org_projs)}"}]
 
                     files = record.pop("files", [])
                     if not with_file_support and (files or random_files):


### PR DESCRIPTION
Random assignments of subdivisions, collections and projects during fixture import picked from all available PIDs regardless of organisation, causing facet entries to appear without a label when a document was linked to a resource from a different org.

Fix by pre-building {org_pid: [pids]} maps for each resource type and resolving the record's org (directly for documents, via the submitting user for deposits) before sampling. Introduce build_pids_by_org() to remove the repeated mapping loop.