### PR TITLE
feat(documents): add BibTeX, RIS serializers and export

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ Each module has a `permissions.py` using `invenio-records-permissions`. Access i
 - Be clear and concise in the docstrings and do not over-comment the code.
 - Do not use Python type annotations (no `-> str`, `: str`, etc. in signatures).
 - Ruff is configured with `line-length = 120` and pep257 docstring convention; see `[tool.ruff]` in `pyproject.toml` for the enabled rule sets.
+- Since Python 3.14 (PEP 758), parentheses around multiple exception types are optional when the handler has no `as` clause: `except AttributeError, UnboundLocalError:` is valid and equivalent to `except (AttributeError, UnboundLocalError):` — not the old Python 2 comma syntax. `ruff format` only removes the parentheses this way when its `target-version` resolves to Python 3.14+ (here, from `requires-python` in `pyproject.toml`); this is expected, not a bug.
 - Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
 
 ### Translations

--- a/sonar/config.py
+++ b/sonar/config.py
@@ -367,22 +367,42 @@ RECORDS_REST_ENDPOINTS = {
             "application/rero+json": (
                 "sonar.modules.documents.serializers" ":json_doc_response"
             ),
+            "application/export+json": (
+                "sonar.modules.documents.serializers" ":json_export_v1_response"
+            ),
             "text/xml": ("sonar.modules.documents.serializers" ":dc_v1_response"),
+            "application/x-bibtex": ("sonar.modules.documents.serializers" ":bibtex_v1_response"),
+            "application/x-research-info-systems": (
+                "sonar.modules.documents.serializers" ":ris_v1_response"
+            ),
         },
         record_serializers_aliases={
             "json": "application/json",
             "rero": "application/rero+json",
+            "json_export": "application/export+json",
             "dc": "text/xml",
+            "bibtex": "application/x-bibtex",
+            "ris": "application/x-research-info-systems",
         },
         search_serializers={
             "application/json": (
                 "sonar.modules.documents.serializers" ":json_v1_search"
             ),
+            "application/export+json": (
+                "sonar.modules.documents.serializers" ":json_export_v1_search"
+            ),
             "text/xml": ("sonar.modules.documents.serializers" ":dc_v1_search"),
+            "application/x-bibtex": ("sonar.modules.documents.serializers" ":bibtex_v1_search"),
+            "application/x-research-info-systems": (
+                "sonar.modules.documents.serializers" ":ris_v1_search"
+            ),
         },
         search_serializers_aliases={
             "json": "application/json",
+            "json_export": "application/export+json",
             "dc": "text/xml",
+            "bibtex": "application/x-bibtex",
+            "ris": "application/x-research-info-systems",
         },
         record_loaders={
             "application/json": ("sonar.modules.documents.loaders" ":json_v1"),

--- a/sonar/modules/documents/serializers/__init__.py
+++ b/sonar/modules/documents/serializers/__init__.py
@@ -3,17 +3,15 @@
 
 """Document serializers."""
 
-from invenio_records_rest.serializers.response import (
-    record_responsify,
-    search_responsify,
-)
-
+from sonar.modules.documents.serializers.response import record_responsify, search_responsify
 from sonar.modules.documents.serializers.schemas.dc import DublinCoreSchema
 
 from ..marshmallow import DocumentListSchemaV1, DocumentReroSchemaV1, DocumentSchemaV1
+from .bibtex import BibTeXSerializer
 from .dc import DublinCoreSerializer
 from .google_scholar import SonarGoogleScholarSerializer
 from .json import JSONSerializer
+from .ris import RISSerializer
 from .schemaorg import SonarSchemaOrgSerializer
 from .schemas.google_scholar import GoogleScholarV1
 from .schemas.schemaorg import SchemaOrgV1
@@ -30,6 +28,8 @@ schemaorg_v1 = SonarSchemaOrgSerializer(SchemaOrgV1, replace_refs=True)
 google_scholar_v1 = SonarGoogleScholarSerializer(GoogleScholarV1, replace_refs=True)
 
 dc_v1 = DublinCoreSerializer(DublinCoreSchema)
+bibtex_v1 = BibTeXSerializer()
+ris_v1 = RISSerializer()
 
 # Records-REST serializers
 # ========================
@@ -39,15 +39,38 @@ json_doc_response = record_responsify(json_doc, "application/rero+json")
 #: JSON record serializer for search results.
 json_v1_search = search_responsify(json_list_v1, "application/json")
 
-#: JSON record serializer for individual records.
-dc_v1_response = record_responsify(dc_v1, "text/xml")
-#: JSON record serializer for search results.
-dc_v1_search = search_responsify(dc_v1, "text/xml")
+#: JSON record serializer for individual records, downloaded as an attachment.
+#: Uses a dedicated mimetype so it never shadows the plain application/json
+#: response consumed by the UI on the same endpoint.
+json_export_v1_response = record_responsify(json_v1, "application/export+json", extension=".json")
+#: JSON record serializer for search results, downloaded as an attachment.
+json_export_v1_search = search_responsify(json_list_v1, "application/export+json", extension=".json")
+
+#: Dublin Core record serializer for individual records.
+dc_v1_response = record_responsify(dc_v1, "text/xml", extension=".xml")
+#: Dublin Core record serializer for search results.
+dc_v1_search = search_responsify(dc_v1, "text/xml", extension=".xml")
+
+#: BibTeX record serializer for individual records.
+bibtex_v1_response = record_responsify(bibtex_v1, "application/x-bibtex", extension=".bib")
+#: BibTeX record serializer for search results.
+bibtex_v1_search = search_responsify(bibtex_v1, "application/x-bibtex", extension=".bib")
+
+#: RIS record serializer for individual records.
+ris_v1_response = record_responsify(ris_v1, "application/x-research-info-systems", extension=".ris")
+#: RIS record serializer for search results.
+ris_v1_search = search_responsify(ris_v1, "application/x-research-info-systems", extension=".ris")
 
 __all__ = (
+    "bibtex_v1_response",
+    "bibtex_v1_search",
     "dc_v1_response",
     "dc_v1_search",
+    "json_export_v1_response",
+    "json_export_v1_search",
     "json_v1",
     "json_v1_response",
     "json_v1_search",
+    "ris_v1_response",
+    "ris_v1_search",
 )

--- a/sonar/modules/documents/serializers/bibtex.py
+++ b/sonar/modules/documents/serializers/bibtex.py
@@ -1,0 +1,230 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""BibTeX serializer."""
+
+import re
+import string
+
+from invenio_records_rest.serializers.base import SerializerMixinInterface
+
+from .common import (
+    extract_abstract,
+    extract_authors,
+    extract_dissertation,
+    extract_editors,
+    extract_identifiers,
+    extract_journal_info,
+    extract_publication_info,
+    extract_title,
+    extract_url,
+    extract_year,
+    unwrap_metadata,
+)
+
+# Mapping from COAR resource types to BibTeX entry types, mirroring the COAR
+# classification already established in
+# sonar/modules/documents/serializers/schemas/schemaorg.py. Types with no
+# clean BibTeX equivalent (images, video, software, maps, ...) fall back to
+# "misc" rather than a close-but-wrong entry type.
+# https://purl.org/coar/resource_type
+_COAR_TO_BIBTEX = {
+    "coar:c_2f33": "book",
+    "coar:c_3248": "incollection",
+    "coar:c_c94f": "misc",
+    "coar:c_5794": "inproceedings",
+    "coar:c_18cp": "inproceedings",
+    "coar:c_6670": "misc",
+    "coar:c_18co": "misc",
+    "coar:c_f744": "proceedings",
+    "coar:c_ddb1": "misc",
+    "coar:c_3e5a": "article",
+    "coar:c_beb9": "article",
+    "coar:c_6501": "article",
+    "coar:c_998f": "article",
+    "coar:c_dcae04bc": "article",
+    "coar:c_8544": "misc",
+    "non_textual_object": "misc",
+    "coar:c_8a7e": "misc",
+    "coar:c_ecc8": "misc",
+    "coar:c_12cc": "misc",
+    "coar:c_18cc": "misc",
+    "coar:c_18cw": "misc",
+    "coar:c_5ce6": "misc",
+    "coar:c_15cd": "misc",
+    "coar:c_2659": "misc",
+    "coar:c_0640": "misc",
+    "coar:c_2cd9": "misc",
+    "coar:c_2fe3": "misc",
+    "coar:c_816b": "article",
+    "coar:c_93fc": "techreport",
+    "coar:c_18ww": "techreport",
+    "coar:c_18wz": "techreport",
+    "coar:c_18wq": "techreport",
+    "coar:c_186u": "techreport",
+    "coar:c_18op": "techreport",
+    "coar:c_ba1f": "techreport",
+    "coar:c_18hj": "techreport",
+    "coar:c_18ws": "techreport",
+    "coar:c_18gh": "techreport",
+    "coar:c_46ec": "phdthesis",
+    "coar:c_7a1f": "mastersthesis",
+    "coar:c_db06": "phdthesis",
+    "coar:c_bdcc": "mastersthesis",
+    "habilitation_thesis": "phdthesis",
+    "advanced_studies_thesis": "mastersthesis",
+    "other_thesis": "phdthesis",
+    "coar:c_8042": "techreport",
+    "coar:c_1843": "misc",
+    "coar:R60J-J5BD": "misc",
+    "coar:c_ba08": "misc",
+}
+
+
+def _bibtex_entry_type(doc_type):
+    """Return BibTeX entry type for a COAR document type."""
+    return _COAR_TO_BIBTEX.get(doc_type, "misc")
+
+
+def _bibtex_key(metadata):
+    """Generate a BibTeX cite key from first author and year."""
+    authors = extract_authors(metadata)
+    last_name = authors[0].split(",")[0].strip() if authors else "unknown"
+    # BibTeX keys cannot contain whitespace: collapse multi-word last names
+    # like "van der Berg" into a single token.
+    name = re.sub(r"\s+", "", last_name)
+    return f"{name}{extract_year(metadata) or ''}"
+
+
+_BIBTEX_ESCAPE = {
+    "\\": r"\textbackslash{}",
+    "&": r"\&",
+    "%": r"\%",
+    "$": r"\$",
+    "#": r"\#",
+    "_": r"\_",
+    "{": r"\{",
+    "}": r"\}",
+    "~": r"\textasciitilde{}",
+    "^": r"\textasciicircum{}",
+}
+_BIBTEX_ESCAPE_RE = re.compile("|".join(re.escape(char) for char in _BIBTEX_ESCAPE))
+
+
+def _bibtex_escape(value):
+    r"""Escape LaTeX special characters in a free-text field value.
+
+    A single-pass regex substitution is required: replacing characters one
+    at a time (e.g. "\\" then "{") would re-escape the braces just inserted
+    by the backslash replacement, producing double-escaped output.
+    """
+    return _BIBTEX_ESCAPE_RE.sub(lambda match: _BIBTEX_ESCAPE[match.group()], str(value))
+
+
+def _bibtex_field(name, value, escape=True):
+    """Return a formatted BibTeX field line."""
+    text = _bibtex_escape(value) if escape else str(value)
+    return f"  {name:<12} = {{{text}}}"
+
+
+def serialize_record_to_bibtex(metadata, used_keys=None):
+    """Serialize a document metadata dict to a BibTeX entry string.
+
+    :param used_keys: Optional set of cite keys already emitted in the same
+        export (e.g. a search result with several entries). When the
+        generated key collides with one already in the set, a letter suffix
+        ("a", "b", ...) is appended to keep cite keys unique, as BibTeX
+        consumers can otherwise reject or silently overwrite one entry.
+    """
+    doc_type = metadata.get("documentType", "")
+    entry_type = _bibtex_entry_type(doc_type)
+    key = _bibtex_key(metadata)
+
+    if used_keys is not None:
+        base_key = key
+        suffix_index = 0
+        while key in used_keys:
+            key = f"{base_key}{string.ascii_lowercase[suffix_index]}"
+            suffix_index += 1
+        used_keys.add(key)
+
+    fields = []
+
+    # Authors
+    if authors := extract_authors(metadata):
+        fields.append(_bibtex_field("author", " and ".join(authors)))
+
+    # Editors (only if no authors)
+    editors = extract_editors(metadata)
+    if editors and not authors:
+        fields.append(_bibtex_field("editor", " and ".join(editors)))
+
+    # Title
+    if title := extract_title(metadata):
+        fields.append(_bibtex_field("title", title))
+
+    # Publication info
+    _, place, publisher = extract_publication_info(metadata)
+    if year := extract_year(metadata):
+        fields.append(_bibtex_field("year", year))
+    if place:
+        fields.append(_bibtex_field("address", place))
+    if publisher:
+        fields.append(_bibtex_field("publisher", publisher))
+
+    # Thesis: granting institution -> school
+    if entry_type in ("phdthesis", "mastersthesis"):
+        _, school, _ = extract_dissertation(metadata)
+        if school:
+            fields.append(_bibtex_field("school", school))
+
+    # Host document: journal for articles, book/proceedings title otherwise
+    journal, volume, issue, pages = extract_journal_info(metadata)
+    if journal:
+        host_field = "booktitle" if entry_type in ("incollection", "inproceedings", "proceedings") else "journal"
+        fields.append(_bibtex_field(host_field, journal))
+    if volume:
+        fields.append(_bibtex_field("volume", volume))
+    if issue:
+        fields.append(_bibtex_field("number", issue))
+    if pages:
+        fields.append(_bibtex_field("pages", pages))
+
+    # Identifiers
+    doi, isbn, issn = extract_identifiers(metadata)
+    if doi:
+        fields.append(_bibtex_field("doi", doi, escape=False))
+    if isbn:
+        fields.append(_bibtex_field("isbn", isbn, escape=False))
+    if issn:
+        fields.append(_bibtex_field("issn", issn, escape=False))
+
+    # Abstract
+    if abstract := extract_abstract(metadata):
+        fields.append(_bibtex_field("abstract", abstract))
+
+    # Permalink
+    if url := extract_url(metadata):
+        fields.append(_bibtex_field("url", url, escape=False))
+
+    lines = [f"@{entry_type}{{{key},"] + [f"{f}," for f in fields] + ["}"]
+    return "\n".join(lines)
+
+
+class BibTeXSerializer(SerializerMixinInterface):
+    """BibTeX serializer for document records."""
+
+    mimetype = "application/x-bibtex"
+
+    def serialize(self, pid, record, links_factory=None):
+        """Serialize a single record to BibTeX."""
+        return serialize_record_to_bibtex(unwrap_metadata(record))
+
+    def serialize_search(self, pid_fetcher, search_result, links=None, item_links_factory=None):
+        """Serialize search results to BibTeX (one entry per hit)."""
+        used_keys = set()
+        entries = [
+            serialize_record_to_bibtex(unwrap_metadata(hit["_source"]), used_keys=used_keys)
+            for hit in search_result["hits"]["hits"]
+        ]
+        return "\n\n".join(entries)

--- a/sonar/modules/documents/serializers/common.py
+++ b/sonar/modules/documents/serializers/common.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Shared metadata extraction helpers for citation serializers (BibTeX, RIS)."""
+
+
+def unwrap_metadata(record):
+    """Return a record's metadata dict, keeping "pid"/"permalink" reachable.
+
+    Most callers pass the document's own metadata (no "metadata" key), but a
+    record can also arrive as an envelope {"metadata": {...}, "pid": ...,
+    "permalink": ...} with those two fields as siblings rather than nested
+    inside "metadata" (e.g. an ES search hit's _source). extract_url()
+    needs "pid"/"permalink" to build the permalink, so they are copied into
+    the returned dict when missing there, instead of being silently dropped.
+    """
+    metadata = record.get("metadata", record)
+    if metadata is record:
+        return metadata
+    for key in ("pid", "permalink"):
+        if key not in metadata and key in record:
+            metadata = {**metadata, key: record[key]}
+    return metadata
+
+
+def extract_authors(metadata):
+    """Return preferred names of contributors with the "cre" (creator) role.
+
+    Meetings are events, not names, so a bf:Meeting agent is never returned
+    even if it carries the "cre" role.
+    """
+    return [
+        c["agent"]["preferred_name"]
+        for c in metadata.get("contribution", [])
+        if "cre" in c.get("role", [])
+        and c.get("agent", {}).get("type") != "bf:Meeting"
+        and c.get("agent", {}).get("preferred_name")
+    ]
+
+
+def extract_editors(metadata):
+    """Return preferred names of contributors with the "edt" (editor) role.
+
+    Meetings are events, not names, so a bf:Meeting agent is never returned
+    even if it carries the "edt" role.
+    """
+    return [
+        c["agent"]["preferred_name"]
+        for c in metadata.get("contribution", [])
+        if "edt" in c.get("role", [])
+        and c.get("agent", {}).get("type") != "bf:Meeting"
+        and c.get("agent", {}).get("preferred_name")
+    ]
+
+
+def extract_title(metadata):
+    """Return the main title, combined with its subtitle if any."""
+    for title_entry in metadata.get("title", []):
+        if main_titles := title_entry.get("mainTitle", []):
+            title = main_titles[0]["value"]
+            subtitle = title_entry.get("subtitle", [{}])[0].get("value") if title_entry.get("subtitle") else None
+            return f"{title}: {subtitle}" if subtitle else title
+    return None
+
+
+def extract_publication_info(metadata):
+    """Return publication year, place and publisher from the "bf:Publication" activity."""
+    year = place = publisher = None
+    for activity in metadata.get("provisionActivity", []):
+        if activity.get("type") != "bf:Publication":
+            continue
+        if activity.get("startDate"):
+            year = activity["startDate"][:4]
+        for stmt in activity.get("statement", []):
+            label = stmt.get("label")
+            value = label[0]["value"] if isinstance(label, list) and label else (label or {}).get("value", "")
+            if stmt.get("type") == "bf:Place":
+                place = value
+            elif stmt.get("type") == "bf:Agent":
+                publisher = value
+        break
+    return year, place, publisher
+
+
+def extract_journal_info(metadata):
+    """Return journal title, volume, issue and pages from the first "partOf" entry."""
+    parts = metadata.get("partOf", [])
+    if not parts:
+        return None, None, None, None
+    part = parts[0]
+    journal = part.get("document", {}).get("title")
+    return journal, part.get("numberingVolume"), part.get("numberingIssue"), part.get("numberingPages")
+
+
+def extract_abstract(metadata):
+    """Return the first non-empty abstract value."""
+    for abstract in metadata.get("abstracts", []):
+        if abstract.get("value"):
+            return abstract["value"]
+    return None
+
+
+def extract_year(metadata):
+    """Return the publication year.
+
+    Prefer the "bf:Publication" activity start date, then fall back to the host
+    document numbering year ("partOf"), where journal articles and other
+    host-based types store their year (provisionActivity is optional for them).
+    """
+    year, _, _ = extract_publication_info(metadata)
+    if year:
+        return year
+    for part in metadata.get("partOf", []):
+        if part.get("numberingYear"):
+            return part["numberingYear"]
+    return None
+
+
+def extract_dissertation(metadata):
+    """Return (degree, granting institution, jury note) from the "dissertation" field."""
+    dissertation = metadata.get("dissertation", {})
+    return dissertation.get("degree"), dissertation.get("grantingInstitution"), dissertation.get("jury_note")
+
+
+def extract_identifiers(metadata):
+    """Return DOI, ISBN and ISSN, falling back to the host document (partOf).
+
+    A journal's ISSN or a host book's ISBN is stored in partOf for articles
+    and book chapters, not at the top level. The top level wins when present.
+    """
+    result = {}
+    sources = [metadata.get("identifiedBy", [])]
+    sources += [p.get("document", {}).get("identifiedBy", []) for p in metadata.get("partOf", [])]
+    type_map = {"bf:Doi": "doi", "bf:Isbn": "isbn", "bf:Issn": "issn", "bf:IssnL": "issn"}
+    for identifiers in sources:
+        for identifier in identifiers:
+            key = type_map.get(identifier.get("type"))
+            if key and identifier.get("value") and key not in result:
+                result[key] = identifier["value"]
+    return result.get("doi"), result.get("isbn"), result.get("issn")
+
+
+def extract_url(metadata):
+    """Return the record's permanent link.
+
+    Search hits already carry "permalink" in the ES source; for a single
+    record it is computed from the PID.
+    """
+    if metadata.get("permalink"):
+        return metadata["permalink"]
+    if not metadata.get("pid"):
+        return None
+    from flask import request
+
+    from sonar.modules.documents.api import DocumentRecord
+
+    return DocumentRecord.get_permanent_link(request.host_url, metadata["pid"])

--- a/sonar/modules/documents/serializers/response.py
+++ b/sonar/modules/documents/serializers/response.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Serialization response factories.
+
+Responsible for creating a custom HTTP response given the output of a serializer.
+"""
+
+from datetime import UTC, datetime
+
+from flask import current_app
+from invenio_records_rest.serializers.response import add_link_header
+from werkzeug.utils import secure_filename
+
+
+def record_responsify(serializer, mimetype, extension=None):
+    """Create a Records-REST response serializer.
+
+    :param serializer: Serializer instance.
+    :param mimetype: MIME type of response.
+    :param extension: File extension (e.g. ".bib"). When given, the response
+        is sent as a downloadable attachment named "{pid}-{version}{extension}".
+    :returns: Function that generates a record HTTP response.
+    """
+
+    def view(pid, record, code=200, headers=None, links_factory=None):
+        response = current_app.response_class(
+            serializer.serialize(pid, record, links_factory=links_factory),
+            mimetype=mimetype,
+        )
+        response.status_code = code
+        response.cache_control.no_cache = True
+        response.set_etag(str(record.revision_id))
+        response.last_modified = record.updated
+        if headers is not None:
+            response.headers.extend(headers)
+
+        if links_factory is not None:
+            add_link_header(response, links_factory(pid))
+
+        if extension:
+            filename = secure_filename(f"{pid.pid_value}-{record.revision_id}{extension}")
+            response.headers["Content-Disposition"] = f"attachment; filename={filename}"
+
+        return response
+
+    return view
+
+
+def search_responsify(serializer, mimetype, extension=None):
+    """Create a Records-REST search result response serializer.
+
+    :param serializer: Serializer instance.
+    :param mimetype: MIME type of response.
+    :param extension: File extension (e.g. ".bib"). When given, the response
+        is sent as a downloadable attachment named
+        "documents-export-{date}-{time}{extension}", since a search result
+        has no single pid or revision to identify it by.
+    :returns: Function that generates a record HTTP response.
+    """
+
+    def view(
+        pid_fetcher,
+        search_result,
+        code=200,
+        headers=None,
+        links=None,
+        item_links_factory=None,
+    ):
+        response = current_app.response_class(
+            serializer.serialize_search(
+                pid_fetcher,
+                search_result,
+                links=links,
+                item_links_factory=item_links_factory,
+            ),
+            mimetype=mimetype,
+        )
+        response.status_code = code
+        if headers is not None:
+            response.headers.extend(headers)
+
+        if links is not None:
+            add_link_header(response, links)
+
+        if extension:
+            now = datetime.now(UTC)
+            filename = f"documents-export-{now.strftime('%Y%m%d')}-{now.strftime('%H%M')}{extension}"
+            response.headers["Content-Disposition"] = f"attachment; filename={filename}"
+
+        return response
+
+    return view

--- a/sonar/modules/documents/serializers/ris.py
+++ b/sonar/modules/documents/serializers/ris.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""RIS serializer."""
+
+import re
+
+from invenio_records_rest.serializers.base import SerializerMixinInterface
+
+from .common import (
+    extract_abstract,
+    extract_authors,
+    extract_dissertation,
+    extract_editors,
+    extract_identifiers,
+    extract_journal_info,
+    extract_publication_info,
+    extract_title,
+    extract_url,
+    extract_year,
+    unwrap_metadata,
+)
+
+# Mapping from COAR resource types to RIS type tags, mirroring the COAR
+# classification already established in
+# sonar/modules/documents/serializers/schemas/schemaorg.py. Types with no
+# clean RIS equivalent (images, video, software, maps, ...) fall back to
+# "GEN" rather than a close-but-wrong type tag.
+# https://purl.org/coar/resource_type
+_COAR_TO_RIS = {
+    "coar:c_2f33": "BOOK",
+    "coar:c_3248": "CHAP",
+    "coar:c_c94f": "GEN",
+    "coar:c_5794": "CONF",
+    "coar:c_18cp": "CONF",
+    "coar:c_6670": "CONF",
+    "coar:c_18co": "CONF",
+    "coar:c_f744": "CONF",
+    "coar:c_ddb1": "DATA",
+    "coar:c_3e5a": "JOUR",
+    "coar:c_beb9": "JOUR",
+    "coar:c_6501": "JOUR",
+    "coar:c_998f": "NEWS",
+    "coar:c_dcae04bc": "JOUR",
+    "coar:c_8544": "SLIDE",
+    "non_textual_object": "GEN",
+    "coar:c_8a7e": "VIDEO",
+    "coar:c_ecc8": "ART",
+    "coar:c_12cc": "MAP",
+    "coar:c_18cc": "SOUND",
+    "coar:c_18cw": "MUSIC",
+    "coar:c_5ce6": "COMP",
+    "coar:c_15cd": "PAT",
+    "coar:c_2659": "JFULL",
+    "coar:c_0640": "JFULL",
+    "coar:c_2cd9": "JFULL",
+    "coar:c_2fe3": "NEWS",
+    "coar:c_816b": "JOUR",
+    "coar:c_93fc": "RPRT",
+    "coar:c_18ww": "RPRT",
+    "coar:c_18wz": "RPRT",
+    "coar:c_18wq": "RPRT",
+    "coar:c_186u": "RPRT",
+    "coar:c_18op": "RPRT",
+    "coar:c_ba1f": "RPRT",
+    "coar:c_18hj": "RPRT",
+    "coar:c_18ws": "RPRT",
+    "coar:c_18gh": "RPRT",
+    "coar:c_46ec": "THES",
+    "coar:c_7a1f": "THES",
+    "coar:c_db06": "THES",
+    "coar:c_bdcc": "THES",
+    "habilitation_thesis": "THES",
+    "advanced_studies_thesis": "THES",
+    "other_thesis": "THES",
+    "coar:c_8042": "RPRT",
+    "coar:c_1843": "GEN",
+    "coar:R60J-J5BD": "CONF",
+    "coar:c_ba08": "JOUR",
+}
+
+
+def _ris_type(doc_type):
+    """Return RIS type tag for a COAR document type."""
+    return _COAR_TO_RIS.get(doc_type, "GEN")
+
+
+def _ris_line(tag, value):
+    """Return a formatted RIS field line.
+
+    RIS is a line-based format: any embedded newline in a value would be
+    read back as a malformed extra line, so newlines are collapsed to spaces.
+    """
+    return f"{tag}  - {' '.join(str(value).split())}"
+
+
+def serialize_record_to_ris(metadata):
+    """Serialize a document metadata dict to a RIS entry string."""
+    doc_type = _ris_type(metadata.get("documentType", ""))
+    lines = [_ris_line("TY", doc_type)]
+
+    # Authors
+    if authors := extract_authors(metadata):
+        lines.extend(_ris_line("AU", name) for name in authors)
+
+    # Editors (only if no authors)
+    if not authors:
+        lines.extend(_ris_line("ED", name) for name in extract_editors(metadata))
+
+    # Title
+    if title := extract_title(metadata):
+        lines.append(_ris_line("TI", title))
+
+    # Publication info
+    _, place, publisher = extract_publication_info(metadata)
+    if year := extract_year(metadata):
+        lines.append(_ris_line("PY", year))
+    if place:
+        lines.append(_ris_line("CY", place))
+
+    # Thesis: institution -> PB (if not already set), degree -> M3
+    if doc_type == "THES":
+        degree, institution, _ = extract_dissertation(metadata)
+        if institution and not publisher:
+            lines.append(_ris_line("PB", institution))
+        if degree:
+            lines.append(_ris_line("M3", degree))
+    if publisher:
+        lines.append(_ris_line("PB", publisher))
+
+    # Host document: JO for journals, T2 (secondary title) for chapters/proceedings
+    journal, volume, issue, pages = extract_journal_info(metadata)
+    if journal:
+        host_tag = "T2" if doc_type in ("CHAP", "CONF") else "JO"
+        lines.append(_ris_line(host_tag, journal))
+    if volume:
+        lines.append(_ris_line("VL", volume))
+    if issue:
+        lines.append(_ris_line("IS", issue))
+    if pages:
+        page_numbers = re.findall(r"\d+", pages)
+        if page_numbers:
+            lines.append(_ris_line("SP", page_numbers[0]))
+            if len(page_numbers) > 1:
+                lines.append(_ris_line("EP", page_numbers[1]))
+
+    # Identifiers
+    doi, isbn, issn = extract_identifiers(metadata)
+    if doi:
+        lines.append(_ris_line("DO", doi))
+    if isbn:
+        lines.append(_ris_line("SN", isbn))
+    if issn:
+        lines.append(_ris_line("SN", issn))
+
+    # Abstract
+    if abstract := extract_abstract(metadata):
+        lines.append(_ris_line("AB", abstract))
+
+    # Language
+    lines.extend(
+        _ris_line("LA", language["value"]) for language in metadata.get("language", []) if language.get("value")
+    )
+
+    # Permalink
+    if url := extract_url(metadata):
+        lines.append(_ris_line("UR", url))
+
+    lines.append("ER  - ")
+    return "\n".join(lines)
+
+
+class RISSerializer(SerializerMixinInterface):
+    """RIS serializer for document records."""
+
+    mimetype = "application/x-research-info-systems"
+
+    def serialize(self, pid, record, links_factory=None):
+        """Serialize a single record to RIS."""
+        return serialize_record_to_ris(unwrap_metadata(record))
+
+    def serialize_search(self, pid_fetcher, search_result, links=None, item_links_factory=None):
+        """Serialize search results to RIS (one entry per hit)."""
+        entries = [serialize_record_to_ris(unwrap_metadata(hit["_source"])) for hit in search_result["hits"]["hits"]]
+        return "\n\n".join(entries)

--- a/sonar/modules/documents/templates/documents/_export.html
+++ b/sonar/modules/documents/templates/documents/_export.html
@@ -1,0 +1,15 @@
+{# SPDX-FileCopyrightText: Fondation RERO+ #}
+{# SPDX-License-Identifier: AGPL-3.0-or-later #}
+
+<h5 id="export" class="mt-3">{{ _('Export to…') }}</h5>
+<hr class="mb-3 mt-0" />
+<div class="d-flex flex-wrap flex-sm-nowrap">
+  {% for serializer in document_serializers %}
+  <a class="text-decoration-none mb-3" href="/api/documents/{{record.pid}}?format={{ serializer.format }}">
+    <div class="d-flex flex-column align-items-center text-muted export-item">
+      <i class="fa-2x {{ serializer.icon }}"></i>
+      <span class="text-center">{{ serializer.label }}</span>
+    </div>
+  </a>
+  {% endfor %}
+</div>

--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -463,9 +463,12 @@
   </div>
   {% endif %}
 
+  <!-- Export -->
+  {% include 'documents/_export.html' %}
+
   <!-- Statistics -->
-  <h5 id="stats" class="mt-5">{{ _('Statistics') }}</h5>
-  <hr class="mb-4 mt-0" />
+  <h5 id="stats" class="mt-3">{{ _('Statistics') }}</h5>
+  <hr class="mb-2 mt-0" />
   <div class="row">
     <div class="col">
       <strong>{{ _('Document views') }}:</strong> {{ stats['record-view'] }}

--- a/sonar/modules/documents/utils.py
+++ b/sonar/modules/documents/utils.py
@@ -7,6 +7,7 @@ import os
 from datetime import datetime
 
 from flask import current_app, request
+from flask_babel import lazy_gettext as _
 
 from sonar.modules.api import SonarRecord
 from sonar.modules.organisations.api import OrganisationRecord, current_organisation
@@ -234,3 +235,35 @@ def get_organisations(record):
         organisations.append(OrganisationRecord.get_record_by_pid(organisation_pid))
 
     return organisations
+
+
+#: Label and icon for each document serializer format exposed to end users.
+#: label uses lazy_gettext, not gettext, since this dict is built once at
+#: import time, outside of any request context, and the label must still
+#: resolve to the right language per request.
+_SERIALIZER_META = {
+    "json_export": {"label": _("JSON data"), "icon": "fa-regular fa-file-code"},
+    "dc": {"label": _("Dublin Core"), "icon": "fa-regular fa-file-code"},
+    "bibtex": {"label": _("BibTeX"), "icon": "fa-regular fa-file-lines"},
+    "ris": {"label": _("RIS (Zotero, …)"), "icon": "fa-regular fa-file-lines"},
+}
+
+
+def get_document_serializers():
+    """Return downloadable document export formats, with label and icon.
+
+    Excludes "json" and "rero", the plain JSON aliases consumed internally
+    by the UI, which are not meant to be offered as a download option.
+
+    :returns: list of dicts with "format", "label" and "icon" keys.
+    """
+    doc_endpoint = current_app.config.get("RECORDS_REST_ENDPOINTS", {}).get("doc", {})
+    return [
+        {
+            "format": s,
+            "label": str(_SERIALIZER_META.get(s, {}).get("label", s)),
+            "icon": _SERIALIZER_META.get(s, {}).get("icon", "fa-file-o"),
+        }
+        for s in doc_endpoint.get("record_serializers_aliases", {})
+        if s not in ("json", "rero")
+    ]

--- a/sonar/modules/documents/views.py
+++ b/sonar/modules/documents/views.py
@@ -12,6 +12,7 @@ from invenio_records_ui.signals import record_viewed
 
 from sonar.modules.collections.api import Record as CollectionRecord
 from sonar.modules.documents.utils import (
+    get_document_serializers,
     has_external_urls_for_files,
     populate_files_properties,
 )
@@ -98,6 +99,7 @@ def detail(pid, record, template=None, **kwargs):
         view=kwargs.get("view"),
         schema_org_data=schema_org_data,
         google_scholar_data=google_scholar_data,
+        document_serializers=get_document_serializers(),
     )
 
 

--- a/sonar/theme/assets/scss/common/_theme.scss
+++ b/sonar/theme/assets/scss/common/_theme.scss
@@ -31,3 +31,7 @@ div.wiki-page div.sticky-top {
   transition: none;
   display: none;
 }
+
+.export-item {
+  width: 110px;
+}

--- a/sonar/theme/views.py
+++ b/sonar/theme/views.py
@@ -26,7 +26,7 @@ from flask import (
     request,
     url_for,
 )
-from flask_babel import gettext as _
+from flask_babel import lazy_gettext as _
 from flask_login import current_user, login_required
 from flask_menu import current_menu
 from invenio_jsonschemas import current_jsonschemas
@@ -38,6 +38,7 @@ from sonar.modules.collections.permissions import (
 )
 from sonar.modules.deposits.permissions import DepositPermission
 from sonar.modules.documents.permissions import DocumentPermission
+from sonar.modules.documents.utils import get_document_serializers
 from sonar.modules.organisations.api import OrganisationSearch
 from sonar.modules.organisations.permissions import OrganisationPermission
 from sonar.modules.permissions import can_access_manage_view
@@ -121,6 +122,7 @@ def logged_user():
             "document_identifier_link": current_app.config.get("SONAR_APP_DOCUMENT_IDENTIFIER_LINK"),
             "availableLanguages": [{"code": "en", "name": _("English")}]
             + [{"code": code, "name": name} for code, name in current_app.config.get("I18N_LANGUAGES", [])],
+            "document_serializers": get_document_serializers(),
         }
     }
 

--- a/tests/api/documents/test_documents_rest.py
+++ b/tests/api/documents/test_documents_rest.py
@@ -4,8 +4,11 @@
 """Test REST endpoint for documents."""
 
 import json
+import re
 from copy import deepcopy
+from unittest import mock
 
+import pytest
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 
@@ -56,10 +59,57 @@ def test_get(client, document_with_file):
     assert "updated" in res.json
 
 
-def test_post_put_delete(app, client, document_json, organisation):
+@pytest.mark.parametrize(
+    ("fmt", "extension"), [("bibtex", ".bib"), ("ris", ".ris"), ("dc", ".xml"), ("json_export", ".json")]
+)
+def test_get_content_disposition_on_export_formats(client, document_with_file, fmt, extension):
+    """Attachment formats set a Content-Disposition filename based on pid and revision."""
+    pid = document_with_file["pid"]
+    revision_id = document_with_file.model.version_id - 1
+    res = client.get(url_for("invenio_records_rest.doc_item", pid_value=pid, format=fmt))
+    assert res.status_code == 200
+    assert res.headers["Content-Disposition"] == f"attachment; filename={pid}-{revision_id}{extension}"
+
+
+def test_get_json_format_has_no_content_disposition(client, document_with_file):
+    """The plain "json" alias used by the UI is not sent as an attachment."""
+    pid = document_with_file["pid"]
+    res = client.get(url_for("invenio_records_rest.doc_item", pid_value=pid, format="json"))
+    assert res.status_code == 200
+    assert "Content-Disposition" not in res.headers
+
+
+@pytest.mark.parametrize(
+    ("fmt", "extension"), [("bibtex", ".bib"), ("ris", ".ris"), ("dc", ".xml"), ("json_export", ".json")]
+)
+def test_search_content_disposition_on_export_formats(client, document_with_file, fmt, extension):
+    """Attachment formats set a Content-Disposition filename based on the export date and time."""
+    res = client.get(url_for("invenio_records_rest.doc_list", view="global", format=fmt))
+    assert res.status_code == 200
+    assert re.fullmatch(
+        rf"attachment; filename=documents-export-\d{{8}}-\d{{4}}{re.escape(extension)}",
+        res.headers["Content-Disposition"],
+    )
+
+
+def test_search_json_format_has_no_content_disposition(client, document_with_file):
+    """The plain "json" alias used by the UI is not sent as an attachment."""
+    res = client.get(url_for("invenio_records_rest.doc_list", view="global", format="json"))
+    assert res.status_code == 200
+    assert "Content-Disposition" not in res.headers
+
+
+def test_get_default_json_has_no_content_disposition(client, document_with_file):
+    """The default JSON response is not sent as an attachment."""
+    res = client.get(url_for("invenio_records_rest.doc_item", pid_value=document_with_file["pid"]))
+    assert res.status_code == 200
+    assert "Content-Disposition" not in res.headers
+
+
+def test_post_put_delete(app, client, document_json, organisation, monkeypatch):
     """Test putting metadata on existing file."""
     # Disable configuration
-    app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
+    monkeypatch.setitem(app.config, "SONAR_APP_DISABLE_PERMISSION_CHECKS", True)
     headers = [("Content-Type", "application/json")]
     data = deepcopy(document_json)
     data["organisation"] = [{"$ref": f"https://sonar.ch/api/organisations/{organisation['code']}"}]
@@ -208,3 +258,21 @@ def test_aggregations(app, client, document, superuser, admin):
         "subdivision",
         {"key": "customField1", "name": "Test"},
     ]
+
+
+def test_export_sanitizes_filename(client, make_document):
+    """Content-Disposition filename is sanitized from unsafe pid characters."""
+    doc = make_document(organisation="org", pid='foo"; evil')
+    res = client.get(url_for("invenio_records_rest.doc_item", pid_value=doc["pid"], format="bibtex"))
+    assert res.status_code == 200
+    disposition = res.headers["Content-Disposition"]
+    assert '"' not in disposition.split("filename=", 1)[1]
+    assert ";" not in disposition.split("filename=", 1)[1]
+
+
+def test_export_masked_document_denied_anonymous(client, document):
+    """Anonymous export of a masked document is denied with 401."""
+    magic_mock = mock.MagicMock(return_value=True)
+    with mock.patch("sonar.modules.documents.api.DocumentRecord.is_masked", magic_mock):
+        res = client.get(url_for("invenio_records_rest.doc_item", pid_value=document["pid"], format="bibtex"))
+        assert res.status_code == 401

--- a/tests/ui/documents/test_documents_utils.py
+++ b/tests/ui/documents/test_documents_utils.py
@@ -32,6 +32,16 @@ def test_publication_statement_text():
     assert utils.publication_statement_text({"type": "bf:Publication", "startDate": "1990-12-31"}) == "31.12.1990"
 
 
+def test_get_document_serializers(app):
+    """Downloadable formats are returned with a label and icon, excluding json/rero."""
+    serializers = utils.get_document_serializers()
+    formats = [s["format"] for s in serializers]
+    assert "json" not in formats
+    assert "rero" not in formats
+    assert set(formats) == {"json_export", "dc", "bibtex", "ris"}
+    assert all("label" in s and "icon" in s for s in serializers)
+
+
 def test_get_file_restriction(app, organisation, admin, monkeypatch, embargo_date):
     """Test if a file is restricted by embargo date and/or organisation."""
     # No view arg, file is allowed

--- a/tests/ui/test_views.py
+++ b/tests/ui/test_views.py
@@ -69,6 +69,11 @@ def test_logged_user(app, client, superuser, admin, moderator, submitter, user):
     assert res.json["settings"]["document_identifier_link"]
     assert res.json["settings"]["availableLanguages"]
     assert not res.json.get("metadata")
+    serializers = res.json["settings"]["document_serializers"]
+    assert isinstance(serializers, list)
+    assert all("format" in s and "label" in s and "icon" in s for s in serializers)
+    assert not any(s["format"] in ("json", "rero") for s in serializers)
+    assert any(s["format"] == "json_export" for s in serializers)
 
     # Logged as admin
     login_user_via_session(client, email=admin["email"])

--- a/tests/unit/documents/serializers/test_bibtex.py
+++ b/tests/unit/documents/serializers/test_bibtex.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Test BibTeX serializer."""
+
+import json
+from pathlib import Path
+
+import sonar
+from sonar.modules.documents.serializers.bibtex import (
+    _COAR_TO_BIBTEX,
+    BibTeXSerializer,
+    _bibtex_key,
+    serialize_record_to_bibtex,
+)
+
+
+def test_bibtex_coar_mapping_is_complete():
+    """Every COAR documentType value has an explicit BibTeX entry type."""
+    schema_path = Path(sonar.__file__).parent / "jsonschemas" / "common" / "type-v1.0.0.json"
+    coar_types = set(json.loads(schema_path.read_text())["enum"])
+    assert coar_types <= _COAR_TO_BIBTEX.keys()
+
+
+def test_bibtex_coar_mapping_conference_and_bachelor():
+    """Conference papers, proceedings and bachelor theses map to their dedicated entry types."""
+    assert _COAR_TO_BIBTEX["coar:c_5794"] == "inproceedings"
+    assert _COAR_TO_BIBTEX["coar:c_f744"] == "proceedings"
+    assert _COAR_TO_BIBTEX["coar:c_7a1f"] == "mastersthesis"
+
+
+def test_bibtex_key_multi_word_last_name():
+    """A multi-word last name does not introduce whitespace in the cite key."""
+    metadata = {
+        "contribution": [{"agent": {"type": "bf:Person", "preferred_name": "van der Berg, Jan"}, "role": ["cre"]}],
+        "provisionActivity": [{"type": "bf:Publication", "startDate": "2020", "statement": []}],
+    }
+    assert _bibtex_key(metadata) == "vanderBerg2020"
+
+
+def test_bibtex_issn_identifier():
+    """ISSN identifiers use the dedicated issn field."""
+    metadata = {"identifiedBy": [{"type": "bf:Issn", "value": "1234-5678"}]}
+    assert "issn         = {1234-5678}," in serialize_record_to_bibtex(metadata)
+
+
+def test_bibtex_serialize_search_unwraps_metadata():
+    """serialize_search unwraps the record envelope like serialize does."""
+    metadata = {"identifiedBy": [{"type": "bf:Issn", "value": "1234-5678"}]}
+    search_result = {"hits": {"hits": [{"_source": {"metadata": metadata}}]}}
+    result = BibTeXSerializer().serialize_search(None, search_result)
+    assert "issn         = {1234-5678}," in result
+
+
+def test_bibtex_book_chapter_uses_booktitle():
+    """A book chapter's host document is exported as booktitle, not journal."""
+    metadata = {
+        "documentType": "coar:c_3248",
+        "partOf": [{"document": {"title": "Host Book"}}],
+    }
+    result = serialize_record_to_bibtex(metadata)
+    assert "booktitle    = {Host Book}," in result
+    assert "journal" not in result
+
+
+def test_bibtex_article_uses_journal():
+    """A journal article's host document is exported as journal."""
+    metadata = {
+        "documentType": "coar:c_3e5a",
+        "partOf": [{"document": {"title": "Host Journal"}}],
+    }
+    result = serialize_record_to_bibtex(metadata)
+    assert "journal      = {Host Journal}," in result
+    assert "booktitle" not in result
+
+
+def test_bibtex_thesis_school():
+    """A thesis exports its granting institution as school."""
+    metadata = {
+        "documentType": "coar:c_46ec",
+        "dissertation": {"grantingInstitution": "University of Example"},
+    }
+    assert "school       = {University of Example}," in serialize_record_to_bibtex(metadata)
+
+
+def test_bibtex_escapes_special_characters():
+    """LaTeX special characters are escaped in free-text fields."""
+    metadata = {"title": [{"mainTitle": [{"value": "100% AT&T's Report_v2"}]}]}
+    result = serialize_record_to_bibtex(metadata)
+    assert r"100\% AT\&T's Report\_v2" in result
+
+
+def test_bibtex_does_not_escape_identifiers_and_url():
+    """DOI, ISBN, ISSN and URL fields are not LaTeX-escaped."""
+    metadata = {
+        "permalink": "https://sonar.example/documents/abc_def",
+        "identifiedBy": [{"type": "bf:Doi", "value": "10.1000/abc_def"}],
+    }
+    result = serialize_record_to_bibtex(metadata)
+    assert "doi          = {10.1000/abc_def}," in result
+    assert "url          = {https://sonar.example/documents/abc_def}," in result
+
+
+def test_bibtex_year_falls_back_to_part_of():
+    """The year falls back to the host document's numbering year."""
+    metadata = {"partOf": [{"numberingYear": "2019"}]}
+    assert "year         = {2019}," in serialize_record_to_bibtex(metadata)
+
+
+def test_bibtex_excludes_meeting_authors():
+    """A bf:Meeting agent is never exported as an author."""
+    metadata = {
+        "contribution": [{"agent": {"type": "bf:Meeting", "preferred_name": "Some Conference"}, "role": ["cre"]}]
+    }
+    assert "author" not in serialize_record_to_bibtex(metadata)
+
+
+def test_bibtex_escapes_backslash_in_single_pass():
+    """A literal backslash is escaped without doubling the inserted braces."""
+    metadata = {"title": [{"mainTitle": [{"value": "a\\b"}]}]}
+    result = serialize_record_to_bibtex(metadata)
+    assert r"a\textbackslash{}b" in result
+    assert r"\{\}" not in result
+
+
+def test_bibtex_serialize_search_deduplicates_cite_keys():
+    """Two records with the same author surname and year get distinct cite keys."""
+    metadata1 = {
+        "contribution": [{"agent": {"type": "bf:Person", "preferred_name": "Smith, John"}, "role": ["cre"]}],
+        "provisionActivity": [{"type": "bf:Publication", "startDate": "2020", "statement": []}],
+    }
+    metadata2 = {
+        "contribution": [{"agent": {"type": "bf:Person", "preferred_name": "Smith, Jane"}, "role": ["cre"]}],
+        "provisionActivity": [{"type": "bf:Publication", "startDate": "2020", "statement": []}],
+    }
+    search_result = {"hits": {"hits": [{"_source": {"metadata": metadata1}}, {"_source": {"metadata": metadata2}}]}}
+    result = BibTeXSerializer().serialize_search(None, search_result)
+    assert "@misc{Smith2020," in result
+    assert "@misc{Smith2020a," in result
+
+
+def test_bibtex_serialize_search_unwraps_sibling_permalink():
+    """A permalink sibling to "metadata" (not nested inside it) is not dropped."""
+    search_result = {
+        "hits": {
+            "hits": [
+                {
+                    "_source": {
+                        "metadata": {"identifiedBy": [{"type": "bf:Issn", "value": "1234-5678"}]},
+                        "permalink": "https://sonar.example/documents/abc",
+                    }
+                }
+            ]
+        }
+    }
+    result = BibTeXSerializer().serialize_search(None, search_result)
+    assert "url          = {https://sonar.example/documents/abc}," in result

--- a/tests/unit/documents/serializers/test_common_serializer_helpers.py
+++ b/tests/unit/documents/serializers/test_common_serializer_helpers.py
@@ -1,0 +1,265 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Test shared metadata extraction helpers for citation serializers."""
+
+from sonar.modules.documents.serializers.common import (
+    extract_abstract,
+    extract_authors,
+    extract_dissertation,
+    extract_editors,
+    extract_identifiers,
+    extract_journal_info,
+    extract_publication_info,
+    extract_title,
+    extract_url,
+    extract_year,
+    unwrap_metadata,
+)
+
+
+def test_extract_authors():
+    """Only contributors with the "cre" role and a preferred name are returned."""
+    metadata = {
+        "contribution": [
+            {"agent": {"preferred_name": "Doe, John"}, "role": ["cre"]},
+            {"agent": {"preferred_name": "Smith, Jane"}, "role": ["cre", "edt"]},
+            {"agent": {"preferred_name": "Editor, Ed"}, "role": ["edt"]},
+            {"agent": {}, "role": ["cre"]},
+        ]
+    }
+    assert extract_authors(metadata) == ["Doe, John", "Smith, Jane"]
+
+
+def test_extract_authors_empty():
+    """No contribution field returns an empty list."""
+    assert extract_authors({}) == []
+
+
+def test_extract_authors_excludes_meetings():
+    """A bf:Meeting agent is never returned as an author."""
+    metadata = {
+        "contribution": [
+            {"agent": {"type": "bf:Meeting", "preferred_name": "Some Conference"}, "role": ["cre"]},
+            {"agent": {"type": "bf:Person", "preferred_name": "Doe, John"}, "role": ["cre"]},
+        ]
+    }
+    assert extract_authors(metadata) == ["Doe, John"]
+
+
+def test_extract_editors():
+    """Only contributors with the "edt" role and a preferred name are returned."""
+    metadata = {
+        "contribution": [
+            {"agent": {"preferred_name": "Doe, John"}, "role": ["cre"]},
+            {"agent": {"preferred_name": "Editor, Ed"}, "role": ["edt"]},
+        ]
+    }
+    assert extract_editors(metadata) == ["Editor, Ed"]
+
+
+def test_extract_editors_empty():
+    """No contribution field returns an empty list."""
+    assert extract_editors({}) == []
+
+
+def test_extract_editors_excludes_meetings():
+    """A bf:Meeting agent is never returned as an editor."""
+    metadata = {
+        "contribution": [
+            {"agent": {"type": "bf:Meeting", "preferred_name": "Some Conference"}, "role": ["edt"]},
+            {"agent": {"type": "bf:Person", "preferred_name": "Editor, Ed"}, "role": ["edt"]},
+        ]
+    }
+    assert extract_editors(metadata) == ["Editor, Ed"]
+
+
+def test_extract_title_with_subtitle():
+    """Title and subtitle are combined with a colon."""
+    metadata = {
+        "title": [
+            {
+                "mainTitle": [{"value": "Main title"}],
+                "subtitle": [{"value": "Sub title"}],
+            }
+        ]
+    }
+    assert extract_title(metadata) == "Main title: Sub title"
+
+
+def test_extract_title_without_subtitle():
+    """Title alone is returned unchanged when there is no subtitle."""
+    metadata = {"title": [{"mainTitle": [{"value": "Main title"}]}]}
+    assert extract_title(metadata) == "Main title"
+
+
+def test_extract_title_missing():
+    """No title field returns None."""
+    assert extract_title({}) is None
+
+
+def test_extract_publication_info():
+    """Year, place and publisher are extracted from the "bf:Publication" activity."""
+    metadata = {
+        "provisionActivity": [
+            {
+                "type": "bf:Publication",
+                "startDate": "2020-05-01",
+                "statement": [
+                    {"type": "bf:Place", "label": [{"value": "Geneva"}]},
+                    {"type": "bf:Agent", "label": {"value": "Pub Inc"}},
+                ],
+            }
+        ]
+    }
+    assert extract_publication_info(metadata) == ("2020", "Geneva", "Pub Inc")
+
+
+def test_extract_publication_info_ignores_other_activity_types():
+    """Activities that are not "bf:Publication" are skipped."""
+    metadata = {"provisionActivity": [{"type": "bf:Manufacture", "startDate": "2020-01-01"}]}
+    assert extract_publication_info(metadata) == (None, None, None)
+
+
+def test_extract_publication_info_missing():
+    """No provisionActivity field returns a tuple of None."""
+    assert extract_publication_info({}) == (None, None, None)
+
+
+def test_extract_journal_info():
+    """Journal, volume, issue and pages are extracted from the first partOf entry."""
+    metadata = {
+        "partOf": [
+            {
+                "document": {"title": "Journal X"},
+                "numberingVolume": "3",
+                "numberingIssue": "2",
+                "numberingPages": "10-20",
+            }
+        ]
+    }
+    assert extract_journal_info(metadata) == ("Journal X", "3", "2", "10-20")
+
+
+def test_extract_journal_info_missing():
+    """No partOf field returns a tuple of None."""
+    assert extract_journal_info({}) == (None, None, None, None)
+
+
+def test_extract_abstract():
+    """The first non-empty abstract value is returned."""
+    metadata = {"abstracts": [{"value": ""}, {"value": "Real abstract"}, {"value": "Second abstract"}]}
+    assert extract_abstract(metadata) == "Real abstract"
+
+
+def test_extract_abstract_missing():
+    """No abstracts field returns None."""
+    assert extract_abstract({}) is None
+
+
+def test_extract_year_from_publication_activity():
+    """The year is taken from the "bf:Publication" activity when present."""
+    metadata = {"provisionActivity": [{"type": "bf:Publication", "startDate": "2020-05-01", "statement": []}]}
+    assert extract_year(metadata) == "2020"
+
+
+def test_extract_year_falls_back_to_part_of():
+    """The year falls back to the host document's numbering year."""
+    metadata = {"partOf": [{"numberingYear": "2019"}]}
+    assert extract_year(metadata) == "2019"
+
+
+def test_extract_year_missing():
+    """No provisionActivity nor partOf field returns None."""
+    assert extract_year({}) is None
+
+
+def test_extract_dissertation():
+    """Degree, granting institution and jury note are extracted from the dissertation field."""
+    metadata = {
+        "dissertation": {
+            "degree": "PhD",
+            "grantingInstitution": "University of Example",
+            "jury_note": "Passed with honors",
+        }
+    }
+    assert extract_dissertation(metadata) == ("PhD", "University of Example", "Passed with honors")
+
+
+def test_extract_dissertation_missing():
+    """No dissertation field returns a tuple of None."""
+    assert extract_dissertation({}) == (None, None, None)
+
+
+def test_extract_identifiers_top_level():
+    """DOI, ISBN and ISSN are extracted from the top-level identifiedBy."""
+    metadata = {
+        "identifiedBy": [
+            {"type": "bf:Doi", "value": "10.1000/abc"},
+            {"type": "bf:Isbn", "value": "978-3-16-148410-0"},
+            {"type": "bf:Issn", "value": "1234-5678"},
+        ]
+    }
+    assert extract_identifiers(metadata) == ("10.1000/abc", "978-3-16-148410-0", "1234-5678")
+
+
+def test_extract_identifiers_falls_back_to_part_of():
+    """The host document's ISSN is used when there is none at the top level."""
+    metadata = {"partOf": [{"document": {"identifiedBy": [{"type": "bf:Issn", "value": "1234-5678"}]}}]}
+    assert extract_identifiers(metadata) == (None, None, "1234-5678")
+
+
+def test_extract_identifiers_top_level_wins_over_part_of():
+    """A top-level identifier takes precedence over the host document's."""
+    metadata = {
+        "identifiedBy": [{"type": "bf:Issn", "value": "1111-1111"}],
+        "partOf": [{"document": {"identifiedBy": [{"type": "bf:Issn", "value": "2222-2222"}]}}],
+    }
+    assert extract_identifiers(metadata) == (None, None, "1111-1111")
+
+
+def test_extract_identifiers_missing():
+    """No identifiedBy nor partOf field returns a tuple of None."""
+    assert extract_identifiers({}) == (None, None, None)
+
+
+def test_extract_url_uses_permalink_when_present():
+    """The permalink already computed on a search hit is used as-is."""
+    metadata = {"permalink": "https://sonar.example/documents/123"}
+    assert extract_url(metadata) == "https://sonar.example/documents/123"
+
+
+def test_extract_url_missing():
+    """No permalink nor pid field returns None."""
+    assert extract_url({}) is None
+
+
+def test_unwrap_metadata_no_envelope():
+    """A plain metadata dict with no "metadata" key is returned unchanged."""
+    metadata = {"title": [{"mainTitle": [{"value": "Title"}]}]}
+    assert unwrap_metadata(metadata) is metadata
+
+
+def test_unwrap_metadata_preserves_sibling_pid_and_permalink():
+    """Pid/permalink siblings of "metadata" are merged in, not dropped."""
+    record = {
+        "metadata": {"title": [{"mainTitle": [{"value": "Title"}]}]},
+        "pid": "123",
+        "permalink": "https://sonar.example/documents/123",
+    }
+    result = unwrap_metadata(record)
+    assert result["pid"] == "123"
+    assert result["permalink"] == "https://sonar.example/documents/123"
+    assert result["title"] == record["metadata"]["title"]
+
+
+def test_unwrap_metadata_metadata_pid_wins_over_sibling():
+    """A "pid"/"permalink" already inside "metadata" is not overwritten."""
+    record = {
+        "metadata": {"pid": "inner", "permalink": "https://sonar.example/inner"},
+        "pid": "outer",
+        "permalink": "https://sonar.example/outer",
+    }
+    result = unwrap_metadata(record)
+    assert result["pid"] == "inner"
+    assert result["permalink"] == "https://sonar.example/inner"

--- a/tests/unit/documents/serializers/test_ris.py
+++ b/tests/unit/documents/serializers/test_ris.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Test RIS serializer."""
+
+import json
+from pathlib import Path
+
+import sonar
+from sonar.modules.documents.serializers.ris import _COAR_TO_RIS, RISSerializer, serialize_record_to_ris
+
+
+def test_ris_coar_mapping_is_complete():
+    """Every COAR documentType value has an explicit RIS type tag."""
+    schema_path = Path(sonar.__file__).parent / "jsonschemas" / "common" / "type-v1.0.0.json"
+    coar_types = set(json.loads(schema_path.read_text())["enum"])
+    assert coar_types <= _COAR_TO_RIS.keys()
+
+
+def test_ris_coar_mapping_conference_papers():
+    """Conference papers and proceedings map to CONF, not JOUR or BOOK."""
+    assert _COAR_TO_RIS["coar:c_5794"] == "CONF"
+    assert _COAR_TO_RIS["coar:c_f744"] == "CONF"
+
+
+def test_ris_issn_identifier():
+    """ISSN identifiers are exported the same way as ISBN."""
+    metadata = {"identifiedBy": [{"type": "bf:Issn", "value": "1234-5678"}]}
+    assert "SN  - 1234-5678" in serialize_record_to_ris(metadata)
+
+
+def test_ris_serialize_search_unwraps_metadata():
+    """serialize_search unwraps the record envelope like serialize does."""
+    metadata = {"identifiedBy": [{"type": "bf:Issn", "value": "1234-5678"}]}
+    search_result = {"hits": {"hits": [{"_source": {"metadata": metadata}}]}}
+    result = RISSerializer().serialize_search(None, search_result)
+    assert "SN  - 1234-5678" in result
+
+
+def test_ris_abstract_with_embedded_newlines():
+    """Newlines inside a field value do not produce malformed RIS lines."""
+    metadata = {"abstracts": [{"language": "eng", "value": "Line one\nLine two\r\nLine three"}]}
+    result = serialize_record_to_ris(metadata)
+    assert "AB  - Line one Line two Line three" in result
+    assert "\nLine two" not in result
+
+
+def test_ris_book_chapter_uses_secondary_title():
+    """A book chapter's host document is exported as T2, not JO."""
+    metadata = {
+        "documentType": "coar:c_3248",
+        "partOf": [{"document": {"title": "Host Book"}}],
+    }
+    result = serialize_record_to_ris(metadata)
+    assert "T2  - Host Book" in result
+    assert "JO  - " not in result
+
+
+def test_ris_article_uses_journal_tag():
+    """A journal article's host document is exported as JO."""
+    metadata = {
+        "documentType": "coar:c_3e5a",
+        "partOf": [{"document": {"title": "Host Journal"}}],
+    }
+    result = serialize_record_to_ris(metadata)
+    assert "JO  - Host Journal" in result
+    assert "T2  - " not in result
+
+
+def test_ris_thesis_institution_and_degree():
+    """A thesis exports its granting institution as PB and degree as M3."""
+    metadata = {
+        "documentType": "coar:c_46ec",
+        "dissertation": {"grantingInstitution": "University of Example", "degree": "PhD"},
+    }
+    result = serialize_record_to_ris(metadata)
+    assert "PB  - University of Example" in result
+    assert "M3  - PhD" in result
+
+
+def test_ris_pages_with_double_dash():
+    """A page range using a double dash is still parsed correctly."""
+    metadata = {"partOf": [{"numberingPages": "135--142"}]}
+    result = serialize_record_to_ris(metadata)
+    assert "SP  - 135" in result
+    assert "EP  - 142" in result
+
+
+def test_ris_pages_open_ended():
+    """A single page number does not produce an EP line."""
+    metadata = {"partOf": [{"numberingPages": "135-"}]}
+    result = serialize_record_to_ris(metadata)
+    assert "SP  - 135" in result
+    assert "EP  - " not in result
+
+
+def test_ris_year_falls_back_to_part_of():
+    """The year falls back to the host document's numbering year."""
+    metadata = {"partOf": [{"numberingYear": "2019"}]}
+    assert "PY  - 2019" in serialize_record_to_ris(metadata)
+
+
+def test_ris_multiple_languages():
+    """Every language with a value is exported, not only the first one."""
+    metadata = {"language": [{"value": "eng"}, {"value": "fre"}]}
+    result = serialize_record_to_ris(metadata)
+    assert "LA  - eng" in result
+    assert "LA  - fre" in result
+
+
+def test_ris_excludes_meeting_authors():
+    """A bf:Meeting agent is never exported as an author."""
+    metadata = {
+        "contribution": [{"agent": {"type": "bf:Meeting", "preferred_name": "Some Conference"}, "role": ["cre"]}]
+    }
+    assert "AU  - " not in serialize_record_to_ris(metadata)
+
+
+def test_ris_serialize_search_unwraps_sibling_permalink():
+    """A permalink sibling to "metadata" (not nested inside it) is not dropped."""
+    search_result = {
+        "hits": {
+            "hits": [
+                {
+                    "_source": {
+                        "metadata": {"identifiedBy": [{"type": "bf:Issn", "value": "1234-5678"}]},
+                        "permalink": "https://sonar.example/documents/abc",
+                    }
+                }
+            ]
+        }
+    }
+    result = RISSerializer().serialize_search(None, search_result)
+    assert "UR  - https://sonar.example/documents/abc" in result


### PR DESCRIPTION
* Add BibTeX and RIS serializers with COAR type mapping, shared
  metadata extraction helpers (year, dissertation, identifiers,
  permalink), and LaTeX escaping for BibTeX free-text fields.
* Register bibtex/ris/dc/json_export via content negotiation
  (record_serializers/search_serializers) in config, reusing the
  existing GET /documents/<pid_value>?format=<alias> endpoint
  instead of a dedicated export route.
* record_responsify/search_responsify accept an optional extension
  and set a Content-Disposition attachment filename
  ("{pid}-{revision}{extension}" for a single record,
  "documents-export-{date}-{time}{extension}" for search results)
  without affecting the plain application/json response the UI
  consumes on the same endpoint.
* Extract get_document_serializers() (label, icon per format,
  excluding json/rero) into documents/utils.py so it can be shared
  between logged_user() and the document detail view.
* Add an export menu to the document detail page (_export.html),
  listing the downloadable formats with their icon and label.
* Add unit and API tests for the serializers, helpers and
  Content-Disposition behavior.
* Closes https://github.com/rero/sonar/issues/401.

### Explanations
- [ ] routes /api/documents/30?format=[json_export|dc|bibtex|ris]
       filename: {pid}-{version}.{extension}
- [ ] The export title label comes directly from the backend. I added a “label” entry to _SERIALIZER_META

### Display
<img width="520" height="172" alt="export" src="https://github.com/user-attachments/assets/de1e72a2-a8c0-4b9a-b2da-f47ad4b52d2c" />

At the bottom of the page