### PR TITLE
fix(docker): use correct bootstrap flag for UI package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,6 @@ ENV TERM=xterm-256color
 ENV UWSGI_PROFILE_OVERRIDE="xml=no"
 ARG UI_TGZ=""
 ENV INVENIO_COLLECT_STORAGE='flask_collect.storage.file'
-RUN uv run --no-sync ./scripts/bootstrap --deploy --ui ${UI_TGZ}
+RUN uv run --no-sync ./scripts/bootstrap --deploy -t ${UI_TGZ}
 
 ENTRYPOINT [ "bash", "-c"]


### PR DESCRIPTION
The bootstrap script expects -t/--tgz_package, not --ui, which does not exist and silently breaks the deploy build.