### PR TITLE
feat(deposits): hide add new project option

### DIFF
--- a/sonar/config.py
+++ b/sonar/config.py
@@ -185,6 +185,10 @@ JSONSCHEMAS_URL_SCHEME = "https"
 JSONSCHEMAS_HOST = "sonar.ch"
 JSONSCHEMAS_REPLACE_REFS = True
 
+#: List of organisation codes for which the "Add a new project" option
+#: is removed from the deposit's projects field.
+SONAR_APP_DEPOSITS_DISABLE_NEW_PROJECT_ORGANISATIONS = ["hepvs"]
+
 # Flask configuration
 # ===================
 # See details on

--- a/sonar/jsonschemas/deposits_json_schema.py
+++ b/sonar/jsonschemas/deposits_json_schema.py
@@ -3,6 +3,8 @@
 
 """Deposits JSON schema class."""
 
+from flask import current_app
+
 from sonar.modules.users.api import current_user_record
 
 from .json_schema_base import JSONSchemaBase
@@ -21,6 +23,11 @@ class DepositsJSONSchema(JSONSchemaBase):
         organisation = {}
         if current_user_record:
             organisation = current_user_record.replace_refs().get("organisation")
+
+        if organisation.get("code") in current_app.config.get(
+            "SONAR_APP_DEPOSITS_DISABLE_NEW_PROJECT_ORGANISATIONS", []
+        ):
+            schema["properties"]["projects"]["items"]["oneOf"].pop(1)
 
         if not current_user_record or (current_user_record.is_moderator and organisation.get("isDedicated", False)):
             return schema

--- a/tests/unit/json_schemas/test_deposits_json_schema.py
+++ b/tests/unit/json_schemas/test_deposits_json_schema.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Test deposits JSON schema."""
+
+from sonar.jsonschemas.deposits_json_schema import DepositsJSONSchema
+
+
+class MockUserRecord:
+    """Mock user record exposing only what DepositsJSONSchema.process() needs."""
+
+    is_moderator = False
+
+    def __init__(self, organisation):
+        """Store the organisation to return."""
+        self.organisation = organisation
+
+    def replace_refs(self):
+        """Return self, no reference to resolve in this mock."""
+        return self
+
+    def get(self, key):
+        """Return the mocked organisation."""
+        return self.organisation if key == "organisation" else None
+
+
+def test_process_keeps_new_project_option_by_default(app, monkeypatch):
+    """Test the "Add a new project" option is kept when no organisation is restricted."""
+    app.config["SONAR_APP_DEPOSITS_DISABLE_NEW_PROJECT_ORGANISATIONS"] = []
+    monkeypatch.setattr(
+        "sonar.jsonschemas.deposits_json_schema.current_user_record",
+        MockUserRecord({"code": "hepvs"}),
+    )
+
+    schema = DepositsJSONSchema("deposits").process()
+
+    assert len(schema["properties"]["projects"]["items"]["oneOf"]) == 2
+
+
+def test_process_removes_new_project_option_for_restricted_organisation(app, monkeypatch):
+    """Test the "Add a new project" option is removed for a restricted organisation."""
+    app.config["SONAR_APP_DEPOSITS_DISABLE_NEW_PROJECT_ORGANISATIONS"] = ["hepvs"]
+    monkeypatch.setattr(
+        "sonar.jsonschemas.deposits_json_schema.current_user_record",
+        MockUserRecord({"code": "hepvs"}),
+    )
+
+    schema = DepositsJSONSchema("deposits").process()
+
+    one_of = schema["properties"]["projects"]["items"]["oneOf"]
+    assert len(one_of) == 1
+    assert one_of[0]["title"] == "Existing project"
+
+
+def test_process_keeps_new_project_option_for_other_organisation(app, monkeypatch):
+    """Test the "Add a new project" option is kept for a non-restricted organisation."""
+    app.config["SONAR_APP_DEPOSITS_DISABLE_NEW_PROJECT_ORGANISATIONS"] = ["hepvs"]
+    monkeypatch.setattr(
+        "sonar.jsonschemas.deposits_json_schema.current_user_record",
+        MockUserRecord({"code": "other"}),
+    )
+
+    schema = DepositsJSONSchema("deposits").process()
+
+    assert len(schema["properties"]["projects"]["items"]["oneOf"]) == 2


### PR DESCRIPTION
Some organisations (e.g. hepvs) manage projects through their own
dedicated form with a richer structure, so creating a project
inline from the deposit form no longer makes sense for them.

* Closes #1087