### PR TITLE
fix(docker): raise Elasticsearch mem_limit to avoid OOM kills

### DIFF
--- a/docker-services.yml
+++ b/docker-services.yml
@@ -75,7 +75,7 @@ services:
       nofile:
         soft: 65536
         hard: 65536
-    mem_limit: 1g
+    mem_limit: 3g
     ports:
       - "9200:9200"
       - "9300:9300"


### PR DESCRIPTION
Raise the Elasticsearch container `mem_limit` from 1g to 3g in `docker-services.yml`. It allows more breathing room  in local development and during the CI actions.