### PR TITLE
feat(documents): add BibTeX, RIS serializers and export

### DIFF
--- a/sonar/config.py
+++ b/sonar/config.py
@@ -366,21 +366,33 @@ RECORDS_REST_ENDPOINTS = {
                 "sonar.modules.documents.serializers" ":json_doc_response"
             ),
             "text/xml": ("sonar.modules.documents.serializers" ":dc_v1_response"),
+            "application/x-bibtex": ("sonar.modules.documents.serializers" ":bibtex_v1_response"),
+            "application/x-research-info-systems": (
+                "sonar.modules.documents.serializers" ":ris_v1_response"
+            ),
         },
         record_serializers_aliases={
             "json": "application/json",
             "rero": "application/rero+json",
             "dc": "text/xml",
+            "bibtex": "application/x-bibtex",
+            "ris": "application/x-research-info-systems",
         },
         search_serializers={
             "application/json": (
                 "sonar.modules.documents.serializers" ":json_v1_search"
             ),
             "text/xml": ("sonar.modules.documents.serializers" ":dc_v1_search"),
+            "application/x-bibtex": ("sonar.modules.documents.serializers" ":bibtex_v1_search"),
+            "application/x-research-info-systems": (
+                "sonar.modules.documents.serializers" ":ris_v1_search"
+            ),
         },
         search_serializers_aliases={
             "json": "application/json",
             "dc": "text/xml",
+            "bibtex": "application/x-bibtex",
+            "ris": "application/x-research-info-systems",
         },
         record_loaders={
             "application/json": ("sonar.modules.documents.loaders" ":json_v1"),

--- a/sonar/modules/documents/rest.py
+++ b/sonar/modules/documents/rest.py
@@ -3,7 +3,10 @@
 
 """Documents rest views."""
 
-from flask import Blueprint, current_app, jsonify, request
+from datetime import UTC, datetime
+
+from flask import Blueprint, Response, current_app, jsonify, request
+from werkzeug.utils import secure_filename
 
 from sonar.modules.organisations.api import OrganisationRecord, current_organisation
 from sonar.modules.users.api import current_user_record
@@ -76,3 +79,51 @@ def aggregations():
         aggregations_list.remove("subdivision")
 
     return jsonify(aggregations_list)
+
+
+@api_blueprint.route("/<pid_value>/export/<fmt>", methods=["GET"])
+def export(pid_value, fmt):
+    """Export a document record in the requested format as a downloadable file.
+
+    :param pid_value: Document PID.
+    :param fmt: Format alias (json, dc, bibtex, ris).
+    """
+    from invenio_pidstore.errors import PIDDoesNotExistError
+    from invenio_pidstore.models import PersistentIdentifier
+    from sqlalchemy.exc import SQLAlchemyError
+
+    from sonar.modules.documents.api import DocumentRecord
+    from sonar.modules.documents.serializers import bibtex_v1, dc_v1, json_v1, ris_v1
+
+    formats = {
+        "json": (json_v1, "application/json", ".json"),
+        "dc": (dc_v1, "text/xml", ".xml"),
+        "bibtex": (bibtex_v1, "application/x-bibtex", ".bib"),
+        "ris": (ris_v1, "application/x-research-info-systems", ".ris"),
+    }
+
+    if fmt not in formats:
+        return jsonify({"message": f"Unsupported format '{fmt}'. Choose from: {', '.join(formats)}"}), 400
+
+    try:
+        pid = PersistentIdentifier.get(DocumentRecord.provider.pid_type, pid_value)
+        record = DocumentRecord.get_record_by_pid(pid_value)
+    except PIDDoesNotExistError:
+        return jsonify({"message": "Document not found"}), 404
+    except SQLAlchemyError:
+        current_app.logger.exception("Unexpected DB error while resolving document %s", pid_value)
+        raise
+
+    if record is None:
+        return jsonify({"message": "Document not found"}), 404
+
+    serializer, mimetype, extension = formats[fmt]
+    body = serializer.serialize(pid, record)
+    today = datetime.now(UTC).strftime("%Y%m%d")
+    safe_pid_value = secure_filename(pid_value)
+
+    return Response(
+        body,
+        mimetype=mimetype,
+        headers={"Content-Disposition": f"attachment; filename={today}-{safe_pid_value}{extension}"},
+    )

--- a/sonar/modules/documents/serializers/__init__.py
+++ b/sonar/modules/documents/serializers/__init__.py
@@ -11,9 +11,11 @@ from invenio_records_rest.serializers.response import (
 from sonar.modules.documents.serializers.schemas.dc import DublinCoreSchema
 
 from ..marshmallow import DocumentListSchemaV1, DocumentReroSchemaV1, DocumentSchemaV1
+from .bibtex import BibTeXSerializer
 from .dc import DublinCoreSerializer
 from .google_scholar import SonarGoogleScholarSerializer
 from .json import JSONSerializer
+from .ris import RISSerializer
 from .schemaorg import SonarSchemaOrgSerializer
 from .schemas.google_scholar import GoogleScholarV1
 from .schemas.schemaorg import SchemaOrgV1
@@ -30,6 +32,8 @@ schemaorg_v1 = SonarSchemaOrgSerializer(SchemaOrgV1, replace_refs=True)
 google_scholar_v1 = SonarGoogleScholarSerializer(GoogleScholarV1, replace_refs=True)
 
 dc_v1 = DublinCoreSerializer(DublinCoreSchema)
+bibtex_v1 = BibTeXSerializer()
+ris_v1 = RISSerializer()
 
 # Records-REST serializers
 # ========================
@@ -39,15 +43,29 @@ json_doc_response = record_responsify(json_doc, "application/rero+json")
 #: JSON record serializer for search results.
 json_v1_search = search_responsify(json_list_v1, "application/json")
 
-#: JSON record serializer for individual records.
+#: Dublin Core record serializer for individual records.
 dc_v1_response = record_responsify(dc_v1, "text/xml")
-#: JSON record serializer for search results.
+#: Dublin Core record serializer for search results.
 dc_v1_search = search_responsify(dc_v1, "text/xml")
 
+#: BibTeX record serializer for individual records.
+bibtex_v1_response = record_responsify(bibtex_v1, "application/x-bibtex")
+#: BibTeX record serializer for search results.
+bibtex_v1_search = search_responsify(bibtex_v1, "application/x-bibtex")
+
+#: RIS record serializer for individual records.
+ris_v1_response = record_responsify(ris_v1, "application/x-research-info-systems")
+#: RIS record serializer for search results.
+ris_v1_search = search_responsify(ris_v1, "application/x-research-info-systems")
+
 __all__ = (
+    "bibtex_v1_response",
+    "bibtex_v1_search",
     "dc_v1_response",
     "dc_v1_search",
     "json_v1",
     "json_v1_response",
     "json_v1_search",
+    "ris_v1_response",
+    "ris_v1_search",
 )

--- a/sonar/modules/documents/serializers/bibtex.py
+++ b/sonar/modules/documents/serializers/bibtex.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""BibTeX serializer."""
+
+from invenio_records_rest.serializers.base import SerializerMixinInterface
+
+from .common import (
+    extract_abstract,
+    extract_authors,
+    extract_editors,
+    extract_journal_info,
+    extract_publication_info,
+    extract_title,
+)
+
+# Mapping from COAR resource types to BibTeX entry types.
+# https://purl.org/coar/resource_type
+_COAR_TO_BIBTEX = {
+    "coar:c_2f33": "book",  # book
+    "coar:c_3248": "book",  # book part → use book as fallback
+    "coar:c_5794": "article",  # journal article
+    "coar:c_18cp": "inproceedings",  # conference paper
+    "coar:c_6670": "incollection",  # book chapter
+    "coar:c_816b": "mastersthesis",  # master thesis
+    "coar:c_db06": "phdthesis",  # doctoral thesis
+    "coar:c_7a1f": "phdthesis",  # thesis
+    "coar:c_bdcc": "mastersthesis",  # master thesis (other)
+    "coar:c_46ec": "phdthesis",  # thesis (generic)
+    "coar:c_8042": "techreport",  # technical report
+}
+
+
+def _bibtex_entry_type(doc_type):
+    """Return BibTeX entry type for a COAR document type."""
+    return _COAR_TO_BIBTEX.get(doc_type, "misc")
+
+
+def _bibtex_key(metadata):
+    """Generate a BibTeX cite key from first author and year."""
+    authors = extract_authors(metadata)
+    name = authors[0].split(",")[0].strip() if authors else "unknown"
+    year, _, _ = extract_publication_info(metadata)
+    return f"{name}{year or ''}"
+
+
+def _bibtex_field(name, value):
+    """Return a formatted BibTeX field line."""
+    return f"  {name:<12} = {{{value}}}"
+
+
+def serialize_record_to_bibtex(metadata):
+    """Serialize a document metadata dict to a BibTeX entry string."""
+    doc_type = metadata.get("documentType", "")
+    entry_type = _bibtex_entry_type(doc_type)
+    key = _bibtex_key(metadata)
+
+    fields = []
+
+    # Authors
+    if authors := extract_authors(metadata):
+        fields.append(_bibtex_field("author", " and ".join(authors)))
+
+    # Editors (only if no authors)
+    editors = extract_editors(metadata)
+    if editors and not authors:
+        fields.append(_bibtex_field("editor", " and ".join(editors)))
+
+    # Title
+    if title := extract_title(metadata):
+        fields.append(_bibtex_field("title", title))
+
+    # Publication info
+    year, place, publisher = extract_publication_info(metadata)
+    if year:
+        fields.append(_bibtex_field("year", year))
+    if place:
+        fields.append(_bibtex_field("address", place))
+    if publisher:
+        fields.append(_bibtex_field("publisher", publisher))
+
+    # Journal / partOf
+    journal, volume, issue, pages = extract_journal_info(metadata)
+    if journal:
+        fields.append(_bibtex_field("journal", journal))
+    if volume:
+        fields.append(_bibtex_field("volume", volume))
+    if issue:
+        fields.append(_bibtex_field("number", issue))
+    if pages:
+        fields.append(_bibtex_field("pages", pages))
+
+    # Identifiers
+    for identifier in metadata.get("identifiedBy", []):
+        if identifier.get("type") == "bf:Doi":
+            fields.append(_bibtex_field("doi", identifier["value"]))
+        elif identifier.get("type") in ("bf:Isbn", "bf:Issn"):
+            fields.append(_bibtex_field("isbn", identifier["value"]))
+
+    # Abstract
+    if abstract := extract_abstract(metadata):
+        fields.append(_bibtex_field("abstract", abstract))
+
+    lines = [f"@{entry_type}{{{key},"] + [f"{f}," for f in fields] + ["}"]
+    return "\n".join(lines)
+
+
+class BibTeXSerializer(SerializerMixinInterface):
+    """BibTeX serializer for document records."""
+
+    mimetype = "application/x-bibtex"
+
+    def serialize(self, pid, record, links_factory=None):
+        """Serialize a single record to BibTeX."""
+        return serialize_record_to_bibtex(record.get("metadata", record))
+
+    def serialize_search(self, pid_fetcher, search_result, links=None, item_links_factory=None):
+        """Serialize search results to BibTeX (one entry per hit)."""
+        entries = [
+            serialize_record_to_bibtex(hit["_source"].get("metadata", hit["_source"]))
+            for hit in search_result["hits"]["hits"]
+        ]
+        return "\n\n".join(entries)

--- a/sonar/modules/documents/serializers/common.py
+++ b/sonar/modules/documents/serializers/common.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Shared metadata extraction helpers for citation serializers (BibTeX, RIS)."""
+
+
+def extract_authors(metadata):
+    """Return preferred names of contributors with the "cre" (creator) role."""
+    return [
+        c["agent"]["preferred_name"]
+        for c in metadata.get("contribution", [])
+        if "cre" in c.get("role", []) and c.get("agent", {}).get("preferred_name")
+    ]
+
+
+def extract_editors(metadata):
+    """Return preferred names of contributors with the "edt" (editor) role."""
+    return [
+        c["agent"]["preferred_name"]
+        for c in metadata.get("contribution", [])
+        if "edt" in c.get("role", []) and c.get("agent", {}).get("preferred_name")
+    ]
+
+
+def extract_title(metadata):
+    """Return the main title, combined with its subtitle if any."""
+    for title_entry in metadata.get("title", []):
+        if main_titles := title_entry.get("mainTitle", []):
+            title = main_titles[0]["value"]
+            subtitle = title_entry.get("subtitle", [{}])[0].get("value") if title_entry.get("subtitle") else None
+            return f"{title}: {subtitle}" if subtitle else title
+    return None
+
+
+def extract_publication_info(metadata):
+    """Return publication year, place and publisher from the "bf:Publication" activity."""
+    year = place = publisher = None
+    for activity in metadata.get("provisionActivity", []):
+        if activity.get("type") != "bf:Publication":
+            continue
+        if activity.get("startDate"):
+            year = activity["startDate"][:4]
+        for stmt in activity.get("statement", []):
+            label = stmt.get("label")
+            value = label[0]["value"] if isinstance(label, list) and label else (label or {}).get("value", "")
+            if stmt.get("type") == "bf:Place":
+                place = value
+            elif stmt.get("type") == "bf:Agent":
+                publisher = value
+        break
+    return year, place, publisher
+
+
+def extract_journal_info(metadata):
+    """Return journal title, volume, issue and pages from the first "partOf" entry."""
+    parts = metadata.get("partOf", [])
+    if not parts:
+        return None, None, None, None
+    part = parts[0]
+    journal = part.get("document", {}).get("title")
+    return journal, part.get("numberingVolume"), part.get("numberingIssue"), part.get("numberingPages")
+
+
+def extract_abstract(metadata):
+    """Return the first non-empty abstract value."""
+    for abstract in metadata.get("abstracts", []):
+        if abstract.get("value"):
+            return abstract["value"]
+    return None

--- a/sonar/modules/documents/serializers/ris.py
+++ b/sonar/modules/documents/serializers/ris.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""RIS serializer."""
+
+from invenio_records_rest.serializers.base import SerializerMixinInterface
+
+from .common import (
+    extract_abstract,
+    extract_authors,
+    extract_editors,
+    extract_journal_info,
+    extract_publication_info,
+    extract_title,
+)
+
+# Mapping from COAR resource types to RIS type tags.
+# https://purl.org/coar/resource_type
+_COAR_TO_RIS = {
+    "coar:c_2f33": "BOOK",  # book
+    "coar:c_3248": "CHAP",  # book part
+    "coar:c_5794": "JOUR",  # journal article
+    "coar:c_18cp": "CONF",  # conference paper
+    "coar:c_6670": "CHAP",  # book chapter
+    "coar:c_816b": "THES",  # master thesis
+    "coar:c_db06": "THES",  # doctoral thesis
+    "coar:c_7a1f": "THES",  # thesis
+    "coar:c_bdcc": "THES",  # master thesis (other)
+    "coar:c_46ec": "THES",  # thesis (generic)
+    "coar:c_8042": "RPRT",  # technical report
+}
+
+
+def _ris_type(doc_type):
+    """Return RIS type tag for a COAR document type."""
+    return _COAR_TO_RIS.get(doc_type, "GEN")
+
+
+def serialize_record_to_ris(metadata):
+    """Serialize a document metadata dict to a RIS entry string."""
+    lines = [f"TY  - {_ris_type(metadata.get('documentType', ''))}"]
+
+    # Authors
+    if authors := extract_authors(metadata):
+        lines.extend(f"AU  - {name}" for name in authors)
+
+    # Editors (only if no authors)
+    if not authors:
+        lines.extend(f"ED  - {name}" for name in extract_editors(metadata))
+
+    # Title
+    if title := extract_title(metadata):
+        lines.append(f"TI  - {title}")
+
+    # Publication info
+    year, place, publisher = extract_publication_info(metadata)
+    if year:
+        lines.append(f"PY  - {year}")
+    if place:
+        lines.append(f"CY  - {place}")
+    if publisher:
+        lines.append(f"PB  - {publisher}")
+
+    # Journal / partOf
+    journal, volume, issue, pages = extract_journal_info(metadata)
+    if journal:
+        lines.append(f"JO  - {journal}")
+    if volume:
+        lines.append(f"VL  - {volume}")
+    if issue:
+        lines.append(f"IS  - {issue}")
+    if pages:
+        page_range = pages.split("-")
+        lines.append(f"SP  - {page_range[0].strip()}")
+        if len(page_range) == 2:
+            lines.append(f"EP  - {page_range[1].strip()}")
+
+    # Identifiers
+    for identifier in metadata.get("identifiedBy", []):
+        if identifier.get("type") == "bf:Doi":
+            lines.append(f"DO  - {identifier['value']}")
+        elif identifier.get("type") in ("bf:Isbn", "bf:Issn"):
+            lines.append(f"SN  - {identifier['value']}")
+
+    # Abstract
+    if abstract := extract_abstract(metadata):
+        lines.append(f"AB  - {abstract}")
+
+    # Language
+    for language in metadata.get("language", []):
+        if language.get("value"):
+            lines.append(f"LA  - {language['value']}")
+            break
+
+    lines.append("ER  - ")
+    return "\n".join(lines)
+
+
+class RISSerializer(SerializerMixinInterface):
+    """RIS serializer for document records."""
+
+    mimetype = "application/x-research-info-systems"
+
+    def serialize(self, pid, record, links_factory=None):
+        """Serialize a single record to RIS."""
+        return serialize_record_to_ris(record.get("metadata", record))
+
+    def serialize_search(self, pid_fetcher, search_result, links=None, item_links_factory=None):
+        """Serialize search results to RIS (one entry per hit)."""
+        entries = [
+            serialize_record_to_ris(hit["_source"].get("metadata", hit["_source"]))
+            for hit in search_result["hits"]["hits"]
+        ]
+        return "\n\n".join(entries)

--- a/sonar/theme/views.py
+++ b/sonar/theme/views.py
@@ -47,6 +47,13 @@ from sonar.modules.users.api import current_user_record
 from sonar.modules.users.permissions import UserPermission
 from sonar.resources.projects.permissions import RecordPermissionPolicy
 
+_SERIALIZER_ICONS = {
+    "json": "fa-file-code-o",
+    "dc": "fa-file-code-o",
+    "bibtex": "fa-file-text-o",
+    "ris": "fa-file-text-o",
+}
+
 blueprint = Blueprint("sonar", __name__, template_folder="templates", static_folder="static")
 
 
@@ -121,7 +128,17 @@ def manage(path=None):
 @blueprint.route("/logged-user/", methods=["GET"])
 def logged_user():
     """Current logged user informations in JSON."""
-    data = {"settings": {"document_identifier_link": current_app.config.get("SONAR_APP_DOCUMENT_IDENTIFIER_LINK")}}
+    doc_endpoint = current_app.config.get("RECORDS_REST_ENDPOINTS", {}).get("doc", {})
+    data = {
+        "settings": {
+            "document_identifier_link": current_app.config.get("SONAR_APP_DOCUMENT_IDENTIFIER_LINK"),
+            "document_serializers": [
+                {"format": s, "icon": _SERIALIZER_ICONS.get(s, "fa-file-o")}
+                for s in doc_endpoint.get("record_serializers_aliases", {})
+                if s != "rero"
+            ],
+        }
+    }
 
     if not current_user.is_anonymous:
         user = current_user_record

--- a/tests/api/documents/test_documents_rest.py
+++ b/tests/api/documents/test_documents_rest.py
@@ -4,6 +4,7 @@
 """Test REST endpoint for documents."""
 
 import json
+import re
 from copy import deepcopy
 
 from flask import url_for
@@ -208,3 +209,65 @@ def test_aggregations(app, client, document, superuser, admin):
         "subdivision",
         {"key": "customField1", "name": "Test"},
     ]
+
+
+def test_export_invalid_format(client, document):
+    """Unsupported format returns 400."""
+    res = client.get(url_for("documents.export", pid_value=document["pid"], fmt="unknown"))
+    assert res.status_code == 400
+    assert "format" in res.json["message"].lower()
+
+
+def test_export_not_found(db, client):
+    """Unknown pid returns 404 for export."""
+    res = client.get(url_for("documents.export", pid_value="unknown-pid", fmt="json"))
+    assert res.status_code == 404
+
+
+def _assert_export_filename(headers, pid, extension):
+    """Assert Content-Disposition contains a dated filename."""
+    assert re.search(rf"\d{{8}}-{re.escape(pid)}{re.escape(extension)}", headers["Content-Disposition"])
+
+
+def test_export_json(client, document):
+    """JSON export returns attachment with .json extension."""
+    res = client.get(url_for("documents.export", pid_value=document["pid"], fmt="json"))
+    assert res.status_code == 200
+    assert res.content_type == "application/json"
+    _assert_export_filename(res.headers, document["pid"], ".json")
+
+
+def test_export_bibtex(client, document):
+    """BibTeX export returns attachment with .bib extension."""
+    res = client.get(url_for("documents.export", pid_value=document["pid"], fmt="bibtex"))
+    assert res.status_code == 200
+    assert res.content_type == "application/x-bibtex"
+    _assert_export_filename(res.headers, document["pid"], ".bib")
+    assert "@" in res.data.decode()
+
+
+def test_export_ris(client, document):
+    """RIS export returns attachment with .ris extension."""
+    res = client.get(url_for("documents.export", pid_value=document["pid"], fmt="ris"))
+    assert res.status_code == 200
+    assert res.content_type == "application/x-research-info-systems"
+    _assert_export_filename(res.headers, document["pid"], ".ris")
+    assert "TY  -" in res.data.decode()
+
+
+def test_export_dc(client, document):
+    """Dublin Core export returns attachment with .xml extension."""
+    res = client.get(url_for("documents.export", pid_value=document["pid"], fmt="dc"))
+    assert res.status_code == 200
+    assert res.content_type.startswith("text/xml")
+    _assert_export_filename(res.headers, document["pid"], ".xml")
+
+
+def test_export_sanitizes_filename(client, make_document):
+    """Content-Disposition filename is sanitized from unsafe pid characters."""
+    doc = make_document(organisation="org", pid='foo"; evil')
+    res = client.get(url_for("documents.export", pid_value=doc["pid"], fmt="json"))
+    assert res.status_code == 200
+    disposition = res.headers["Content-Disposition"]
+    assert '"' not in disposition.split("filename=", 1)[1]
+    assert ";" not in disposition.split("filename=", 1)[1]

--- a/tests/ui/test_views.py
+++ b/tests/ui/test_views.py
@@ -68,6 +68,10 @@ def test_logged_user(app, client, superuser, admin, moderator, submitter, user):
     res = client.get(url)
     assert res.json["settings"]
     assert not res.json.get("metadata")
+    serializers = res.json["settings"]["document_serializers"]
+    assert isinstance(serializers, list)
+    assert all("format" in s and "icon" in s for s in serializers)
+    assert not any(s["format"] == "rero" for s in serializers)
 
     # Logged as admin
     login_user_via_session(client, email=admin["email"])

--- a/tests/unit/documents/serializers/test_bibtex.py
+++ b/tests/unit/documents/serializers/test_bibtex.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Test BibTeX serializer."""
+
+from sonar.modules.documents.serializers.bibtex import BibTeXSerializer, serialize_record_to_bibtex
+
+
+def test_bibtex_issn_identifier():
+    """ISSN identifiers are exported the same way as ISBN."""
+    metadata = {"identifiedBy": [{"type": "bf:Issn", "value": "1234-5678"}]}
+    assert "isbn         = {1234-5678}," in serialize_record_to_bibtex(metadata)
+
+
+def test_bibtex_serialize_search_unwraps_metadata():
+    """serialize_search unwraps the record envelope like serialize does."""
+    metadata = {"identifiedBy": [{"type": "bf:Issn", "value": "1234-5678"}]}
+    search_result = {"hits": {"hits": [{"_source": {"metadata": metadata}}]}}
+    result = BibTeXSerializer().serialize_search(None, search_result)
+    assert "isbn         = {1234-5678}," in result

--- a/tests/unit/documents/serializers/test_common_serializer_helpers.py
+++ b/tests/unit/documents/serializers/test_common_serializer_helpers.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Test shared metadata extraction helpers for citation serializers."""
+
+from sonar.modules.documents.serializers.common import (
+    extract_abstract,
+    extract_authors,
+    extract_editors,
+    extract_journal_info,
+    extract_publication_info,
+    extract_title,
+)
+
+
+def test_extract_authors():
+    """Only contributors with the "cre" role and a preferred name are returned."""
+    metadata = {
+        "contribution": [
+            {"agent": {"preferred_name": "Doe, John"}, "role": ["cre"]},
+            {"agent": {"preferred_name": "Smith, Jane"}, "role": ["cre", "edt"]},
+            {"agent": {"preferred_name": "Editor, Ed"}, "role": ["edt"]},
+            {"agent": {}, "role": ["cre"]},
+        ]
+    }
+    assert extract_authors(metadata) == ["Doe, John", "Smith, Jane"]
+
+
+def test_extract_authors_empty():
+    """No contribution field returns an empty list."""
+    assert extract_authors({}) == []
+
+
+def test_extract_editors():
+    """Only contributors with the "edt" role and a preferred name are returned."""
+    metadata = {
+        "contribution": [
+            {"agent": {"preferred_name": "Doe, John"}, "role": ["cre"]},
+            {"agent": {"preferred_name": "Editor, Ed"}, "role": ["edt"]},
+        ]
+    }
+    assert extract_editors(metadata) == ["Editor, Ed"]
+
+
+def test_extract_editors_empty():
+    """No contribution field returns an empty list."""
+    assert extract_editors({}) == []
+
+
+def test_extract_title_with_subtitle():
+    """Title and subtitle are combined with a colon."""
+    metadata = {
+        "title": [
+            {
+                "mainTitle": [{"value": "Main title"}],
+                "subtitle": [{"value": "Sub title"}],
+            }
+        ]
+    }
+    assert extract_title(metadata) == "Main title: Sub title"
+
+
+def test_extract_title_without_subtitle():
+    """Title alone is returned unchanged when there is no subtitle."""
+    metadata = {"title": [{"mainTitle": [{"value": "Main title"}]}]}
+    assert extract_title(metadata) == "Main title"
+
+
+def test_extract_title_missing():
+    """No title field returns None."""
+    assert extract_title({}) is None
+
+
+def test_extract_publication_info():
+    """Year, place and publisher are extracted from the "bf:Publication" activity."""
+    metadata = {
+        "provisionActivity": [
+            {
+                "type": "bf:Publication",
+                "startDate": "2020-05-01",
+                "statement": [
+                    {"type": "bf:Place", "label": [{"value": "Geneva"}]},
+                    {"type": "bf:Agent", "label": {"value": "Pub Inc"}},
+                ],
+            }
+        ]
+    }
+    assert extract_publication_info(metadata) == ("2020", "Geneva", "Pub Inc")
+
+
+def test_extract_publication_info_ignores_other_activity_types():
+    """Activities that are not "bf:Publication" are skipped."""
+    metadata = {"provisionActivity": [{"type": "bf:Manufacture", "startDate": "2020-01-01"}]}
+    assert extract_publication_info(metadata) == (None, None, None)
+
+
+def test_extract_publication_info_missing():
+    """No provisionActivity field returns a tuple of None."""
+    assert extract_publication_info({}) == (None, None, None)
+
+
+def test_extract_journal_info():
+    """Journal, volume, issue and pages are extracted from the first partOf entry."""
+    metadata = {
+        "partOf": [
+            {
+                "document": {"title": "Journal X"},
+                "numberingVolume": "3",
+                "numberingIssue": "2",
+                "numberingPages": "10-20",
+            }
+        ]
+    }
+    assert extract_journal_info(metadata) == ("Journal X", "3", "2", "10-20")
+
+
+def test_extract_journal_info_missing():
+    """No partOf field returns a tuple of None."""
+    assert extract_journal_info({}) == (None, None, None, None)
+
+
+def test_extract_abstract():
+    """The first non-empty abstract value is returned."""
+    metadata = {"abstracts": [{"value": ""}, {"value": "Real abstract"}, {"value": "Second abstract"}]}
+    assert extract_abstract(metadata) == "Real abstract"
+
+
+def test_extract_abstract_missing():
+    """No abstracts field returns None."""
+    assert extract_abstract({}) is None

--- a/tests/unit/documents/serializers/test_ris.py
+++ b/tests/unit/documents/serializers/test_ris.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Test RIS serializer."""
+
+from sonar.modules.documents.serializers.ris import RISSerializer, serialize_record_to_ris
+
+
+def test_ris_issn_identifier():
+    """ISSN identifiers are exported the same way as ISBN."""
+    metadata = {"identifiedBy": [{"type": "bf:Issn", "value": "1234-5678"}]}
+    assert "SN  - 1234-5678" in serialize_record_to_ris(metadata)
+
+
+def test_ris_serialize_search_unwraps_metadata():
+    """serialize_search unwraps the record envelope like serialize does."""
+    metadata = {"identifiedBy": [{"type": "bf:Issn", "value": "1234-5678"}]}
+    search_result = {"hits": {"hits": [{"_source": {"metadata": metadata}}]}}
+    result = RISSerializer().serialize_search(None, search_result)
+    assert "SN  - 1234-5678" in result


### PR DESCRIPTION
* Add BibTeX and RIS serializers with COAR type mapping
* Register bibtex/ris via content negotiation in config
* Add GET /documents/<pid>/export/<fmt> route with Content-Disposition: attachment header
* Expose document_serializers with icon in logged_user()
* Add tests for export route
* Closes #401.

⚠️ **Be sure to carefully check the BibTeX and RIS export formats and the data, since Claude was the one who created this along with the documentation.**