### PR TITLE
build: update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,8 +241,20 @@ extend-exclude = ["config.py"]
 line-length = 120
 
 [tool.ruff.lint]
-extend-select = ["A", "C4", "INT", "ISC", "T20", "PIE", "Q", "RET", "SIM", "I", "N", "PERF", "W", "D", "F", "UP", "RUF"]
-ignore = ["D100", "D101", "D103", "D200", "D202", "D205", "D400", "D401", "F403", "F405", "F841", "N815", "PERF203", "RUF012"]
+extend-select = ["A", "C4", "D", "F", "I", "INT", "ISC", "N", "PERF", "PIE", "Q", "RET", "RUF", "SIM", "T20", "UP", "W"]
+ignore = [
+    "BLE001",  # blind-except: catching `Exception` is deliberate around external services and harvesters
+    "D401",    # non-imperative-mood: docstring wording is left to the author
+    "DTZ",     # flake8-datetimez: naive dates are intentional (embargo dates, sitemap, display formatting)
+    "RUF012",  # mutable-class-default: Invenio base classes rely on mutable class attributes
+    "TRY002",  # raise-vanilla-class: TODO replace the bare `Exception` raises with a SonarError hierarchy
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Marshmallow and serializer schemas mirror the camelCase fields of the JSON schemas.
+"**/marshmallow/*.py" = ["N815"]
+"**/schema.py" = ["N815"]
+"**/schemas/*.py" = ["N815"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "pep257"

--- a/sonar/heg/cli/harvest.py
+++ b/sonar/heg/cli/harvest.py
@@ -71,7 +71,7 @@ def import_records(file, remove_file):
             file_path = path.join(target_directory, single_file)
 
             with open(file_path) as json_file:
-                for data in json_file.readlines():
+                for data in json_file:
                     data = json.loads(data)
                     try:
                         heg_record = HEGRecord(data)

--- a/sonar/heg/serializers/schemas/medline.py
+++ b/sonar/heg/serializers/schemas/medline.py
@@ -42,7 +42,6 @@ class MedlineSchema(HEGSchema):
 
     def get_subjects(self, obj):
         """Get subjects."""
-
         subjects = [{"label": {"language": obj["language"], "value": [item]}} for item in obj.get("keywords", [])]
 
         for item in obj.get("mesh_terms", []):

--- a/sonar/modules/babel_extractors.py
+++ b/sonar/modules/babel_extractors.py
@@ -8,12 +8,14 @@ import re
 KEY_VAL_REGEX = re.compile(r'"(.*?)"\s*:\s*"(.*?)"')
 
 
-def extract(fileobj, keys=["title"]):
+def extract(fileobj, keys=None):
     """Extract translation from a json file.
 
     :param fileobj: File object to extract translations from.
     :param keys: Properties to take into account.
     """
+    if keys is None:
+        keys = ["title"]
     translations = []
     line = 1
     for v in fileobj:

--- a/sonar/modules/cli/fixtures.py
+++ b/sonar/modules/cli/fixtures.py
@@ -169,11 +169,11 @@ def import_data(file, doc_type, random_files, with_file_support):
                     # Register record to DB
                     db_record = record_class.create(data=record, with_bucket=with_file_support)
                     # Add files
-                    for file in files:
-                        file_path = os.path.join(directory, file["path"])
+                    for record_file in files:
+                        file_path = os.path.join(directory, record_file["path"])
                         if os.path.isfile(file_path):
                             with open(file_path, "rb") as f:
-                                db_record.add_file(f.read(), file["key"])
+                                db_record.add_file(f.read(), record_file["key"])
                     if random_files:
                         data = extract_metadata({"metadata": db_record})
                         for i in range(1, randint(2, 5)):

--- a/sonar/modules/documents/cli/oai.py
+++ b/sonar/modules/documents/cli/oai.py
@@ -20,6 +20,7 @@ def oai():
 @click.argument("pattern")
 @with_appcontext
 def create_set(code, name, pattern):
+    """Create an OAI set."""
     oaiset = OAISet(
         spec=code,
         name=name,

--- a/sonar/modules/documents/dnb.py
+++ b/sonar/modules/documents/dnb.py
@@ -94,7 +94,6 @@ class DnbUrnService:
         """
         # Documentation: https://wiki.dnb.de/display/URNSERVDOK/URN-Service+API
         # https://wiki.dnb.de/display/URNSERVDOK/Beispiele%3A+URN-Verwaltung
-        answer = False
         try:
             response = requests.get(f"{cls.base_url()}/urn/{urn_code}", headers=cls.headers())
             if response.status_code != 200:

--- a/sonar/modules/documents/dojson/sru/model.py
+++ b/sonar/modules/documents/dojson/sru/model.py
@@ -297,8 +297,6 @@ def marc21_to_language_and_provision_activity_from_008(self, key, value):
 
     self["provisionActivity"] = provision_activity
 
-    return
-
 
 @overdo.over("title", "^245..")
 @utils.for_each_value
@@ -429,8 +427,6 @@ def marc21_to_extent_from_300(self, key, value):
     # Additional materials
     if value.get("e"):
         self["additionalMaterials"] = value["e"]
-
-    return
 
 
 @overdo.over("dissertation", "^502..")
@@ -582,8 +578,6 @@ def marc21_to_provision_activity_from_264_1(self, key, value):
 
     self["provisionActivity"] = provision_activity
 
-    return
-
 
 @overdo.over("provisionActivity", "^264.(1|3)")
 @utils.ignore_value
@@ -604,8 +598,6 @@ def marc21_to_provision_activity_from_264_3(self, key, value):
 
     provision_activity.append(manufacture)
     self["provisionActivity"] = provision_activity
-
-    return
 
 
 @overdo.over("notes", "^(500|504|508|510|511|530|545|555)..")

--- a/sonar/modules/documents/permissions.py
+++ b/sonar/modules/documents/permissions.py
@@ -26,7 +26,6 @@ class DocumentPermission(RecordPermission):
         :param record: Record to check.
         :returns: True is action can be done.
         """
-
         # Documents are accessible in public view, but eventually filtered
         # later by organisation
         if request.args.get("view"):
@@ -114,12 +113,13 @@ class DocumentPermission(RecordPermission):
         :param record: Record to check.
         :returns: True if action can be done.
         """
-        # Delete only documents with no URN or no registred URN
+        # A URN is never released, so documents holding one cannot be deleted,
+        # whether the URN is only reserved or already registered on the DNB.
         document = DocumentRecord.get_record_by_pid(record["pid"])
         if document:
             # check if document has urn
             try:
-                urn_identifier = PersistentIdentifier.get_by_object("urn", "rec", document.id)
+                PersistentIdentifier.get_by_object("urn", "rec", document.id)
             except PIDDoesNotExistError:
                 return False
 

--- a/sonar/modules/documents/serializers/json.py
+++ b/sonar/modules/documents/serializers/json.py
@@ -5,8 +5,6 @@
 
 from datetime import datetime
 
-from flask import request
-
 from sonar.modules.collections.api import Record as CollectionRecord
 from sonar.modules.organisations.api import OrganisationRecord
 from sonar.modules.serializers import JSONSerializer as BasedJSONSerializer
@@ -18,8 +16,6 @@ class JSONSerializer(BasedJSONSerializer):
 
     def post_process_serialize_search(self, results, pid_fetcher):
         """Post process the search results."""
-        view = request.args.get("view")
-
         if results["aggregations"].get("year"):
             results["aggregations"]["year"]["type"] = "range"
             results["aggregations"]["year"]["config"] = {

--- a/sonar/modules/documents/urn.py
+++ b/sonar/modules/documents/urn.py
@@ -79,12 +79,12 @@ class Urn:
         # chars
         digit_sequence = ""
         for idx, element in enumerate(urn, 0):
-            digits = conversion_table[urn[idx].upper()]
+            digits = conversion_table[element.upper()]
             digit_sequence = digit_sequence + digits
         # calculate product sum
         product_sum = 0
         for idx, element in enumerate(digit_sequence, 0):
-            product_sum = product_sum + ((idx + 1) * int(digit_sequence[idx]))
+            product_sum = product_sum + ((idx + 1) * int(element))
         # read the last number of the digit sequence and calculate the quotient
         last_number = int(digit_sequence[-1])
         quotient = int(product_sum / last_number)

--- a/sonar/modules/organisations/api.py
+++ b/sonar/modules/organisations/api.py
@@ -113,7 +113,6 @@ class OrganisationRecord(SonarRecord):
         :param with_bucket: If True create a bucket for the organisation.
         :returns: The created record.
         """
-
         return super().create(data, id_=id_, dbcommit=dbcommit, with_bucket=with_bucket, **kwargs)
 
     @classmethod

--- a/sonar/modules/permissions.py
+++ b/sonar/modules/permissions.py
@@ -300,7 +300,7 @@ class FilesPermission(RecordPermission):
     ]
     delete_actions = ["object-delete", "object-delete-version", "multipart-delete"]
 
-    def __init__(self, record, func, user=None, pid=None, parent_record={}):
+    def __init__(self, record, func, user=None, pid=None, parent_record=None):
         """Initialize a file permission object.
 
         :param record: Record to check.
@@ -310,6 +310,8 @@ class FilesPermission(RecordPermission):
         instance.
         :param parent_record: the record related to the bucket.
         """
+        if parent_record is None:
+            parent_record = {}
         self.pid = pid
         self.parent_record = parent_record
         super().__init__(record, func, user)

--- a/sonar/modules/swisscovery/rest.py
+++ b/sonar/modules/swisscovery/rest.py
@@ -55,7 +55,7 @@ def get_record():
 
     # Regular expression to remove the << and >> around a value in the title
     # Ex: <<La>> vie est belle => La vie est belle
-    pattern = re.compile("<<(.+)>>", re.S)
+    pattern = re.compile("<<(.+)>>", re.DOTALL)
     for title in record.get("title", []):
         for main_title in title.get("mainTitle", []):
             main_title["value"] = re.sub(pattern, r"\1", main_title["value"])

--- a/sonar/modules/users/api.py
+++ b/sonar/modules/users/api.py
@@ -334,5 +334,4 @@ class UserIndexer(SonarIndexer):
 
         :param record: Record instance.
         """
-
         return super().delete(record)

--- a/sonar/modules/users/extensions/remove_roles.py
+++ b/sonar/modules/users/extensions/remove_roles.py
@@ -11,5 +11,4 @@ class DeleteRolesExtension(RecordExtension):
 
     def post_delete(self, record, force=False):
         """Called after a record is deleted."""
-
         record.remove_roles()

--- a/sonar/modules/utils.py
+++ b/sonar/modules/utils.py
@@ -11,7 +11,7 @@ import requests
 from flask import abort, current_app, g, request
 from invenio_i18n.selectors import get_locale
 from invenio_mail.api import TemplatedMessage
-from netaddr import IPAddress, IPGlob, IPNetwork, IPSet
+from netaddr import AddrFormatError, IPAddress, IPGlob, IPNetwork, IPSet
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from wand.color import Color
@@ -175,7 +175,7 @@ def is_ip_in_list(ip_address, addresses_list):
     :returns: True if given IP is in list.
     """
     if not isinstance(addresses_list, list):
-        raise Exception("Given parameter is not a list.")
+        raise TypeError("Given parameter is not a list.")
 
     ip_set = IPSet()
 
@@ -190,8 +190,8 @@ def is_ip_in_list(ip_address, addresses_list):
             # Simple IP
             else:
                 ip_set.add(IPAddress(ip_range))
-        except Exception:
-            pass
+        except AddrFormatError, ValueError:
+            continue
 
     try:
         return ip_address in ip_set
@@ -285,8 +285,8 @@ def get_ips_list(ranges):
             # Simple IP
             else:
                 ip_set.add(IPAddress(ip_range))
-        except Exception:
-            pass
+        except AddrFormatError, ValueError:
+            continue
 
     return [str(ip.cidr) for ip in ip_set.iter_cidrs()]
 

--- a/sonar/resources/projects/service.py
+++ b/sonar/resources/projects/service.py
@@ -106,8 +106,10 @@ class ProjectsRecordServiceConfig(RecordServiceConfig):
 
 
 class ProjectServiceSchemaWrapper(ServiceSchemaWrapper):
+    """Schema wrapper injecting the organisation into project data."""
+
     def _get_organisation_pid(self, data):
-        """Get organisation PID from data"""
+        """Get organisation PID from data."""
         if org := data.get("metadata", {}).get("organisation"):
             return get_pid_from_ref_or_data(org)
         return None

--- a/sonar/suggestions/rest.py
+++ b/sonar/suggestions/rest.py
@@ -41,7 +41,9 @@ def completion():
     try:
         service = sonar.service(resource)
         search = service.config.search.search_cls(index=resource)
-    except Exception as err:
+    except AttributeError:
+        # `sonar.service()` returns None for resources without a service,
+        # fall back on the REST endpoints.
         endpoints = current_app.config.get("RECORDS_REST_ENDPOINTS")
         for config in endpoints.values():
             if config.get("search_index") == resource:

--- a/sonar/theme/views.py
+++ b/sonar/theme/views.py
@@ -108,7 +108,7 @@ def profile(pid=None):
 @blueprint.route("/error")
 def error():
     """Error to generate exception for test purposes."""
-    raise Exception("this is an error for test purposes")
+    raise RuntimeError("this is an error for test purposes")
 
 
 @blueprint.route("/manage/")

--- a/tests/api/collections/test_collections_documents_facets.py
+++ b/tests/api/collections/test_collections_documents_facets.py
@@ -8,6 +8,7 @@ from invenio_accounts.testutils import login_user_via_session
 
 
 def test_list(app, db, client, document, collection, superuser):
+    """Test collection facet on documents list."""
     document["collections"] = [{"$ref": f"https://sonar.ch/api/collections/{collection['pid']}"}]
     document.commit()
     db.session.commit()

--- a/tests/api/collections/test_collections_files_permissions.py
+++ b/tests/api/collections/test_collections_files_permissions.py
@@ -36,7 +36,6 @@ def test_update_delete(client, superuser, admin, moderator, submitter, user, col
 
 def test_read_metadata(client, superuser, admin, moderator, submitter, user, collection_with_file):
     """Test read files permissions."""
-
     users = [superuser, admin, moderator, submitter, user, None]
     url_files = url_for(
         "invenio_records_files.coll_bucket_api",
@@ -53,7 +52,6 @@ def test_read_metadata(client, superuser, admin, moderator, submitter, user, col
 
 def test_read_content(client, superuser, admin, moderator, submitter, user, collection_with_file):
     """Test read collections permissions."""
-
     file_name = "test1.pdf"
     users = [superuser, admin, moderator, submitter, user, None]
     url_file_content = url_for(

--- a/tests/api/deposits/test_deposits_files_permissions.py
+++ b/tests/api/deposits/test_deposits_files_permissions.py
@@ -36,7 +36,6 @@ def test_update_delete(client, superuser, admin, moderator, submitter, user, dep
 
 def test_read_metadata(client, superuser, admin, moderator, submitter, user, deposit):
     """Test read files permissions."""
-
     users = [superuser, admin, moderator, submitter, user, None]
     url_files = url_for("invenio_records_files.depo_bucket_api", pid_value=deposit.get("pid"))
     for u, status in zip(users, [200, 200, 200, 404, 404, 404]):
@@ -50,7 +49,6 @@ def test_read_metadata(client, superuser, admin, moderator, submitter, user, dep
 
 def test_read_content(client, superuser, admin, moderator, submitter, user, deposit):
     """Test read deposits permissions."""
-
     file_name = "main.pdf"
     users = [superuser, admin, moderator, submitter, user, None]
     url_file_content = url_for(

--- a/tests/api/documents/test_documents_ark.py
+++ b/tests/api/documents/test_documents_ark.py
@@ -8,7 +8,6 @@ from flask import url_for
 
 def test_ark_query(db, client, organisation, document, search_clear):
     """Test ark search query."""
-
     # an empty query: the document should be in the results
     res = client.get(url_for("invenio_records_rest.doc_list", view="global"))
     assert res.status_code == 200

--- a/tests/api/documents/test_documents_files_permissions.py
+++ b/tests/api/documents/test_documents_files_permissions.py
@@ -38,7 +38,6 @@ def test_update_delete(client, superuser, admin, moderator, submitter, user, doc
 
 def test_read_metadata(client, superuser, admin, moderator, submitter, user, document_with_file):
     """Test read files permissions."""
-
     users = [superuser, admin, moderator, submitter, user, None]
     url_files = url_for("invenio_records_files.doc_bucket_api", pid_value=document_with_file.get("pid"))
     for u, status in zip(users, [200, 200, 200, 200, 200, 200]):
@@ -72,7 +71,6 @@ def test_read_content(
     document_with_file,
 ):
     """Test read documents permissions."""
-
     file_name = "test1.pdf"
     users = [superuser, admin, moderator, submitter, user, user_without_org, None]
     url_file_content = url_for(

--- a/tests/api/documents/test_documents_permissions.py
+++ b/tests/api/documents/test_documents_permissions.py
@@ -151,7 +151,6 @@ def test_create(client, document_json, superuser, admin, moderator, submitter, u
 
 def test_read(client, document, make_user, superuser, admin, moderator, submitter, user):
     """Test read documents permissions."""
-
     # Not logged
     res = client.get(url_for("invenio_records_rest.doc_item", pid_value=document["pid"]))
     assert res.status_code == 200
@@ -230,7 +229,6 @@ def test_update(
     make_subdivision,
 ):
     """Test update documents permissions."""
-
     headers = {"Content-Type": "application/json", "Accept": "application/json"}
 
     # Not logged
@@ -358,7 +356,6 @@ def test_delete(
     user,
 ):
     """Test delete documents permissions."""
-
     # Not logged
     res = client.delete(url_for("invenio_records_rest.doc_item", pid_value=document["pid"]))
     assert res.status_code == 401

--- a/tests/api/documents/test_documents_query.py
+++ b/tests/api/documents/test_documents_query.py
@@ -7,6 +7,7 @@ from flask import url_for
 
 
 def test_collection_query(db, client, document, collection, search_clear):
+    """Test documents query filtered by collection."""
     document["collections"] = [{"$ref": f"https://sonar.ch/api/collections/{collection['pid']}"}]
     document.commit()
     db.session.commit()
@@ -25,7 +26,6 @@ def test_collection_query(db, client, document, collection, search_clear):
 
 def test_identifiers_query(client, document, search_clear):
     """Test identifiers search query."""
-
     res = client.get(
         url_for(
             "invenio_records_rest.doc_list",

--- a/tests/api/organisations/test_organisations_files_permissions.py
+++ b/tests/api/organisations/test_organisations_files_permissions.py
@@ -36,7 +36,6 @@ def test_update_delete(client, superuser, admin, moderator, submitter, user, org
 
 def test_read_metadata(client, superuser, admin, moderator, submitter, user, organisation_with_file):
     """Test read files permissions."""
-
     users = [superuser, admin, moderator, submitter, user, None]
     url_files = url_for(
         "invenio_records_files.org_bucket_api",
@@ -53,7 +52,6 @@ def test_read_metadata(client, superuser, admin, moderator, submitter, user, org
 
 def test_read_content(client, superuser, admin, moderator, submitter, user, organisation_with_file):
     """Test read organisations permissions."""
-
     file_name = "test1.pdf"
     users = [superuser, admin, moderator, submitter, user, None]
     url_file_content = url_for(

--- a/tests/api/stats/test_stats_permissions.py
+++ b/tests/api/stats/test_stats_permissions.py
@@ -17,8 +17,8 @@ def test_list(app, client, document, superuser, admin, moderator, submitter, use
     res = client.get(url_for("invenio_records_rest.stat_list"))
     assert res.status_code == 401
 
-    for user in [superuser, admin, moderator, submitter, user]:
-        login_user_via_session(client, email=user["email"])
+    for logged_user in [superuser, admin, moderator, submitter, user]:
+        login_user_via_session(client, email=logged_user["email"])
         res = client.get(url_for("invenio_records_rest.stat_list"))
         assert res.status_code == 403
 
@@ -31,8 +31,8 @@ def test_create(client, superuser, admin, moderator, submitter, user, search_cle
     res = client.post(url_for("invenio_records_rest.stat_list"), data=json.dumps({}), headers=headers)
     assert res.status_code == 401
 
-    for user in [superuser, admin, moderator, submitter, user]:
-        login_user_via_session(client, email=user["email"])
+    for logged_user in [superuser, admin, moderator, submitter, user]:
+        login_user_via_session(client, email=logged_user["email"])
         res = client.post(
             url_for("invenio_records_rest.stat_list"),
             data=json.dumps({}),
@@ -49,8 +49,8 @@ def test_read(client, document, superuser, admin, moderator, submitter, user, se
     res = client.get(url_for("invenio_records_rest.stat_item", pid_value=record["pid"]))
     assert res.status_code == 401
 
-    for user in [admin, moderator, submitter, user]:
-        login_user_via_session(client, email=user["email"])
+    for logged_user in [admin, moderator, submitter, user]:
+        login_user_via_session(client, email=logged_user["email"])
         res = client.get(url_for("invenio_records_rest.stat_item", pid_value=record["pid"]))
         assert res.status_code == 403
 
@@ -78,8 +78,8 @@ def test_update(client, superuser, admin, moderator, submitter, user, search_cle
     )
     assert res.status_code == 401
 
-    for user in [superuser, admin, moderator, submitter, user]:
-        login_user_via_session(client, email=user["email"])
+    for logged_user in [superuser, admin, moderator, submitter, user]:
+        login_user_via_session(client, email=logged_user["email"])
         res = client.put(
             url_for("invenio_records_rest.stat_item", pid_value=record["pid"]),
             data=json.dumps(record.dumps()),
@@ -95,7 +95,7 @@ def test_delete(client, superuser, admin, moderator, submitter, user, search_cle
     res = client.delete(url_for("invenio_records_rest.stat_item", pid_value=record["pid"]))
     assert res.status_code == 401
 
-    for user in [superuser, admin, moderator, submitter, user]:
-        login_user_via_session(client, email=user["email"])
+    for logged_user in [superuser, admin, moderator, submitter, user]:
+        login_user_via_session(client, email=logged_user["email"])
         res = client.delete(url_for("invenio_records_rest.stat_item", pid_value=record["pid"]))
         assert res.status_code == 403

--- a/tests/api/subdivisions/test_subdivisions_documents_facets.py
+++ b/tests/api/subdivisions/test_subdivisions_documents_facets.py
@@ -8,6 +8,7 @@ from invenio_accounts.testutils import login_user_via_session
 
 
 def test_list(app, db, client, document, subdivision, superuser):
+    """Test subdivision facet on documents list."""
     document["subdivisions"] = [{"$ref": f"https://sonar.ch/api/subdivisions/{subdivision['pid']}"}]
     document.commit()
     db.session.commit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,7 +202,6 @@ def app_config(app_config):
         "127.0.0.1",
         "org.domain.com",
     ]
-    app_config
     return app_config
 
 
@@ -733,7 +732,7 @@ def project_hepvs_json():
             "funding": {
                 "choice": True,
                 "funder": {
-                    "type": "​Swiss National Science Foundation",
+                    "type": "\u200bSwiss National Science Foundation",
                     "number": "1111",
                 },
                 "fundingReceived": True,
@@ -859,7 +858,6 @@ def project_with_validation(app, db, es, make_organisation, make_user, roles, pr
     Uses HEPVS organisation since validation workflow is only available for HEPVS.
     Returns a SimpleNamespace with: project, submitter, moderator
     """
-
     make_organisation(code="hepvs", is_shared=False)
     admin = make_user("admin", organisation="hepvs", access="admin-access")
     submitter = make_user("submitter", organisation="hepvs", access="submitter-access")

--- a/tests/ui/collections/test_collections_view_permissions.py
+++ b/tests/ui/collections/test_collections_view_permissions.py
@@ -10,7 +10,6 @@ from invenio_accounts.testutils import login_user_via_session
 
 def test_read(client, superuser, admin, moderator, submitter, user, collection_with_file):
     """Test read collections permissions."""
-
     file_name = "test1.pdf"
     users = [superuser, admin, moderator, submitter, user, None]
     url_file_content = url_for(

--- a/tests/ui/deposits/test_deposits_view_permissions.py
+++ b/tests/ui/deposits/test_deposits_view_permissions.py
@@ -10,7 +10,6 @@ from invenio_accounts.testutils import login_user_via_session
 
 def test_read(client, superuser, admin, moderator, submitter, user, deposit):
     """Test read deposits permissions."""
-
     file_name = "main.pdf"
     users = [superuser, admin, moderator, submitter, user, None]
     url_file_content = url_for(

--- a/tests/ui/documents/cli/test_documents_cli_ark.py
+++ b/tests/ui/documents/cli/test_documents_cli_ark.py
@@ -25,7 +25,6 @@ def test_ark_disabled_cli(app, script_info):
 
 def test_ark_cli_cfg(app, script_info):
     """Test ARK command line interface."""
-
     runner = CliRunner()
 
     # ark server config

--- a/tests/ui/documents/schemas/test_sru_schema.py
+++ b/tests/ui/documents/schemas/test_sru_schema.py
@@ -8,7 +8,6 @@ from sonar.modules.documents.loaders.schemas.sru import SRUSchema
 
 def test_title():
     """Test title."""
-
     # No 245
     xml = """
     <record></record>
@@ -73,7 +72,6 @@ def test_title():
 
 def test_language():
     """Test language."""
-
     # No 008
     xml = """
     <record></record>

--- a/tests/ui/documents/test_dc_schema.py
+++ b/tests/ui/documents/test_dc_schema.py
@@ -12,6 +12,7 @@ from sonar.modules.documents.serializers.oai_dc import SonarDublinCoreXMLSeriali
 
 @pytest.fixture()
 def contributors():
+    """Contributors fixture."""
     return [
         {
             "agent": {"preferred_name": "Creator 1"},
@@ -81,6 +82,7 @@ def test_creators(minimal_document, contributors):
 
 
 def test_dates(app, minimal_document, embargo_date):
+    """Test dates serialization."""
     result = SonarDublinCoreXMLSerializer().transform_record(minimal_document)
     assert result["dates"] == []
 
@@ -119,6 +121,7 @@ def test_dates(app, minimal_document, embargo_date):
 
 
 def test_descriptions(minimal_document):
+    """Test descriptions serialization."""
     result = SonarDublinCoreXMLSerializer().transform_record(minimal_document)
     assert result["descriptions"] == []
 
@@ -131,6 +134,7 @@ def test_descriptions(minimal_document):
 
 
 def test_descriptions_attributes(minimal_document):
+    """Test descriptions attributes serialization."""
     result = SonarDublinCoreXMLSerializer().transform_record(minimal_document)
     assert result["descriptions"] == []
 
@@ -152,11 +156,13 @@ def test_descriptions_attributes(minimal_document):
 
 
 def test_descriptions_xml_control_char(minimal_document):
+    """Test descriptions serialization with XML control chars."""
     minimal_document["abstracts"] = [{"language": "fre", "value": "sous\x02évalués"}]
     assert SonarDublinCoreXMLSerializer().serialize_object_xml({"_source": minimal_document})
 
 
 def test_formats(minimal_document):
+    """Test formats serialization."""
     result = SonarDublinCoreXMLSerializer().transform_record(minimal_document)
     assert result["formats"] == []
 

--- a/tests/ui/documents/test_documents_dumpers.py
+++ b/tests/ui/documents/test_documents_dumpers.py
@@ -30,7 +30,6 @@ def test_document_indexer_dumper(document, pdf_file):
 
 def test_document_indexer_dumper_identifiers(document):
     """Test the additional identifiers produced by the dumper."""
-
     types = [
         "bf:AudioIssueNumber",
         "bf:Doi",

--- a/tests/ui/documents/test_documents_receivers.py
+++ b/tests/ui/documents/test_documents_receivers.py
@@ -16,7 +16,6 @@ from sonar.modules.documents.receivers import (
 
 def test_transform_harvested_records(app, bucket_location, capsys, harvested_record):
     """Test harvested record transformation."""
-
     transform_harvested_records(None, [harvested_record], name="archive_ouverte_unige", max="1")
     captured = capsys.readouterr()
     assert captured.out.find("1 records harvested") != -1

--- a/tests/ui/documents/test_documents_view_permissions.py
+++ b/tests/ui/documents/test_documents_view_permissions.py
@@ -19,7 +19,6 @@ def test_read(
     document_with_file,
 ):
     """Test read documents permissions."""
-
     file_name = "test1.pdf"
     users = [superuser, admin, moderator, submitter, user, user_without_org, None]
     url_file_content = url_for(

--- a/tests/ui/documents/test_documents_views.py
+++ b/tests/ui/documents/test_documents_views.py
@@ -8,7 +8,7 @@ from unittest import mock
 import pytest
 from flask import g, render_template_string, url_for
 
-import sonar.modules.documents.views as views
+from sonar.modules.documents import views
 
 
 def test_contribution_text():

--- a/tests/ui/organisations/test_organisations_view_permissions.py
+++ b/tests/ui/organisations/test_organisations_view_permissions.py
@@ -10,7 +10,6 @@ from invenio_accounts.testutils import login_user_via_session
 
 def test_read(client, superuser, admin, moderator, submitter, user, organisation_with_file):
     """Test read organisations permissions."""
-
     file_name = "test1.pdf"
     users = [superuser, admin, moderator, submitter, user, None]
     url_file_content = url_for(

--- a/tests/ui/projects/test_projects_api.py
+++ b/tests/ui/projects/test_projects_api.py
@@ -48,7 +48,6 @@ def test_create_project(admin, organisation, project_json):
 
 def test_create_project_hepvs(app, admin, make_organisation, project_hepvs_json):
     """Test creating a HEPVS project."""
-
     # Set the user and organisation in the JSON
     organisation = make_organisation(code="hepvs")
     json = copy.deepcopy(project_hepvs_json)

--- a/tests/ui/shibboleth_authenticator/test_shibboleth_auth.py
+++ b/tests/ui/shibboleth_authenticator/test_shibboleth_auth.py
@@ -6,7 +6,7 @@
 import pytest
 from onelogin.saml2.auth import OneLogin_Saml2_Auth
 
-import sonar.modules.shibboleth_authenticator.auth as auth
+from sonar.modules.shibboleth_authenticator import auth
 
 
 def test_get_identity_provider_configuration(app):

--- a/tests/ui/test_permissions.py
+++ b/tests/ui/test_permissions.py
@@ -19,7 +19,6 @@ from sonar.modules.permissions import (
 
 def test_has_submitter_access(app, client, user_without_role, submitter):
     """Test if user has an submitter access."""
-
     app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
     assert has_submitter_access()
 
@@ -37,7 +36,6 @@ def test_has_submitter_access(app, client, user_without_role, submitter):
 
 def test_has_admin_access(app, client, user_without_role, admin):
     """Test if user has an admin access."""
-
     app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
     assert has_admin_access()
 
@@ -83,7 +81,7 @@ def test_list_permission_factory(app, client, superuser):
 
 
 def test_create_permission_factory(app, client, superuser, document):
-    """Test create permission factory"""
+    """Test create permission factory."""
     app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
     assert record_permission_factory(action="create", record=document).can()
 
@@ -95,7 +93,7 @@ def test_create_permission_factory(app, client, superuser, document):
 
 
 def test_read_permission_factory(app, client, superuser, document):
-    """Test read permission factory"""
+    """Test read permission factory."""
     app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
     assert record_permission_factory(action="read", record=document).can()
 
@@ -107,7 +105,7 @@ def test_read_permission_factory(app, client, superuser, document):
 
 
 def test_update_permission_factory(app, client, superuser, document):
-    """Test update permission factory"""
+    """Test update permission factory."""
     app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
     assert record_permission_factory(action="update", record=document).can()
 
@@ -119,7 +117,7 @@ def test_update_permission_factory(app, client, superuser, document):
 
 
 def test_delete_permission_factory(app, client, superuser, document):
-    """Test delete permission factory"""
+    """Test delete permission factory."""
     app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
     assert record_permission_factory(action="delete", record=document).can()
 
@@ -131,7 +129,7 @@ def test_delete_permission_factory(app, client, superuser, document):
 
 
 def test_unknown_permission_factory(app, client, superuser, document):
-    """Test unknown permission factory"""
+    """Test unknown permission factory."""
     app.config.update(SONAR_APP_DISABLE_PERMISSION_CHECKS=True)
     assert record_permission_factory(document, "unknown").can()
 

--- a/tests/ui/test_utils.py
+++ b/tests/ui/test_utils.py
@@ -8,7 +8,21 @@ import os
 import pytest
 from flask import g
 
-from sonar.modules.utils import *
+from sonar.modules.utils import (
+    change_filename_extension,
+    create_thumbnail_from_file,
+    format_date,
+    get_bibliographic_code_from_language,
+    get_current_ip,
+    get_current_language,
+    get_ips_list,
+    get_language_value,
+    get_specific_theme,
+    get_switch_aai_providers,
+    get_view_code,
+    is_ip_in_list,
+    remove_html,
+)
 
 
 def test_change_filename_extension(app):
@@ -120,7 +134,7 @@ def test_is_ip_in_list():
     assert not is_ip_in_list("wrong", [])
 
     # Not a list
-    with pytest.raises(Exception) as exception:
+    with pytest.raises(TypeError) as exception:
         is_ip_in_list("10.10.10.10", "Not a list")
     assert str(exception.value) == "Given parameter is not a list."
 

--- a/tests/ui/test_views.py
+++ b/tests/ui/test_views.py
@@ -15,8 +15,8 @@ from sonar.theme.views import format_date, record_image_url
 
 
 def test_error(client):
-    """Test error page"""
-    with pytest.raises(Exception):
+    """Test error page."""
+    with pytest.raises(RuntimeError):
         assert client.get(url_for("sonar.error"))
 
 

--- a/tests/ui/users/test_users_cli.py
+++ b/tests/ui/users/test_users_cli.py
@@ -5,7 +5,7 @@
 
 from click.testing import CliRunner
 
-import sonar.modules.users.cli as cli
+from sonar.modules.users import cli
 
 
 def test_import_users(app, script_info, organisation, roles):

--- a/tests/unit/documents/serializers/test_google_scholar_schema.py
+++ b/tests/unit/documents/serializers/test_google_scholar_schema.py
@@ -12,6 +12,7 @@ from sonar.modules.documents.serializers import google_scholar_v1
 
 @pytest.fixture()
 def contributors():
+    """Contributors fixture."""
     return [
         {
             "agent": {"preferred_name": "Creator 1"},

--- a/tests/unit/documents/serializers/test_schemaorg_schema.py
+++ b/tests/unit/documents/serializers/test_schemaorg_schema.py
@@ -12,6 +12,7 @@ from sonar.modules.documents.serializers import schemaorg_v1
 
 @pytest.fixture()
 def contributors():
+    """Contributors fixture."""
     return [
         {
             "agent": {"preferred_name": "Creator 1"},

--- a/tests/unit/resources/test_resources_api.py
+++ b/tests/unit/resources/test_resources_api.py
@@ -5,5 +5,5 @@
 
 
 def test_index_name_property(project):
-    """Test getting index name"""
+    """Test getting index name."""
     assert project._record.index_name == "projects"

--- a/uv.lock
+++ b/uv.lock
@@ -39,11 +39,11 @@ wheels = [
 
 [[package]]
 name = "annotated-types"
-version = "0.7.0"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
 ]
 
 [[package]]
@@ -88,27 +88,24 @@ wheels = [
 
 [[package]]
 name = "babel-edtf"
-version = "1.2.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
     { name = "edtf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/25/b2ca3f471b91d37f59ec4304b5f98bdb6001e174a431dda34cf98b2a217c/babel-edtf-1.2.1.tar.gz", hash = "sha256:1ed0c454e123ed7579510d9531eae5af4399272b0dff897d3d42f68e9bed8d8e", size = 18138, upload-time = "2024-11-07T13:05:22.818Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/27/bda221fdb1fc784fce29df636efa2fd6eb94474af4131a2bc2c4f18aace6/babel_edtf-1.2.2.tar.gz", hash = "sha256:383d12703cafc1684727e317f25b9cbf1436090a2830232a26e6edf4e361227e", size = 4997, upload-time = "2026-07-16T12:05:21.124Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/f5/10fe146e609bcae84bfd32384c3e7ed837cf038c1306a7a72b11eeb165cf/babel_edtf-1.2.1-py2.py3-none-any.whl", hash = "sha256:706529185b335f05ca4567c468f4ec307ad36fa9ce13b63671f1e113a57f7d55", size = 6452, upload-time = "2024-11-07T13:05:21.261Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/71/e7ec06e2c6ccf1ee031e1c48d06e29b3d9228568486f8b84590173102867/babel_edtf-1.2.2-py2.py3-none-any.whl", hash = "sha256:e921c85a208858303a75d0aaccf8d74d882001a16931ce2f63422139db4cd1d9", size = 5679, upload-time = "2026-07-16T12:05:20.156Z" },
 ]
 
 [[package]]
 name = "base32-lib"
-version = "1.0.2"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/04/ed/0752d75107d2ec3bb6a2f023f54fa81039f1062b913709b843205aee47ba/base32-lib-1.0.2.tar.gz", hash = "sha256:09663df621bbc454079a54c92fa25d3bc33ea4a191053a09dd1e05ea4c0fe47c", size = 12969, upload-time = "2020-05-07T14:46:12.518Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/81/4963fd2fa8626daf2860202bdc579b79c2e96f4f7636ae1c87e1e76f7cfe/base32_lib-1.1.1.tar.gz", hash = "sha256:ab0b93c046f8ebb9af3a5295eadc68f447080257a331cd9b871f0418d9b5166b", size = 6391, upload-time = "2026-07-16T15:48:51.609Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/c9/5a769cb6649f2fdf366e1c10db4cafd0e6c7f8b3575d6cb5917bb9298086/base32_lib-1.0.2-py2.py3-none-any.whl", hash = "sha256:f3cbc1c4b3df7af844c9b7ffc1638a688423db2b1e51082b2c014b3959b756ae", size = 6701, upload-time = "2020-05-07T14:46:11.153Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c1/14bc1fdba1adccbecfdf2a99395f361e355107b03319583048441ef60d92/base32_lib-1.1.1-py3-none-any.whl", hash = "sha256:ef62b1fa9a20ddee2c0eac2eaf98540f2c6d0af5a806b43a716884ebeb07ac2a", size = 5408, upload-time = "2026-07-16T15:48:50.576Z" },
 ]
 
 [[package]]
@@ -234,16 +231,16 @@ wheels = [
 
 [[package]]
 name = "build"
-version = "1.5.1"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "os_name == 'nt'" },
     { name = "packaging" },
     { name = "pyproject-hooks" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/21/6ec54248b4d0d51f12f3ca4aa77a128077d747a5db86cb5a2fcd9aedecbd/build-1.5.1.tar.gz", hash = "sha256:94e17f1db803ab22f46049376c44c8437c52090f0dfdf1adc43df56542d644fb", size = 112439, upload-time = "2026-07-09T06:21:59.632Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/f7/2c3f99ff9282f1c1ec9f6298f2c03034658a0901eeacb3b3501cb488574c/build-1.5.1-py3-none-any.whl", hash = "sha256:f1a58fe2e5af5b0238a07b9e70207492c79ddebbdb1ad954fc86d62a56be3e0d", size = 31195, upload-time = "2026-07-09T06:21:58.551Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
 ]
 
 [[package]]
@@ -304,11 +301,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.6.17"
+version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
 ]
 
 [[package]]
@@ -487,41 +484,41 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.15.1"
+version = "7.15.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4a/83/6051c2a2feab48ae5bd27c84ef047191d2d4a3172f689e38eaa48ed17db1/coverage-7.15.1.tar.gz", hash = "sha256:165e9949eaf222ef1f018635d0d7f368a23bfe0212af558534c40d8c04686d67", size = 927640, upload-time = "2026-07-12T20:58:19.908Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d0/55fe630f4cf94e3fcba868240fad8c8cdd1f764e2a932f8926347e6ec4cd/coverage-7.15.2.tar.gz", hash = "sha256:3df60dc267f0a2ca23cb7a9ab1109c62b9335ffbf519fcfe167157c28c09b81d", size = 927741, upload-time = "2026-07-15T18:56:19.558Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/46/81961952e7aebfb38ad0ae4264e8954cc607a7af9e7ac111f9fa986595cc/coverage-7.15.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a886af95f59edf67d5770fd3564d53f4a8af93f25f8c1d60d27e00d7f5674ee8", size = 221560, upload-time = "2026-07-12T20:57:24.282Z" },
-    { url = "https://files.pythonhosted.org/packages/13/d2/ee14d715889f216baf47301d9f469e08fff6995552aaf67e897b282865f6/coverage-7.15.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:985657ebd707941de90d488d1cbb5efac20bdf81f7b91eba771624ccda4d36f4", size = 221894, upload-time = "2026-07-12T20:57:25.87Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/38/f830bc6e6c2c5f23f43847125e6c650d378872f7eeba8d49f1d42193e8a9/coverage-7.15.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5bbe2a06e0a5e1404d9ffbdb49b819bbd6a3bb198ebea4c8dfe7ad9f1e1c2e81", size = 252938, upload-time = "2026-07-12T20:57:27.506Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/53/0d3dd963631259d794c898735d5436e68d6a8d40749c419a07ff7c171469/coverage-7.15.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bde0fe24083d0b7b3dbafa7a09f0796410af1afa2523f28f5f208d8340a4aaca", size = 255445, upload-time = "2026-07-12T20:57:29.234Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/fd/aabed228557565c958259251b89bab8c5669b31291fa63b3e2154ebb017a/coverage-7.15.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f89f7453d6d46db14cf233e2cd8edcd78de2b9c49d4f1dc109590b4e5dbfbb74", size = 256790, upload-time = "2026-07-12T20:57:30.826Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/aa/1cc888e5d3623e603c4e5399653cb25728bb2b40d7519188a3e293d24620/coverage-7.15.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc3656c9ecc27b36bd0907455b77f83c0069ca9ad4a66dec892b76c696eb6047", size = 259104, upload-time = "2026-07-12T20:57:32.63Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/61/fc16d5f5e53098dae41efa21e8ccc611a9b4fe922750dd03dc56db552182/coverage-7.15.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:24d8e85a2a45e44883b488c2659f51fa761dad5353fdb319b672a93facbd2ca9", size = 252956, upload-time = "2026-07-12T20:57:34.316Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/f3/52384668c3de4519ca770bf1975a89e4d6eb5aa2faf0da0577a14008cba4/coverage-7.15.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:68931b5fe746ed4fdaa8892989cab9e6c35781eeb3b0ab2ded893d561e1b3652", size = 254797, upload-time = "2026-07-12T20:57:35.947Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/68/54b807e7c1868178e902fd8360b5d4e559394462f97285c50edf1c4608db/coverage-7.15.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:1ce6947e2a95534ecaa5a15e73c21e550514c980d80eda204d064d789a95f6a4", size = 252762, upload-time = "2026-07-12T20:57:37.856Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/48/dde8adf0338e3ace738757dccf1ce817e5fdcadfae77e1b48a77e5a3b265/coverage-7.15.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:841befdbc89b9c82435fc25b0f4f41858b6238693e45af758bec4cfc1968171c", size = 257037, upload-time = "2026-07-12T20:57:39.488Z" },
-    { url = "https://files.pythonhosted.org/packages/07/f2/179dd88cf60a0aeeee16a970ffe250dccea8b80ed4beab4c5d3f6c41ad4b/coverage-7.15.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5d3de58b837375e7f4c0e1a088ccab5f655efb2fd7427b729df02c862a559633", size = 252577, upload-time = "2026-07-12T20:57:41.363Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/37/8a593d69ab521beb6a105a2017cac4ba94425ee0a8349e29c3c0b522d24f/coverage-7.15.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b1801963f9f44ae0c0f6d737bc7aeb2bbcde7d1fe7e3b43cddc1961af42d3b41", size = 254235, upload-time = "2026-07-12T20:57:43.025Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/34/bc9b3bced66f2cdad4bf5e57ae51c54ea226e8aaaebfc9370a9a11877bf3/coverage-7.15.1-cp314-cp314-win32.whl", hash = "sha256:8c7953c4128ef53b6ffb5f90d87c87d4ce26731df294760bb2314eb0e069e44b", size = 223771, upload-time = "2026-07-12T20:57:44.662Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/f3/4d20337bed61915d14349e62b88d5e4144d5a9872b64adbe90e9906db6db/coverage-7.15.1-cp314-cp314-win_amd64.whl", hash = "sha256:6f0bab60a582d415f0fb535ccff13ba334a47a1538f98913330a525d23bd535a", size = 224257, upload-time = "2026-07-12T20:57:46.412Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/df/bbfeae4948f3ded516f92b32f2d57952427fc5ecfc0924487bb6ee6a5f38/coverage-7.15.1-cp314-cp314-win_arm64.whl", hash = "sha256:0f410ee8f0ac4ec7db71bc0b7632a8b9994e1cad2755bd1566c17e6a162caa74", size = 223683, upload-time = "2026-07-12T20:57:48.106Z" },
-    { url = "https://files.pythonhosted.org/packages/35/65/0b431856064e387d1f5cf474625e4a0465e907024d42f35de6af19ced0be/coverage-7.15.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:fc868bab88e049d41fcd41766810d790a8b960053be2a45e060f5ce0d31d258b", size = 222298, upload-time = "2026-07-12T20:57:49.882Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/96/50eac9bd49df8a3df5f3d38746d1bf332299dffb554486c94ebd55c9dc49/coverage-7.15.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:206d4ec6028f2773b40932d09f074539d6bcdd8f6b318d40cb04bdbd68ed0b49", size = 222561, upload-time = "2026-07-12T20:57:51.688Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/5b/6ba1c4a27e10b8816fd2622b98162c83d3bdf1185097360373611bf96364/coverage-7.15.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:620482ef1c9f4e61f962e159325fe77dea59d16e39d9c9470d069053b244d864", size = 263923, upload-time = "2026-07-12T20:57:53.392Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/59/fe03ade97a3ca2d890e98c572cf48a99fda9adba85757c34b823f41efe1e/coverage-7.15.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d385fc9b054e309ad3cecdc77b586d2af0c98aeec2fdb3773544586f366e817c", size = 266043, upload-time = "2026-07-12T20:57:55.095Z" },
-    { url = "https://files.pythonhosted.org/packages/16/e0/55c4b1217a572a43e13b39e1eb78d0da29fb23679003bd0cdf22c50b1978/coverage-7.15.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1198bca9c0dd7c188aae1f185b0c0b5fc4f0a2b6909000858c29550320bdb07", size = 268465, upload-time = "2026-07-12T20:57:57.017Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/e2/ee47944f76afc03909119b036fe9e0da8cbd274a5141287de79791a0fb6d/coverage-7.15.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5d0297e6a070eadb49df7cddd0ab6f420b8b689dd8904c7dd815a323168fa57e", size = 269584, upload-time = "2026-07-12T20:57:58.958Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/8a/6b4d9779c7b2e21c3d12c3425e3261aa7411399319e27aa402dfec4db5d0/coverage-7.15.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:916fcf2214f56960e409561b37fc32a160a42b6e85483d0652d7b70fa55d707e", size = 263019, upload-time = "2026-07-12T20:58:00.979Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/1e/db5c7fa0c8ba5ece390a1e1a3f30db71d440240a80589df28e66a7503c40/coverage-7.15.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f837bae572c7869ffaa502e604c87e182543012831cf87aae4586ad090ac6dcf", size = 265916, upload-time = "2026-07-12T20:58:03.005Z" },
-    { url = "https://files.pythonhosted.org/packages/83/53/fe5176682b00709b13fab36addd26883139d0dea430816fea412e69255e2/coverage-7.15.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3ea65e3ee6c7c32349fd00559927a9e577bdd72386087eeed1c42b62dfce9b82", size = 263520, upload-time = "2026-07-12T20:58:04.994Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/e7/16f15127be93fbc70c667df5ec5dce934fc76c9b0888d84969a5d5341e2c/coverage-7.15.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:345034976f46a1c54bd17f4e43eb30bb92cb7082fcddff03250cff136cc4eb82", size = 267254, upload-time = "2026-07-12T20:58:06.824Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/73/e5119111f6f065376395a525f7ce6e9174d83f3db6d217ea0211a61cca4d/coverage-7.15.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:4f051a64eb8f8addb4661c2b41d6eea5b7ebc68ad4b2baea8d9bc54e1956e5f7", size = 262366, upload-time = "2026-07-12T20:58:08.555Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/9c/6d0a81182df18a73b081e7a8630f0e2a52b12dfd7898c6ab839551a454d2/coverage-7.15.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a7625770f7720b49bb30d194ad2f8d50fab3c5177874af3d2399676f95f9c594", size = 264680, upload-time = "2026-07-12T20:58:10.359Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/a2/bac0cbd4450638f1be2041a464b1766c8cc94abf705a2df6f1c8d4be870d/coverage-7.15.1-cp314-cp314t-win32.whl", hash = "sha256:81e503d130a472ad1bd38199ecd35116b40d92bcd31e27a2cacde035381f2070", size = 224077, upload-time = "2026-07-12T20:58:12.065Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/b2/d83c5403155172a43ba47c08641bad3f89822d8405102423a41339d2c857/coverage-7.15.1-cp314-cp314t-win_amd64.whl", hash = "sha256:724e878b213b302ad46e9f2fc872d386613f20ebfc492a211482d917ea76c14f", size = 224908, upload-time = "2026-07-12T20:58:13.956Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/41/442b74cad832cc77712080585455482e7cc4f4a9a13192f65731dcd18231/coverage-7.15.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ce2f05c14d077f406fefc4fa5e4f093ad0e0787549f6582535d6e28766f0361b", size = 224219, upload-time = "2026-07-12T20:58:16.315Z" },
-    { url = "https://files.pythonhosted.org/packages/34/98/07a67cf1a26e795d617ed5c540c042b0ac87b72f810c30c07f076cf334f3/coverage-7.15.1-py3-none-any.whl", hash = "sha256:717d01e6e00bed56ad13306f19e0dd2f4f645ee8159d2c72c72301d6cfc7090c", size = 213284, upload-time = "2026-07-12T20:58:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5f/aed265fd7a3551a394f36dfe41868aee709b7f95db4052205b4ad1563ac3/coverage-7.15.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:40f633c5c5fc783732f6312280122e859538fa24461235597c13d803ea9a108a", size = 221650, upload-time = "2026-07-15T18:55:14.527Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/2c/222ba12a545189017120f8eddfc1a0bd4616b47d5d4a8d99421edb2fe4c6/coverage-7.15.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:075560438765b7a2ef43bf7aa7758661b53d889df47f062a31bda6c1ade553a2", size = 221988, upload-time = "2026-07-15T18:55:16.674Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/38/304b5877ab46e6c290b4292cfcf3fe28245f0e5597cad7f6acc91fc7e0a4/coverage-7.15.2-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:25fd15dd40a0a2c51a500d664ca29053c09c3259d998407bf982b6e114696138", size = 253029, upload-time = "2026-07-15T18:55:18.856Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/58/821b533b8db9e44cf1d8a97bd525149ced40dde1d0093da02cb78e715244/coverage-7.15.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9a6367e4aff723e8ee8190836836124284e8fcd4265e307c844010cfa074f3f", size = 255536, upload-time = "2026-07-15T18:55:21.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/f2/7aa06604c389d32ea7f0a6a988359a7eafc3cd3f8e7bc2e88cd2fdf0b877/coverage-7.15.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9854ca62c152874b2060772503535be2e8f53f70b8aaa7686b094888d872f984", size = 256881, upload-time = "2026-07-15T18:55:23.125Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/4f/1ef342339c7916d0096bc5888cc0f653882cc7bc8f897d5cb89143287c9b/coverage-7.15.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:913b6c56e110da40e035bbd168353bf7aaa2544a5eaccea5d98a4629aac156c7", size = 259196, upload-time = "2026-07-15T18:55:25.099Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f4/7ed055d7a9c5ec13b161773a115a5ccc6b0081d568c31fad830806306cc7/coverage-7.15.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aaccad4129d735a8a4d526f26929894c9a4e8ef7034566f210b176749d6906e3", size = 253036, upload-time = "2026-07-15T18:55:27.018Z" },
+    { url = "https://files.pythonhosted.org/packages/14/79/ea82cca18c242a3a38b6c017da39726aa62dcb64aa635abf79b92009975c/coverage-7.15.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a164b50081fc7357331c4024ef4d17b78ba325f8380d05f5a69599a7e05257ee", size = 254887, upload-time = "2026-07-15T18:55:29.084Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ba/a136db3c0d9562b00e10b72540dbf3a33cd3bc5b95060c9308e247494623/coverage-7.15.2-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:bfd341ccf78128e72c094bc70cc25b3ef309c33c7c2c66ba3ed4309549e02de1", size = 252852, upload-time = "2026-07-15T18:55:31.184Z" },
+    { url = "https://files.pythonhosted.org/packages/17/17/ea334246b16b7d059953fad6fdefa11e33c68efbd3fe37b1098120a1fac2/coverage-7.15.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:1473b3ba8e7ee0f076117b1a72c23f579a2b9e2bb742f48a8d86ea27ca93f91a", size = 257128, upload-time = "2026-07-15T18:55:33.163Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c3/074fb66d46d607855f710876b117cbda562c5ab08363528e78820449f937/coverage-7.15.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:17c432b5f73ad52ef46fb06019f6fa7c66ce381961cf0f7dfd1d3a4bd3a98145", size = 252668, upload-time = "2026-07-15T18:55:35.063Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/c1/f620850ada9b36435921c9a3a8057013422b1d964eb4bf37fe138724d192/coverage-7.15.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:77f0ef5011df53a4bd1b35211ab122287f8d9b8d7aa1c4553e5c2deb24b1d446", size = 254325, upload-time = "2026-07-15T18:55:37.125Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/31/a729ca3689404493af82ef8e6ff70bd88bdda8da89aeef6ca9b387aeb2b4/coverage-7.15.2-cp314-cp314-win32.whl", hash = "sha256:f653e5d7248c1191ec988a85c72edeab46c3ff44f90639a4ed4874ec0be90243", size = 223844, upload-time = "2026-07-15T18:55:39.078Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/83/5d809dc808fb1698c671f3e372259bb9158e64b7ea526fc6ab7de64de9fe/coverage-7.15.2-cp314-cp314-win_amd64.whl", hash = "sha256:9911f31aad8906abe337c271343485cf20df5e70df5d2f57f9f136e7b55f26bc", size = 224331, upload-time = "2026-07-15T18:55:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/16/4e/35e488548e952795829e129995c4174df33bf432b591d1aa42c8d9e4e7ad/coverage-7.15.2-cp314-cp314-win_arm64.whl", hash = "sha256:e38def96ad59853824c97953fdcd2c320a84ba3ce99b417db78af8bb6c3db635", size = 223760, upload-time = "2026-07-15T18:55:43.518Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/49/dd2c86cd6374038f6e415fb5bfb86db5218553209c081384a020369dee79/coverage-7.15.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:835ec4e20b45f0a7f63ed78f94065aca00de033403df8377bfe8b9c6abc0a7be", size = 222384, upload-time = "2026-07-15T18:55:45.569Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/173ff17a1c0808e5a438f549f6f145d5ac7528f2791310b63523e3200ac7/coverage-7.15.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7466cc7ab6dc0db871d264bf99e8779f0917ee63d40730af0552f71535a6e072", size = 222647, upload-time = "2026-07-15T18:55:47.544Z" },
+    { url = "https://files.pythonhosted.org/packages/84/f8/b8cba872162356fb44ac79c10309d987206a4461e32072fc29228dad7331/coverage-7.15.2-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e370c12133095ff18432de8c044962be85a5a96d90c6fcbce8e17e76236d2328", size = 264013, upload-time = "2026-07-15T18:55:49.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/67/a807a7586d0b8cae485308ddd55756f0806c92f8e0b411bacbf23c48edf3/coverage-7.15.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fe41909c9515c3bfdb5f02c4d1f857dba322d9a9a1178069b91eea77889df63a", size = 266135, upload-time = "2026-07-15T18:55:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/cd78771dc985f7e4ebdcc82b1a96d9a932af9e806f01f2f91a89f4c72e80/coverage-7.15.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6aa28cfb6488e5453b5b762d65f73aa586380f6693a04d58078ce228a29b06c0", size = 268555, upload-time = "2026-07-15T18:55:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3e/10134cf81275188c58568f324fc74aedff32c63ca4d5bbc513a91944a6f0/coverage-7.15.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcc0aae933921d03096f53b0b03eeb702129fd406dee59f08d2efacc68681fa5", size = 269674, upload-time = "2026-07-15T18:55:56.066Z" },
+    { url = "https://files.pythonhosted.org/packages/75/4a/771b77de446cba985dc414bbc5844bd21604da05dbc044286df8318a48a7/coverage-7.15.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7c63387e21ab21f512c69c9756a8c7dadd322c7275edb064064433c9a09c3743", size = 263101, upload-time = "2026-07-15T18:55:58.107Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b5/70a7011da15f4071943361183aefa27847f3e3aec4fd335f1cb3d3a622b1/coverage-7.15.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e55510bc98ae943cece9e667a6c0fe94c6a92913720dea34243657a17993d0c", size = 266007, upload-time = "2026-07-15T18:56:00.468Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0d/f9547e804ce7ad49646ffeffac26699510efbe6c0f751b66fdc960c4e825/coverage-7.15.2-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:2ff08701be2d1556fc78b326c80a3e8042da09352ecb3819105f8e386c8a3071", size = 263611, upload-time = "2026-07-15T18:56:02.615Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/59/f576a396659c0efd351f5c1544f67c3560e89c7761cabf7f65e412beeda5/coverage-7.15.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:38c9518b7103826c403a461544e3c2e77151e8676d06eaed85911a97e962584a", size = 267344, upload-time = "2026-07-15T18:56:04.622Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/5d/c2e4fce3579c0cb635024293f1a32bbe26df101b3e3a69f22243d1352b6c/coverage-7.15.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:dee88b1ed88587abd8c0269a1fc1f4cc77f7750d1dfde2869e2a123af420e67d", size = 262456, upload-time = "2026-07-15T18:56:06.641Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/956287d69436b66094bc4b57ac2da71e43bfd2a5524e958900b9f582fcf8/coverage-7.15.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fbeeeecea279727f8ac16c8e1133ddfeee793e985c86ae343d6a5ce744eef8c", size = 264771, upload-time = "2026-07-15T18:56:08.795Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/5a/6f979530c2734c575de77cf58f5f28d51f7123a94b5030fd9156fe5f363c/coverage-7.15.2-cp314-cp314t-win32.whl", hash = "sha256:cb0fddaa6884be6aae36ced9544b5e90f7d5f03845a2853bf47a14953a4e8688", size = 224151, upload-time = "2026-07-15T18:56:10.856Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7e/27f6b2a74d484742f4017553e710b01e396b23d809df3e95ca0bb9a2824b/coverage-7.15.2-cp314-cp314t-win_amd64.whl", hash = "sha256:77f091ea3a9cc611cd29f433565476bc1936c084ac8eee00ea0e7e70c27e4199", size = 224981, upload-time = "2026-07-15T18:56:12.928Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/48/284863423aa474240f6842bd00d680da22f4e6ea2e466618ef7c9c9e69a9/coverage-7.15.2-cp314-cp314t-win_arm64.whl", hash = "sha256:6fc448c377d6eeb00a47c673494bd9bae29280ca53987e1869e67ebedfe20658", size = 224294, upload-time = "2026-07-15T18:56:15.156Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/82/32e3bd191d498e64f6f911ad55d14006a0861e54869d2d32452326399e65/coverage-7.15.2-py3-none-any.whl", hash = "sha256:eb6bcae8d1a9d305351ecb108232441d11c5cfe9de840a04388ba5d2db8d735c", size = 213375, upload-time = "2026-07-15T18:56:17.305Z" },
 ]
 
 [[package]]
@@ -647,11 +644,11 @@ wheels = [
 
 [[package]]
 name = "dictdiffer"
-version = "0.9.0"
+version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/61/7b/35cbccb7effc5d7e40f4c55e2b79399e1853041997fcda15c9ff160abba0/dictdiffer-0.9.0.tar.gz", hash = "sha256:17bacf5fbfe613ccf1b6d512bd766e6b21fb798822a133aa86098b8ac9997578", size = 31513, upload-time = "2021-07-22T13:24:29.276Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/31/84b2b2113c2c972431582bffd74f0d04b5efd9126538127b766275580950/dictdiffer-0.10.0.tar.gz", hash = "sha256:0b912acf663949d73b820d3ed59362140a188ab742c94efe13c762dbd24cbbd3", size = 12451, upload-time = "2026-07-16T12:39:07.886Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/ef/4cb333825d10317a36a1154341ba37e6e9c087bac99c1990ef07ffdb376f/dictdiffer-0.9.0-py2.py3-none-any.whl", hash = "sha256:442bfc693cfcadaf46674575d2eba1c53b42f5e404218ca2c2ff549f2df56595", size = 16754, upload-time = "2021-07-22T13:24:26.783Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/2f/7ff60ad2cafd7c970bea75da5f4a9b84b784f7340abcb5fc634d4cf5cd37/dictdiffer-0.10.0-py3-none-any.whl", hash = "sha256:6ca50f38f7c5ee27d52789eee095ae473d9e02e1aa7612cb3aaf25fcf081dbf6", size = 16060, upload-time = "2026-07-16T12:39:06.842Z" },
 ]
 
 [[package]]
@@ -762,20 +759,20 @@ wheels = [
 
 [[package]]
 name = "fastjsonschema"
-version = "2.21.2"
+version = "2.22.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/b5/23b216d9d985a956623b6bd12d4086b60f0059b27799f23016af04a74ea1/fastjsonschema-2.21.2.tar.gz", hash = "sha256:b1eb43748041c880796cd077f1a07c3d94e93ae84bba5ed36800a33554ae05de", size = 374130, upload-time = "2025-08-14T18:49:36.666Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/11/c802f752919c1fd83d44b3b955c6e7120c79f355d4a448c358198a11178c/fastjsonschema-2.22.0.tar.gz", hash = "sha256:6eb12e8f9900db6166c3d396d178ebdf6a4215fe22a06e19792edd612a20035a", size = 382291, upload-time = "2026-07-25T20:32:35.561Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl", hash = "sha256:1c797122d0a86c5cace2e54bf4e819c36223b552017172f32c5c024a6b77e463", size = 24024, upload-time = "2025-08-14T18:49:34.776Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9d/4a0f9355ca3e540b2d22d5f269212e2f227b8f277835b02d8908355245d1/fastjsonschema-2.22.0-py3-none-any.whl", hash = "sha256:60f4c92fda6f93efe3b3261638836478e1e11abc01c647e36e478199f7a86a37", size = 26248, upload-time = "2026-07-25T20:32:33.616Z" },
 ]
 
 [[package]]
 name = "filelock"
-version = "3.29.7"
+version = "3.32.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/94/00f2059e4835eace3ae8fde680b932c496f8ec7bdc99168dfa53fb2e6b79/filelock-3.29.7.tar.gz", hash = "sha256:5b481979797ae69e72f0b389d89a80bdd585c260c5b3f1fb9c0a5ba9bb3f195d", size = 71521, upload-time = "2026-07-08T05:46:58.716Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/80/8232b582c4b318b817cf1274ba74976b07b34d35ef439b3eb948f98645a1/filelock-3.32.0.tar.gz", hash = "sha256:7be2ad23a14607ccc71808e68fe30848aeace7058ace17852f68e2a68e310402", size = 213757, upload-time = "2026-07-21T13:17:42.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/02/be4a57b60c7149b55b9e3b3c13f609cd8eb5307c751f22bd8fb8d262e75b/filelock-3.29.7-py3-none-any.whl", hash = "sha256:987db6f789a3a2a59f55081801b2b3697cb97e2a736b5f1a9e99b559285fbc51", size = 46036, upload-time = "2026-07-08T05:46:57.53Z" },
+    { url = "https://files.pythonhosted.org/packages/06/79/b4c714bef36bc4ec2beeae1e0c124f0223888cd8c6feb1cdc56038116920/filelock-3.32.0-py3-none-any.whl", hash = "sha256:d396bea984af47333ef05e50eae7eff88c84256de6112aea0ec48a233c064fe3", size = 97732, upload-time = "2026-07-21T13:17:41.55Z" },
 ]
 
 [[package]]
@@ -852,27 +849,27 @@ wheels = [
 
 [[package]]
 name = "flask-celeryext"
-version = "0.5.0"
+version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "celery" },
     { name = "flask" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/58/1395b07b9f8ab38ee6e13db16f60ddd82927b4782624e554d3a686a45fd9/Flask-CeleryExt-0.5.0.tar.gz", hash = "sha256:a23a0293bbe8e134233119e003e83ce9fe4f2caaf3fc23d91e09d252c7beb6e5", size = 18526, upload-time = "2023-01-24T12:39:04.174Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/f8/2dc1d579abd25cd0605361d461f7a68059e8a41c16aefc2614aa155575e4/flask_celeryext-0.5.1.tar.gz", hash = "sha256:874b3ee0691ab6041aebcdcfc71f65e8074d4d53851ab93e62557ac5f22ecdcd", size = 7456, upload-time = "2026-07-16T12:43:07.733Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/03/abf800759cd75ab335b3385dc1663c57797d4e7dfd54111ff3351c101246/Flask_CeleryExt-0.5.0-py2.py3-none-any.whl", hash = "sha256:9c4b5c3c157923c86f3c92980bf3a58d0949a2dbf5d3a14b87135bb20d19b71b", size = 10108, upload-time = "2023-01-24T12:39:02.62Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/7a/f4ef5c2d43150e9ba3222c2c751996f1c9459ad9b9f9a3dd0c54814a5af7/flask_celeryext-0.5.1-py3-none-any.whl", hash = "sha256:d42a3857a17b35236b6ff2c2780f98b3360f6bb1b068112746692bfb20a3c778", size = 8768, upload-time = "2026-07-16T12:43:06.776Z" },
 ]
 
 [[package]]
 name = "flask-collect-invenio"
-version = "1.4.0"
+version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/ef/1b253332bd27ddb4152f7702e7c91b5d9048086edd1930c7a3ed97af56cf/Flask-Collect-Invenio-1.4.0.tar.gz", hash = "sha256:52c8343773f6366bb1594905e5c8e1f92101ec06c20e966420237ddad2a7918a", size = 10031, upload-time = "2021-10-11T20:31:04.037Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/9d/fda8a9b590a779931b36b02ebed731831dc87db7078a1b51b7cf2b04d01b/flask_collect_invenio-1.4.1.tar.gz", hash = "sha256:caf1ac862828997487b2508f9ad17970fcbc33ab3d1799cb59f392102e907dc7", size = 6123, upload-time = "2026-07-16T12:54:44.91Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/42/d92da307dddb7e4589e7cada9d6abeb144c20d990f34dd3edc2f96a26b34/Flask_Collect_Invenio-1.4.0-py2.py3-none-any.whl", hash = "sha256:cf969b7cddf27086ee19883e9660aeac2d455646cbad2a43799660b3cc0cbffb", size = 11990, upload-time = "2021-10-11T20:31:00.3Z" },
+    { url = "https://files.pythonhosted.org/packages/48/13/8b9d7e28ac69e5346b57a301137e722054c8a9f535411f598333e510ad16/flask_collect_invenio-1.4.1-py3-none-any.whl", hash = "sha256:c289b4a8990e9f8e1356a3eeee13496883e5aa1ca616e126a7275dd9efdf1c97", size = 9055, upload-time = "2026-07-16T12:54:44.023Z" },
 ]
 
 [[package]]
@@ -955,14 +952,14 @@ sdist = { url = "https://files.pythonhosted.org/packages/05/2f/6a545452040c25565
 
 [[package]]
 name = "flask-menu"
-version = "2.0.0"
+version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/db/96bf20cb438a1dafa4c302b0091933dd09cad142fdbfe1c850dfc53e8a9c/flask_menu-2.0.0.tar.gz", hash = "sha256:162b409e444bea4ab10f12ab1270dd3d62dc0bd1f3d43b3e964a931019f5d580", size = 21775, upload-time = "2024-11-21T15:38:27.552Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/80/fc48ea89b8484d2f060fb3eb5b3620a5ad24b473ae8090e6ce0fe648fb89/flask_menu-2.0.1.tar.gz", hash = "sha256:9a222334d6c21dd7c76adc9b715e67143814c25bed750288e707285a48bb6344", size = 6400, upload-time = "2026-07-16T12:58:43.931Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/c1/81f36322304ccee08505329cb4ff185847fca107f2e51e3b0d4316bc1403/flask_menu-2.0.0-py3-none-any.whl", hash = "sha256:bd9a4c9c4241300aa05e3f27da7d8953f197d4591763a2e0495381b7d9713efa", size = 9440, upload-time = "2024-11-21T15:38:26.452Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cb/b4fe6daa726292564cd3dd4b1ad43f49094befb9c5e39f69c08b17e3949a/flask_menu-2.0.1-py3-none-any.whl", hash = "sha256:80d80b7ca665a9252e9d1a27e46a706cbf5cfd63eeb3291de941404c82a79466", size = 7633, upload-time = "2026-07-16T12:58:43.103Z" },
 ]
 
 [[package]]
@@ -1229,41 +1226,41 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.51"
+version = "3.1.57"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/30/a8a0c15f9480dc91b5b7f11ebd26105e5f80898d7ff02da197fef35d8395/gitpython-3.1.51.tar.gz", hash = "sha256:22c9c94bb6b0b9f3c7157c684fece45a414cea204586b600beae6cd4570dcd6d", size = 223519, upload-time = "2026-07-12T13:40:07.922Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/0d/132ed135c871b6bf91adf16a0e43797cd535b81d4973b5d09291c54fc5ee/gitpython-3.1.57.tar.gz", hash = "sha256:c493ec57c0ef6b19743798b6a5af859c71814b524e7e6f97baa2f8e658961488", size = 225898, upload-time = "2026-07-26T07:33:26.351Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/1232bb1ba52a230f20ff08e1b3df7cd9d43a71b61cc0a1c37941064fe4c7/gitpython-3.1.51-py3-none-any.whl", hash = "sha256:d5b29685708f3c80a56db040b665bfd69492c8e150b5848532af8013b686c5a4", size = 215246, upload-time = "2026-07-12T13:40:06.43Z" },
+    { url = "https://files.pythonhosted.org/packages/41/6e/2139de986d9c7c3ac86f1f8be43858ce90bdfe2f7175e6c80c650ba15242/gitpython-3.1.57-py3-none-any.whl", hash = "sha256:4ccf7d73c10f5c9e76043fbb2675ac5a1b3ff5b41e648f56bcbed5f63792ecaf", size = 217151, upload-time = "2026-07-26T07:33:24.838Z" },
 ]
 
 [[package]]
 name = "greenlet"
-version = "3.5.3"
+version = "3.5.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e2/f1/fbbfef6af0bad0548f09bc28948ea3c275b4edb19e17fc5ca9900a6a634d/greenlet-3.5.3.tar.gz", hash = "sha256:a61efc018fd3eb317eeca31aba90ee9e7f26f22884a79b6c6ec715bf71bb62f1", size = 200270, upload-time = "2026-06-26T19:28:24.832Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/74/b13368064b09053253555d3f2839cc2684d22d5aed0d2ccffbf7a6736558/greenlet-3.5.4.tar.gz", hash = "sha256:0232ae1de90a8e07867bb127d7a6ba2301e859145489f25cda8a6096dabe1d20", size = 206538, upload-time = "2026-07-22T12:47:14.468Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/93/43e116ee114b28737ba7e12952a0d4e2f55944d0f84e42bc91ba7192a3c9/greenlet-3.5.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:fd2e02fa07485778536a036222d616ab957b1d533f36b3ed98ce725d9c9d3117", size = 288202, upload-time = "2026-06-26T18:23:49.604Z" },
-    { url = "https://files.pythonhosted.org/packages/82/2f/146d218299046a43d1f029fd544b3d110d0f175a09c715c7e8da4a4a345d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df0a0628d1597eb0897b62f55d1343f772405fd25f3b2a796c76874b0c2e22e8", size = 654096, upload-time = "2026-06-26T19:07:12.71Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/cc/04738cafb3f45fa991ea44f9de94c47dcec964f5a972300988a6751f49d9/greenlet-3.5.3-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ebd933a6adabc298bab47731a130fe6bfb888bd934eee37810f151159544540d", size = 666304, upload-time = "2026-06-26T19:10:09.503Z" },
-    { url = "https://files.pythonhosted.org/packages/86/a9/73fa62893d5b84b4205544e6b673c654cc43aa5b9899bac00f04d64af73d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8d19fe6c39ebff9259f07bcc685d3290f8fa4ea2278e51dd0008e4d6b0f2d814", size = 670657, upload-time = "2026-06-26T19:24:19.967Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/aa/4e0dad5e605c270c784ab911c43da6adb136ccd4d81180f763ca429a723d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b9d501b40e80b70e32323c799dd9b420a5577a9601469d362ae1ffb690f3a7c", size = 663635, upload-time = "2026-06-26T18:32:20.802Z" },
-    { url = "https://files.pythonhosted.org/packages/29/7e/2ffce64929fb3cab7b65d5a0b20aaf9764e227681d731b041077fc9a525a/greenlet-3.5.3-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:962c5df2db8cb446da51edf1ca5296c389d93b99c9d8aa2ee4c7d0d8f1218260", size = 473497, upload-time = "2026-06-26T19:25:39.421Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/50/13efdbea246fe3d3b735e191fec08fb50809f53cd2383ebe123d0809e44b/greenlet-3.5.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a1fad1d11e7d6aab184107baa8e4ece11ccba3ec9599cd7efa5ff4d70d43256a", size = 1621252, upload-time = "2026-06-26T19:09:05.647Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/22/c0a336ae4a1410fd5f5121098e5bfbf1865f64c5ef80b4b5412886c4a332/greenlet-3.5.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fad5aec764399f1b5cc347ad250a59660f20c8f8888ea6bae1f93b769cce1154", size = 1684824, upload-time = "2026-06-26T18:31:47.738Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/94/91aec0030bea75c4b3244251d0de60a1f3432d1ecb53ab6c437fb5c3ba61/greenlet-3.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:7669aa24cf2a1041d6f7899575b494a3ab4cf68bfcc8609b1dc0be7272db835e", size = 240754, upload-time = "2026-06-26T18:22:15.669Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/06/68d0983e79e02138f64b4d303c500c27ddb48e5e77f3debb80888a921eae/greenlet-3.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:5b4807c4082c9d1b6d9eed56fcd041863e37f2228106eef24c30ca096e238605", size = 239549, upload-time = "2026-06-26T18:22:42.996Z" },
-    { url = "https://files.pythonhosted.org/packages/91/95/3e161213d7f1d378d15aa9e792093e9bfe01844680d04b7fd6e0107c9098/greenlet-3.5.3-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:271a8ea7c1024e8a0d7dd2be66dd66dda8a07193f41a17b9e924f7600f5b62be", size = 296389, upload-time = "2026-06-26T18:22:20.657Z" },
-    { url = "https://files.pythonhosted.org/packages/00/92/715c44721abe2b4d1ae9abde4179411868a5bff312479f54e105d372f131/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19131729ae0ddc3c2e1ef85e650169b5e37ee32e400f215f78b94d7b0d567310", size = 653382, upload-time = "2026-06-26T19:07:14.209Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/83/37a10372a1090a6624cca8e74c12df1a36c2dc36429ed0255b7fb1aeee23/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1540dd8e5fc2a5aec40fbb98ef8e149fa47c89a4b4a1cf2575a14d3d1869d7a8", size = 659401, upload-time = "2026-06-26T19:10:10.876Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/73/8faec206b851c22b1733545fda900829a1f3f5b1c78ae7e0fb3dba57d9f4/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b897d97759425953f69a9c0fac67f8fe333ec0ce7377ef186fb2b0c3ad5e354d", size = 659582, upload-time = "2026-06-26T19:24:21.357Z" },
-    { url = "https://files.pythonhosted.org/packages/db/e2/d1509cad4207da559cc42986ecdd8fc67ad0d1bba2bf03023c467fd5e0f3/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e81fa194a1d20967877bdf9c7794db2bc99063e5be36aee710c08f04c5bb087f", size = 656969, upload-time = "2026-06-26T18:32:22.272Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/55/50c19e49f8045834ada71ef12f8ad048eba8517c6aa41161bed676328fae/greenlet-3.5.3-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:3236754d423955ea08e9bb5f6c04a7895f9e22c290b66aa7653fcb922d839eb0", size = 491037, upload-time = "2026-06-26T19:25:40.672Z" },
-    { url = "https://files.pythonhosted.org/packages/86/7d/eaf70de20aadca3a5884aec58362861c64ce45e7b277f47ed026926a3b89/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:55cf4d777485d43110e47133cbba6d74a8885a87ec1227ef0267f9ee80c5aa21", size = 1617822, upload-time = "2026-06-26T19:09:06.893Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/f9/414d38fc400ae4350d4185eaad1827676f7cf5287b9136e0ed1cbbe20a7f/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:12a248ba75f6a9a236375f52296c498c89ff1d8badf32deb9eca7abd5853f7da", size = 1677983, upload-time = "2026-06-26T18:31:49.396Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/15/7edb977e08f9bff702fe42d6c902702786ff6b9694058b4e6a2a6ac90e57/greenlet-3.5.3-cp314-cp314t-win_amd64.whl", hash = "sha256:efc6bd60ea02e085862c74a3ef64b147ffc6f1a5ea7d9f26e7a939943f68c1e3", size = 243626, upload-time = "2026-06-26T18:24:41.485Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/a7/6ab1d4f9cd548d15ab90da29947f2076100130bb179b0bde59f795a459e3/greenlet-3.5.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:7e8afa5eac028f8140ceafe5ceec66e6aa127ddcb21452d2a564dcd2900b5f22", size = 295410, upload-time = "2026-07-22T11:40:35.747Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7a/422f63b4715cbc0b24385305407adf38b48f6bb68b3e6b04090e994d0f5a/greenlet-3.5.4-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:73b37afe369021423ea53dd3123e04bffa7e93ac64429b9f50835b2e4fcae7cf", size = 661286, upload-time = "2026-07-22T12:26:43.8Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/31/5a1cac663bf5582190c5a714ef81364f03cde232227f39748f8ae4c11da5/greenlet-3.5.4-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3ef964f56dfcb6f9bbef2a190d9126795eac408716aeae47b5e7c73c32aafca9", size = 673517, upload-time = "2026-07-22T12:29:04.815Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/bf/250c2921c7b585dde12f5239e313ca2dcbc464d161ecca36e4e6ef21762d/greenlet-3.5.4-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cef589bc65fae02d10bca2ac341191c5b33acc2967892ebf4fcbd10eabb7a74c", size = 677968, upload-time = "2026-07-22T12:43:46.788Z" },
+    { url = "https://files.pythonhosted.org/packages/15/4a/2a82a1e3f8aaca020853ac8d12211280ca2b231aa08ea39f636f1060c319/greenlet-3.5.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c53ff01a5c53a40f2c16820ebc56d7c61a77f5fbe009dadd96292d5682f80f8", size = 670917, upload-time = "2026-07-22T11:51:13.589Z" },
+    { url = "https://files.pythonhosted.org/packages/18/40/10bfcf6513558d82f7b95dd728001c63bd388259fe27d3e30ae01f103430/greenlet-3.5.4-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:dfc41ae893d9ceaf22c824f2153a88b30651b20e8758c2cd9ac143f23640563c", size = 480643, upload-time = "2026-07-22T12:39:54.149Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b0/e379a152b17bfdfa95795af4049e37c0fd1b4d81f020d426db104ed07c77/greenlet-3.5.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ecca4d80d55a01ad6b23b33262662956149fbb7b2c6be2910f1705921958cbf3", size = 1628478, upload-time = "2026-07-22T12:25:06.678Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/43/bffdfa64f7317f954c5c1230b5dd5922676ce198689a68c1ac1ed4b1b1a5/greenlet-3.5.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2ffbc533e0eaf8e80d8471411646ab88fe58f641d508c0b02b24494479f4d9ec", size = 1692021, upload-time = "2026-07-22T11:51:17.008Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/11/f799f9637e2c6e9b0b716015e339040598b058cf7654dfc0d67468b177ed/greenlet-3.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:305f69e6c4523d7f6979ed001cff4e5853c063e5da04880296603aa0227e544c", size = 248031, upload-time = "2026-07-22T11:40:11.007Z" },
+    { url = "https://files.pythonhosted.org/packages/05/75/625bcdd74d5e6b2dca1ecba3c3ac77bcf8a026c21a649a46cef23e421f97/greenlet-3.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:f260930bbbbcf9caee661211235a5111c86dfe5832fdf6ae4570da1e0995320f", size = 246892, upload-time = "2026-07-22T11:40:27.357Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/69/35c62ed49c320cb4d98e14698ccca5467d3bfe683984172be9cb564d9ce3/greenlet-3.5.4-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:41ddab54e4b238f4a6c323f39b4e59e176affd5a94d461a9fb7583dac74240a3", size = 305571, upload-time = "2026-07-22T11:40:31.659Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6c/64d60216b3640dcb0b62d913dd9e0d80030c09115bb2e4ba70c95d10ca45/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b3dabe3e2809013052c68bdf0b7fa5f5f2859c43a80803131ad61af9cabd7867", size = 672568, upload-time = "2026-07-22T12:26:45.298Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/de/ba3ab0a96292e53039530333b0d2ae18d9e508f3a325cd7bf15f8172944c/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:27d3f00718634d4520a3a150154ac5da36f257869d41321953375b90bfbbc72c", size = 680076, upload-time = "2026-07-22T12:29:06.125Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/db/24a10af12bf8e639cec46c38b9ce1a282543ba42ff4fb0b31a970f1ab603/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:39169a11d87a6a263afda3e9a27d1df16d0f919d40a4837cc73986c9884c0dd8", size = 681690, upload-time = "2026-07-22T12:43:48.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/aeada79083c6f1c15f45d77a332f9c441af263ee298e3eb17522cd337d22/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cbd60b5763c6543c1827e48faaf14ea9bfbad245f52b1a4d76a2a2d8884c6c66", size = 676733, upload-time = "2026-07-22T11:51:16.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/60/44a2eca7b9fd71ae0fae7ff184da1cd3169d176652b97aa1cffcbb0ef961/greenlet-3.5.4-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:bd3d1145f603b2db19feb9078c2e6855eb7c67e15580c010ed815cee519b86fd", size = 510263, upload-time = "2026-07-22T12:39:55.678Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/10/2392fc3a98948652ef5fd1e7275c04f861dd13f74b78a2b4309f4ee4d090/greenlet-3.5.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f00f910f0e7b35416c63b23ad78b769aeccfc1775f712b43c4ee525624a2eef7", size = 1637327, upload-time = "2026-07-22T12:25:07.879Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c6/e7237a3dfa1f205ed0d9ea1e46d70bd2811b32d516266399fb59d28ab90a/greenlet-3.5.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:91c26423753b92caf41ab3f98fd547d7374d4d9fc2d85be041886c1579d9255e", size = 1697493, upload-time = "2026-07-22T11:51:19.214Z" },
+    { url = "https://files.pythonhosted.org/packages/55/e3/4ba8154ba2a3d43729e499f72471b4b5c993f3826d3e24da81d5f06d6572/greenlet-3.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:ee032b91fd8ec29ec6c4cea2b8c561b178435134bd0752c7334b94e9c736c132", size = 251637, upload-time = "2026-07-22T11:40:37.44Z" },
 ]
 
 [[package]]
@@ -1299,14 +1296,14 @@ wheels = [
 
 [[package]]
 name = "idutils"
-version = "1.6.1"
+version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "isbnlib2" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/1b/8d35c02739e1bcf53c23107324f56565e42ab87e53d3cb82322368a024ec/idutils-1.6.1.tar.gz", hash = "sha256:4604827ed52aa272843f1c53b25ed3be864868a9abcdf0ee7932df56f94458b8", size = 35853, upload-time = "2026-05-28T08:54:17.464Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/93/2a3357012f4abc1b3e9740af52e15cbb74ab139c8425311c4957491942b7/idutils-1.7.0.tar.gz", hash = "sha256:848702d9b953a34ba597ac9fd04823fa2ace9dafda3924e91bcf349223cd7442", size = 17933, upload-time = "2026-07-16T13:03:35.373Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/9c/aa092c1daaac95ba6b19d9d2f0542a27692c11ec4e3175f6f98e08d49681/idutils-1.6.1-py2.py3-none-any.whl", hash = "sha256:de24b0f5d9317052223819a99893f913d752820c3d7046d3a4e970b1221e0723", size = 23814, upload-time = "2026-05-28T08:54:16.43Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/c49c4729feead2d0f32d8261418293fa04138184a2af9b650fddbdfebaa3/idutils-1.7.0-py3-none-any.whl", hash = "sha256:2fb2dc5117c58a71261cbc724aa97c770b0f1540c01e671de7c5be66ad015422", size = 22196, upload-time = "2026-07-16T13:03:34.424Z" },
 ]
 
 [[package]]
@@ -1359,21 +1356,21 @@ wheels = [
 
 [[package]]
 name = "invenio-access"
-version = "7.0.0"
+version = "7.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "invenio-accounts" },
     { name = "invenio-base" },
     { name = "invenio-i18n" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/1b/184aac69687d098a0093563b530aa2a9d854faa6dc35016fd5086bcb8d4a/invenio_access-7.0.0.tar.gz", hash = "sha256:6b6f5375205a0b22b5c006bb6c60a829445c427d2429388aa70ab261eacc225a", size = 38458, upload-time = "2026-06-17T21:20:13.059Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/8a/3906bc6d577d831183d9c44bcf1c04b0c9e7e51d9c0c35bb708583d2d1e3/invenio_access-7.0.1.tar.gz", hash = "sha256:d82499cd5a334483c3adf62f92b973a22cb691518b390f9ca0ca8a2d0826ae2b", size = 24544, upload-time = "2026-07-16T13:06:01.286Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/a4/dd053210eab207e88fc0bb233a43a36af7d3590002b28dde11519021ecc6/invenio_access-7.0.0-py2.py3-none-any.whl", hash = "sha256:ec62ddaadfd6692b558c074ae7664df4a819e83b826ae5353685022c1b09b246", size = 80534, upload-time = "2026-06-17T21:20:11.958Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f0/ac5fb9c727b9fe2b6e4131df8ff5447bf4cf8f7db5abc60bdf1251d1924a/invenio_access-7.0.1-py3-none-any.whl", hash = "sha256:6155391320544969b81403feb9edd958ee86d6e1d925c0681a479cc18fa2ffdd", size = 56288, upload-time = "2026-07-16T13:06:00.12Z" },
 ]
 
 [[package]]
 name = "invenio-accounts"
-version = "9.0.0"
+version = "9.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
@@ -1390,14 +1387,14 @@ dependencies = [
     { name = "simplekv" },
     { name = "ua-parser" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/64/865f5435e3881f12a8eb2d599c2bcb75cf03bd858a0d01e769853edd5de6/invenio_accounts-9.0.0.tar.gz", hash = "sha256:495db3692bcfd73e732a438fb1f96b54f6055ed455da366c5acc5b5ac2ddcc99", size = 111544, upload-time = "2026-06-17T21:08:42.096Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/7a/b073e8f7175445d3d3f535e6ff626dbcf81cbe05f61af06c88bffa3800b1/invenio_accounts-9.0.1.tar.gz", hash = "sha256:e35207a00bec640501b9afa0fbd6dd302d7f0d7764198d67fb790f617f90fc43", size = 74189, upload-time = "2026-07-16T14:57:21.66Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/a6/2143ca5f01d208e72f799827a7340c0e98630784a738dab0380ee0e32b02/invenio_accounts-9.0.0-py2.py3-none-any.whl", hash = "sha256:2c38a4c334f778907cffd0620130770bce7ecbfa6392cf98d0e8fa1dd53df160", size = 225680, upload-time = "2026-06-17T21:08:40.778Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/66/065a4f7831efb9b39feb6f7e68668cb32b9bb2903a71fb0de3acf76dcfd9/invenio_accounts-9.0.1-py3-none-any.whl", hash = "sha256:f3b739c170964c6bc1d10b0fecd9d576af8375e32087feba8bfec64a6097ed4f", size = 167325, upload-time = "2026-07-16T14:57:20.285Z" },
 ]
 
 [[package]]
 name = "invenio-admin"
-version = "1.6.0"
+version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask-admin" },
@@ -1410,14 +1407,14 @@ dependencies = [
     { name = "invenio-i18n" },
     { name = "wtforms" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/a7/57eccea9337dae0ed5b6098b33c4d6314d2ceabab67a6ef2f1252ae2aa8a/invenio_admin-1.6.0.tar.gz", hash = "sha256:6473fd1da15d559c528a9adb6ff4ab08ad0c4070fcef86aed32a8ee3fd49db5b", size = 18076, upload-time = "2026-01-27T19:56:45.643Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/aa/2c077396eaa3c886246951f406ba4885c6d47019d7f861f4f953189397fb/invenio_admin-1.6.1.tar.gz", hash = "sha256:045262309adf531f65d92b1bd67b1a945b4b07276a9a8600a183a848902518de", size = 11167, upload-time = "2026-07-16T14:55:00.943Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/c2/416f7365d9c5ea7b3b656b3416878dc0d0ae7005e87eff5c82849d8650fb/invenio_admin-1.6.0-py2.py3-none-any.whl", hash = "sha256:2a0329c64cbc1bf45bf486fe53d170abe2aeeeacbd28a7041b3230ff80e1b6ea", size = 23376, upload-time = "2026-01-27T19:56:44.709Z" },
+    { url = "https://files.pythonhosted.org/packages/49/11/22b4bd87ab1dd87efa2e95e2e737f24ed6684cc315fbf2eab6db8dd08577/invenio_admin-1.6.1-py3-none-any.whl", hash = "sha256:e91fe4f364e21ca2cba07581f4b2a635aa93e1da91426f51fef1e3ef0f0cf689", size = 17688, upload-time = "2026-07-16T14:54:59.855Z" },
 ]
 
 [[package]]
 name = "invenio-app"
-version = "3.1.1"
+version = "3.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask" },
@@ -1430,28 +1427,28 @@ dependencies = [
     { name = "invenio-config" },
     { name = "uritools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/64/7077a69090c0654de5502e61283f0280a9241fc728464aec27af081a5b7a/invenio_app-3.1.1.tar.gz", hash = "sha256:0a7c94cd2619b9629fd190fe908a96d55cee854185c9e7769d5eaef71550a210", size = 19897, upload-time = "2026-04-30T13:21:42.57Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/67/f97eff5e5326a5451c9834f40e338b74b1acb5338f8fc74e89204b8a7d41/invenio_app-3.1.2.tar.gz", hash = "sha256:f2f9b228a2fcf72ea0e91cbdc05c256fcf896bf171477263b485f5ae4de8544c", size = 12439, upload-time = "2026-07-16T14:48:47.175Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/76/4e3d1a62e87e490f0e487de9397b03236d51d1c7388c982621d38cdab8c1/invenio_app-3.1.1-py2.py3-none-any.whl", hash = "sha256:d3aa26d3045e0ad568babde487ff45b5ae2f9894aa87d6c0a6f3e93ea25a4113", size = 20136, upload-time = "2026-04-30T13:21:41.157Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/aa/aff9350938564ed9a4a616337ea55bb1e128340f40d8b483b378cfdb0326/invenio_app-3.1.2-py3-none-any.whl", hash = "sha256:65c68a211d627bd723a114e8ef28856f6e84012587d8d9ee7febb65d987e60c6", size = 16832, upload-time = "2026-07-16T14:48:46.06Z" },
 ]
 
 [[package]]
 name = "invenio-assets"
-version = "4.2.3"
+version = "4.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask-collect-invenio" },
     { name = "flask-webpackext" },
     { name = "invenio-base" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/39/d0282ab71f7f8b669c858fd61f7a0041439e1dfcc9d1928511b7afd2b18c/invenio_assets-4.2.3.tar.gz", hash = "sha256:e00dd1fe99e2d643d70e7293f922f2ed486f19e5197c2c31657debe0c27f33ac", size = 11755, upload-time = "2026-07-01T12:15:52.85Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/28/c06078979b18af770237f2699f086bbf8bfc143336783bcb22a361dd36db/invenio_assets-4.2.4.tar.gz", hash = "sha256:c55ecf5f2e1d22fbbe49f8575fb7a3a911f892b5994afc85649caa20ebd92bf8", size = 11861, upload-time = "2026-07-24T17:37:07.636Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/f7/2b93707497527375906ad2147b8e24534887c7ba81e0c75268cfc5a46a57/invenio_assets-4.2.3-py3-none-any.whl", hash = "sha256:5c7c65938257c2977528ea0427c3c74febecca4d362cc3759a39a02d65cb7460", size = 18376, upload-time = "2026-07-01T12:15:51.928Z" },
+    { url = "https://files.pythonhosted.org/packages/16/46/f1ef4713acccdc589689b08334139c8e87885f89ae7f3853ad2150b49d87/invenio_assets-4.2.4-py3-none-any.whl", hash = "sha256:1e71d66571312613f652b6c24375ab3e982fd1ea0b3485ed68cc8e83b1a9f41c", size = 18487, upload-time = "2026-07-24T17:37:06.578Z" },
 ]
 
 [[package]]
 name = "invenio-base"
-version = "2.4.0"
+version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blinker" },
@@ -1463,27 +1460,27 @@ dependencies = [
     { name = "watchdog" },
     { name = "werkzeug" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/1e/49fc2c14dfbd8f4accec858dfe05d5d2739cbc5192f74bd380b3333efb46/invenio_base-2.4.0.tar.gz", hash = "sha256:283552103785b17c60a7c034382baa69fab9c60b81fa1f961bb1f44ea11134ec", size = 24530, upload-time = "2025-12-02T21:03:24.732Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/a7/9fb93f28dcedab421c4e560b419fde317e6a9d61c74b745cd424ca94c28f/invenio_base-2.4.1.tar.gz", hash = "sha256:a2cd51e1b7db786ad73164c4051e3c5bb3ec08174118a964e4393e64dd22b1a9", size = 16486, upload-time = "2026-07-16T14:42:12.445Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/ee/5e77531034354e402e84ffd530d032b16a7d0fbf786883c61ebdafced3da/invenio_base-2.4.0-py2.py3-none-any.whl", hash = "sha256:407fffa5e85208b5ca9576b4e59cd9d542e5651aaac1baecf7ac160af820ab22", size = 25307, upload-time = "2025-12-02T21:03:23.793Z" },
+    { url = "https://files.pythonhosted.org/packages/93/43/9bccdd5c9a593f89cf45d053c4588d9c83564d2fbef8cfe752b7a62f4782/invenio_base-2.4.1-py3-none-any.whl", hash = "sha256:1655356af811f20eaa291906e0b831caca99e60ffabeddea5728ce86c0ed1b11", size = 21580, upload-time = "2026-07-16T14:42:11.459Z" },
 ]
 
 [[package]]
 name = "invenio-cache"
-version = "3.0.0"
+version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask-caching" },
     { name = "invenio-base" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/0a/942747c7f789b47dacdfdb8ca879e12b286108b71e762b2ed8ef3fbccd7f/invenio_cache-3.0.0.tar.gz", hash = "sha256:0399ec800d102a70e8bd7f35ac7f185f6543bc4752a0c747508fdef5cb86d4ba", size = 11995, upload-time = "2026-01-27T13:02:46.181Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/ee/36fb71ec0f552e8dda7928607a28c5a7ac77e5c0cca3b84a2e8277d641bc/invenio_cache-3.0.1.tar.gz", hash = "sha256:c0f0d288bfac367f86abd0b5c66c4ab80883731d901cfccf3ae1116557e36fd6", size = 7393, upload-time = "2026-07-16T14:36:07.192Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/a4/513432cac2b6b6756b62e322e6fc1fa8d2c0daf942feb5d5bc0fe2164ecb/invenio_cache-3.0.0-py2.py3-none-any.whl", hash = "sha256:663fb5248e446e307d82291da02d1fa83118476850b207231820f3fe708f6191", size = 12226, upload-time = "2026-01-27T13:02:44.966Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d9/a3491db20ba2509f6d38656c4dc125f80b12ef2375987551d3926f1a413a/invenio_cache-3.0.1-py3-none-any.whl", hash = "sha256:c71b50e0a7cdd250f6488037de357c974f45deb2b8f56fe973b396e051425aec", size = 10678, upload-time = "2026-07-16T14:36:06.133Z" },
 ]
 
 [[package]]
 name = "invenio-celery"
-version = "2.2.0"
+version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "celery" },
@@ -1492,27 +1489,27 @@ dependencies = [
     { name = "msgpack" },
     { name = "redis" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/0b/33f7e233501a833706c25892ccb3132133285a23762fdbe4e25ad5a688f7/invenio_celery-2.2.0.tar.gz", hash = "sha256:348f9fadd2af2b33ec8cef61e0c926a9d12995c1687bf74d1de579440ad7f046", size = 21141, upload-time = "2025-07-03T21:30:49.923Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/dc/163a3ad4a1b2059f7bcfb8a1abc26d3b24f7c296603e8957db3d01e7e5c2/invenio_celery-2.2.1.tar.gz", hash = "sha256:8d0dd7cb299080446bab56dd1c95209725d392ad61da7a0b1e221aaf2fa8367a", size = 5235, upload-time = "2026-07-16T14:35:20.996Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/e8/4667c7a6112d62e541e35b1afa40744ad64d71811989488529a74e210f84/invenio_celery-2.2.0-py2.py3-none-any.whl", hash = "sha256:1b34b97d8754f4ecfc121676edbb0a70ff72d3277bfdb2e59e88550bf862fb0e", size = 8320, upload-time = "2025-07-03T21:30:48.969Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/50/2536232567a9f6c23537d917e6cce1c440399530e9b2a8d63b4ffc37a638/invenio_celery-2.2.1-py3-none-any.whl", hash = "sha256:70145edd98b0575633ff6859fe0cf7655fa96526792905f7d48d3d2acbef6962", size = 6629, upload-time = "2026-07-16T14:35:20.194Z" },
 ]
 
 [[package]]
 name = "invenio-config"
-version = "1.1.0"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask" },
     { name = "invenio-base" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/86/1f2d8ea2b2f4b67e5c5c15325d7acc6d2a04b4d238c06abe4b53d57458dd/invenio_config-1.1.0.tar.gz", hash = "sha256:bb6e05b6c24c19fa53349a011e0997c9b88991ccd5144bd7e2cfeecb16477ffe", size = 21289, upload-time = "2025-07-01T20:08:33.522Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/77/d6d058ec1f3160e49eed014222c46abf952e619c47e51a8d923a7b391e57/invenio_config-1.1.1.tar.gz", hash = "sha256:bcbdd05557a946f8ee2d8349b16fef44b2c013f3dfc7aaf22b927c9baeecf7e6", size = 6712, upload-time = "2026-07-16T14:20:05.869Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/d4/b39da24c4b1d0b4f9246de3c001ffd36d2b28d288d402f7d855097fedc0f/invenio_config-1.1.0-py2.py3-none-any.whl", hash = "sha256:34f34902236fa13257c062f1cc4e9e218b7bb8bbe77292b2542e106479b4d37f", size = 11177, upload-time = "2025-07-01T20:08:32.763Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/88/9432ebf48e8b5bd59fe16aeb047adcc41e863b8d75bc7880e8de77cace33/invenio_config-1.1.1-py3-none-any.whl", hash = "sha256:d8592cd616e934abfd404420ac9492e0d4b74f8359c71e70caa2103619568055", size = 9792, upload-time = "2026-07-16T14:20:04.901Z" },
 ]
 
 [[package]]
 name = "invenio-db"
-version = "2.5.1"
+version = "2.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alembic" },
@@ -1523,9 +1520,9 @@ dependencies = [
     { name = "sqlalchemy-continuum" },
     { name = "sqlalchemy-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/48/9e2406e698716243fe22bf8f35823ca456d4405ac86a66a4bd4827043db1/invenio_db-2.5.1.tar.gz", hash = "sha256:1308749b96cd0a29c537c3b60224745bf59b1b631038de8f01b4e0676111b76f", size = 22469, upload-time = "2026-06-05T12:54:14.178Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/65/524ff8dc36965ad10b8cad716660af4a11fab9aab94267acda541ae34779/invenio_db-2.5.2.tar.gz", hash = "sha256:0fdea16d8102377d352894a10628ada224c0744dffbd535a481678ccf37c8280", size = 13823, upload-time = "2026-07-16T14:17:24.024Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/e3/044a8c02bd4ea69ceea0a2c6fa04d5527271e4b85e9e08cd11c497baee72/invenio_db-2.5.1-py2.py3-none-any.whl", hash = "sha256:0cac942699aeaed0ad38f088e3b743d5871c66f909f4f449b02623bac57bf633", size = 22084, upload-time = "2026-06-05T12:54:13.198Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/ae/fbe2757e3e057e5cd29ed6499fcdcf16d4fc1656d701599e7c67494a0b99/invenio_db-2.5.2-py3-none-any.whl", hash = "sha256:9d41fcf9d594df4e3c08beba6a3cb9c3dc92fda6f617a14fa0fc4f2894b2e63e", size = 18549, upload-time = "2026-07-16T14:17:22.879Z" },
 ]
 
 [package.optional-dependencies]
@@ -1584,7 +1581,7 @@ wheels = [
 
 [[package]]
 name = "invenio-indexer"
-version = "6.0.0"
+version = "6.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "invenio-db" },
@@ -1592,35 +1589,35 @@ dependencies = [
     { name = "invenio-records" },
     { name = "pytz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/9e/debe789ebfb09896ccebb62037752ac16d6011d0e56074c9bdbb74775ff1/invenio_indexer-6.0.0.tar.gz", hash = "sha256:39683dbf2c181158954086d67a7ba969f6d708847e59d36c0b951675f1d477da", size = 20800, upload-time = "2026-06-17T21:37:30.753Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/50/2de64257789c7dac573396ad8e612f1482d92d8efdc120de07a398f8fd7d/invenio_indexer-6.0.1.tar.gz", hash = "sha256:504a778ce7e6aa6682c59ba7f3e387af3981586cbb4fe7cde8b18d0c5c01a376", size = 13988, upload-time = "2026-07-16T14:12:14.261Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/31/766c3ed08e4f8577956187661e4ad0ce6b6bd4dcd4738271ee8b788b74ba/invenio_indexer-6.0.0-py2.py3-none-any.whl", hash = "sha256:58e2ae7e9dc10aaf53e758536b065983f571e512d7f3bd686c05e7f673881eeb", size = 19854, upload-time = "2026-06-17T21:37:29.842Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/ab/d9125b587e950076d3314b076088fe587d7aa412c0bc26fedf2988637ccd/invenio_indexer-6.0.1-py3-none-any.whl", hash = "sha256:ef6a72279562acddc48ed5fd2e65fd67887897229460572948e0fe64cd4f698e", size = 18037, upload-time = "2026-07-16T14:12:13.394Z" },
 ]
 
 [[package]]
 name = "invenio-jsonschemas"
-version = "2.1.0"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "invenio-base" },
     { name = "jsonref" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/88/6d11d8ea9e67bd66dff593ead49b7c87b39c6c91ce693c68fe72e89a6ee2/invenio_jsonschemas-2.1.0.tar.gz", hash = "sha256:98712916a35bd6f998a3b1585a7b39e42f61d11a749149d55672918774fa1bd2", size = 28830, upload-time = "2025-07-14T19:38:50.862Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/79/9a740a7cfe682a7abff25e56f7c9f4afd959b6db96f35c28c27325f26e1a/invenio_jsonschemas-2.1.1.tar.gz", hash = "sha256:838539177fe6b0a1e7154350886178692bc3ffd5db47deb38532c1eb1c9469c8", size = 11020, upload-time = "2026-07-16T14:08:23.684Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/cf/d93bec8f33253004d18d1f0034adec756866eb40900685706b23f2ef8730/invenio_jsonschemas-2.1.0-py2.py3-none-any.whl", hash = "sha256:eca99353d7a414bc665b9a99ca594016cc294a6304caea98092f7912a4a8b0c7", size = 16636, upload-time = "2025-07-14T19:38:49.854Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/62/6af3976e3bf102308ff3537a074a52e3ca1d7a5720132e88b8135e451922/invenio_jsonschemas-2.1.1-py3-none-any.whl", hash = "sha256:938d8bcba4d62e13083f69a32f8b3c6caf70da8bd225d944527207c3e0effe6c", size = 14837, upload-time = "2026-07-16T14:08:22.627Z" },
 ]
 
 [[package]]
 name = "invenio-logging"
-version = "4.2.0"
+version = "4.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "invenio-celery" },
     { name = "invenio-db" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/7b/0da29431207f7667b07c5c8638e8f6535b51580ecf221bd1331471725a72/invenio_logging-4.2.0.tar.gz", hash = "sha256:cae00b33022daf5cc2f6d837ce179a76e53206c247a87e1bf1c252d10e4a4540", size = 12631, upload-time = "2026-06-12T08:11:26.305Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/5f/71cb046f99682615fe2c1a27f93a7c8ec7c7164a8630f9c166c7298a082d/invenio_logging-4.3.0.tar.gz", hash = "sha256:f347dd4a6a3c81fbcf1caeb8eb4b51be44152b756c5fe096348cad08bba324ce", size = 7084, upload-time = "2026-07-16T14:08:21.084Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2b/1ef377db4d2cefa57b9bbc7ffda9ba9d15c6689af0ddeb2ce192489b3270/invenio_logging-4.2.0-py2.py3-none-any.whl", hash = "sha256:35f7ca2d1162ad8332cd0ea4328cd6d78f8a1bbaaace1b28bb4d6840ec954996", size = 11315, upload-time = "2026-06-12T08:11:25.223Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/3e/3962353bc29496cf2d7dd62da4ed2878a5f51dc4ef45aef82a7ebdab3bd8/invenio_logging-4.3.0-py3-none-any.whl", hash = "sha256:1f84f183aaaa093db5d9755228cbfdb092bfc42d8471c22e1237df1be17ac5b7", size = 10380, upload-time = "2026-07-16T14:08:20.089Z" },
 ]
 
 [package.optional-dependencies]
@@ -1630,15 +1627,15 @@ sentry = [
 
 [[package]]
 name = "invenio-mail"
-version = "2.3.0"
+version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask" },
     { name = "flask-mail" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/72/f27e212fc8580a216ab0589ae087e2eeff206413e6f05863c19dd8ad7a46/invenio_mail-2.3.0.tar.gz", hash = "sha256:a8ecc485ea0e38307a33f87c7374c329e5e491a3cb3d3dc34aeb84485e78c34b", size = 26940, upload-time = "2025-03-27T17:53:13.161Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/d7/7ab5c068b2670a1c5e39926080fdc55d146fbe8fd4f9b22fba2d3d6891d9/invenio_mail-2.3.1.tar.gz", hash = "sha256:49019aeca5e7277fd4f385d022b82212958d33f12119b80ad06e9147ed349453", size = 6571, upload-time = "2026-07-16T14:05:34.155Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/65/7a30bab57a268a9d52ff7c4b2210448477cd82d2509bcf87bb4f8922e159/invenio_mail-2.3.0-py2.py3-none-any.whl", hash = "sha256:2f560d1e597ce4f033bfe46263d78bf61605980e6b7941ce0ea7adb203df9c3f", size = 10181, upload-time = "2025-03-27T17:53:11.473Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/58/75662ff3ed9d7e124ee548eaf9305d8f1a53a85c6ca4dbc682bec3d1d8aa/invenio_mail-2.3.1-py3-none-any.whl", hash = "sha256:4734a7c3b5843082882749eed4cc9e779c98114f04dd2c676c89ea73374557ae", size = 8814, upload-time = "2026-07-16T14:05:33.203Z" },
 ]
 
 [[package]]
@@ -1658,7 +1655,7 @@ wheels = [
 
 [[package]]
 name = "invenio-oaiserver"
-version = "6.0.0"
+version = "6.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "arrow" },
@@ -1670,14 +1667,14 @@ dependencies = [
     { name = "invenio-rest" },
     { name = "lxml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/17/c6b7111dbdeb9d6ca76411b3f63777aa06d83ae625e87a48bcb134ce2fe5/invenio_oaiserver-6.0.0.tar.gz", hash = "sha256:f821213526e09d54eed97193b8d821715025b84f0bc6e6c6b6729f6203f6252b", size = 51316, upload-time = "2026-06-17T21:46:34.992Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/ba/a653749dd235e5409c1a369f95436e02ba616ce171ad1b5a2bb4993f173f/invenio_oaiserver-6.0.1.tar.gz", hash = "sha256:5dce4be1d05ec25628d9b973215fe589145415b789d96910f6a1ed89dd380c20", size = 33986, upload-time = "2026-07-16T13:58:34.871Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/a1/060488290240566a9ec1864d6eb31e87235a641847fb8bd1039822cdabb2/invenio_oaiserver-6.0.0-py2.py3-none-any.whl", hash = "sha256:ccfc9caa8b3c909ff1e97d1c8342b76cd6421766ec8f88436f1795b5e2a35606", size = 106918, upload-time = "2026-06-17T21:46:33.891Z" },
+    { url = "https://files.pythonhosted.org/packages/66/74/0c581724b1e4bded446dcdab4dae2597cbf65329e10a1eaf14a57ee67e8a/invenio_oaiserver-6.0.1-py3-none-any.whl", hash = "sha256:5cf80dfb2999102baf5919446c4b23c692f0d51c39ccae6848b9002cdf48af91", size = 78269, upload-time = "2026-07-16T13:58:33.917Z" },
 ]
 
 [[package]]
 name = "invenio-oauth2server"
-version = "6.0.0"
+version = "6.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachelib" },
@@ -1694,14 +1691,14 @@ dependencies = [
     { name = "wtforms" },
     { name = "wtforms-alchemy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/5c/1677d771906cc0a3bab8518d03b05245143d5c62d2207f510965eb58134a/invenio_oauth2server-6.0.0.tar.gz", hash = "sha256:e86f7a342df10b092287871abca11b508a344b69be12df43c8f9a3ac9cb08642", size = 120448, upload-time = "2026-06-17T21:45:27.61Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/88/c53eb2ea5f311a7bc99a6ac0159ba3be27d2064fc1c24e5929b4dd313953/invenio_oauth2server-6.0.1.tar.gz", hash = "sha256:a4d8912df62ad90bc97e76db33d4cfc0b411b97dc49d180d388dc5325dbdc273", size = 67707, upload-time = "2026-07-16T13:54:45.377Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/f2/7b8dc438b77911eed6f6602411b0b770dddf693471edcd57941c084d67df/invenio_oauth2server-6.0.0-py2.py3-none-any.whl", hash = "sha256:7c07529edbfc9d9ef603f65d218acd7c923b1a2523f0010aa25a719a7fc85a46", size = 237762, upload-time = "2026-06-17T21:45:26.45Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/cb/517d41e816aad60fefc2466c8e200b937af4ca147aebd228298a1e65a743/invenio_oauth2server-6.0.1-py3-none-any.whl", hash = "sha256:295207e9b25629c8bc021670d29c8eafee8fcbaec9306a9a94c00b3210d75f07", size = 170610, upload-time = "2026-07-16T13:54:44.253Z" },
 ]
 
 [[package]]
 name = "invenio-oauthclient"
-version = "9.1.0"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blinker" },
@@ -1718,14 +1715,14 @@ dependencies = [
     { name = "uritemplate" },
     { name = "uritools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/76/5db32271878dcadb050f80aa690e2116e9ed8946cdcebe8165730993b88a/invenio_oauthclient-9.1.0.tar.gz", hash = "sha256:84c4a8634204ce88c2bbf188dc9d43054c16f808920d86856bbbf8b3f595dccb", size = 106004, upload-time = "2026-06-30T10:27:18.454Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/f9/c1c7808fa646704f26c0c6dae46c7cef0557aeb7bc730c24f135a719ff0d/invenio_oauthclient-9.1.1.tar.gz", hash = "sha256:13f51add27414b4928d4366cb7b44281bd94512562ec14bd725ab61df2a29214", size = 74612, upload-time = "2026-07-16T13:54:51.569Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/9b/a11c20d317ffab84a0cc70fe86a5934b0dc7725335706becfb44e52b3902/invenio_oauthclient-9.1.0-py2.py3-none-any.whl", hash = "sha256:6613a317fb2dea8e51f1555a661c07910dffe2366e68018e208a456e7422bf82", size = 220493, upload-time = "2026-06-30T10:27:17.209Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ba/dcf35640339b66ba2e28741f6aded43273152cd684efc0674d536c43bbb4/invenio_oauthclient-9.1.1-py3-none-any.whl", hash = "sha256:07f8df741d93accf67b321640d0095c0cc84002d945ff37635f4cd11409d979e", size = 173822, upload-time = "2026-07-16T13:54:50.356Z" },
 ]
 
 [[package]]
 name = "invenio-pidstore"
-version = "4.0.0"
+version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "base32-lib" },
@@ -1734,9 +1731,9 @@ dependencies = [
     { name = "invenio-base" },
     { name = "invenio-i18n" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/22/a05addce12bd099c148f44963be722ce78df896c56268cd508cc8def9507/invenio_pidstore-4.0.0.tar.gz", hash = "sha256:0bffa43fb1a4b6811da415bad7bec1d2cea15e24483ebe039f4d10f7a9611a25", size = 39857, upload-time = "2026-06-17T21:28:42.849Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/5b/c4f8050bba769494c56485e09f7bffe08e548272b7eaa2de7321d0b83e9c/invenio_pidstore-4.0.1.tar.gz", hash = "sha256:1dc8050fe13ec46ce9fa9d61ec19c76645522f0d6e9f8a3c75eede913de698e7", size = 24813, upload-time = "2026-07-16T13:52:01.412Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/02/6a0e95937d28fac39a0615597600e7068881c1a1bd7becdbe524560d43b9/invenio_pidstore-4.0.0-py2.py3-none-any.whl", hash = "sha256:221f14353f9d67c4dbd78763af4f88d55b123638f2bb4d3677f8b0400ed3bcfc", size = 83153, upload-time = "2026-06-17T21:28:41.794Z" },
+    { url = "https://files.pythonhosted.org/packages/47/81/840a902bea5e86ad782cdc912eb3b66f02f239f892dd410e975b146a70f4/invenio_pidstore-4.0.1-py3-none-any.whl", hash = "sha256:3ef405f029b0febae75ca76a8d53e6a23ea1b5596550057705498668b82b30a8", size = 58333, upload-time = "2026-07-16T13:52:00.334Z" },
 ]
 
 [[package]]
@@ -1763,21 +1760,21 @@ wheels = [
 
 [[package]]
 name = "invenio-queues"
-version = "1.0.3"
+version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "invenio-base" },
     { name = "invenio-celery" },
     { name = "redis" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/7b/ef16e5d2ef1a6049d2142bd2a295d6e333305b8bd48c2980a9920fe63f5e/invenio_queues-1.0.3.tar.gz", hash = "sha256:7078086422b8c34e98c7a3eed5f79a60a9490ad47c675a3bca1cc991e283715e", size = 11026, upload-time = "2026-04-30T15:13:08.638Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/a3/f78300fbb26a80ddcceccb347e14046745326d135b62a7e8dc2322d10b05/invenio_queues-1.0.4.tar.gz", hash = "sha256:74422cb115c38e59ff782147ca15e44a6f7f074ee727629f4a4bb2a17a8f3adc", size = 6349, upload-time = "2026-07-16T13:50:22.157Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/b6/c711e260629c5d89f76a9453d48c66c8e27bab054b63745a8980a42ac484/invenio_queues-1.0.3-py2.py3-none-any.whl", hash = "sha256:b2a317d8ff27110356723f25dd0cc5db8c0ddcb53f8775d4e52a8c3da0afa836", size = 10717, upload-time = "2026-04-30T15:13:07.657Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/c8/87fbf750c51aa1de8f4d6296be5cc5293aeaba383fb018c7d80334be8ac6/invenio_queues-1.0.4-py3-none-any.whl", hash = "sha256:f75b2ed2c3f05fc40c09717a2b08e83adfdf03b6338fa8defd9d1cb0636fa504", size = 9209, upload-time = "2026-07-16T13:50:21.219Z" },
 ]
 
 [[package]]
 name = "invenio-records"
-version = "6.0.0"
+version = "6.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "arrow" },
@@ -1788,14 +1785,14 @@ dependencies = [
     { name = "jsonresolver" },
     { name = "jsonschema" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/13/c516432ea5bf99bee34efdfffa250f1954281f7dddc7d74759aafe3613b7/invenio_records-6.0.0.tar.gz", hash = "sha256:8714c7798078e86c67136d8e68a796fc6bc015ef1f6783142e6e30b38d0cb611", size = 116516, upload-time = "2026-06-17T21:13:34.306Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/d1/57db79d6b42475df5f1b82fc2877bc058bc0376a38b2d7ef02c659f84590/invenio_records-6.0.1.tar.gz", hash = "sha256:645dd6f2349d2e5165cf529c197c510ba546985af622354bcce3997b957e029f", size = 98320, upload-time = "2026-07-16T13:49:11.124Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/04/f3f5098fb0af1619f52e4b02b519f09eee162cb0a055c8762ccd6954a9dd/invenio_records-6.0.0-py2.py3-none-any.whl", hash = "sha256:a016e8923f8a0d177e001884844c8c520f53d979aa0bc509365c231de7aa4c5c", size = 162452, upload-time = "2026-06-17T21:13:32.927Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/bc/b78f114ab88e16780198e24fc3cff2fdce63d0b1a90fcb17aa6525326274/invenio_records-6.0.1-py3-none-any.whl", hash = "sha256:cd9005274e343f380c656ba698e151d4dae8b734971874890b4f253a08a341ed", size = 137482, upload-time = "2026-07-16T13:49:09.811Z" },
 ]
 
 [[package]]
 name = "invenio-records-files"
-version = "4.0.0"
+version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "invenio-base" },
@@ -1803,26 +1800,26 @@ dependencies = [
     { name = "invenio-records" },
     { name = "invenio-records-rest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/97/f96f5c1d551480b61e14d2a7d09016b2bab80531dc8d7acd9ef316ca89b8/invenio_records_files-4.0.0.tar.gz", hash = "sha256:8060332d8f6b552e978f89eff3ea8215f6660df8b932fc33c91235864744338c", size = 19055, upload-time = "2026-06-17T21:54:33.725Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/1d/8b165de6293816729d1d915f906a080da6a60135d5025e8eaeb3bba6aefb/invenio_records_files-4.0.1.tar.gz", hash = "sha256:9c9ac9a04cec2dcf7ac72c5f35ea5272d0b480c22bfbb1a39f19d2cdc7e10f41", size = 13330, upload-time = "2026-07-16T13:46:46.077Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/23/1b438661c656e926654b426bd6ca436fa2e01c190c41c7eb50ab0b4e1f3a/invenio_records_files-4.0.0-py2.py3-none-any.whl", hash = "sha256:3938de965af52edc1885b9bc20ec1cd405c0ef398d206173c92941eaacd583a9", size = 20311, upload-time = "2026-06-17T21:54:32.715Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8c/059f4bf36812f9219341a7b9488c3d1c43ec91f2948f403159d857b7e1cf/invenio_records_files-4.0.1-py3-none-any.whl", hash = "sha256:c2dcb1fd28860321985e4b8c334a39ce99a4880b9e810243071f718b698cecd5", size = 19294, upload-time = "2026-07-16T13:46:45.07Z" },
 ]
 
 [[package]]
 name = "invenio-records-permissions"
-version = "4.0.0"
+version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "invenio-access" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/1e/7466671f11c75d137a81adbd9cc353747d6e5e0cf4992d13c73d1bcf0a35/invenio_records_permissions-4.0.0.tar.gz", hash = "sha256:765414adb4e485b62d90784c07dec033e5ed8ec3684d3d166ded91875575b5db", size = 16379, upload-time = "2026-06-17T21:44:00.26Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/f0/9df224f22bafc6bc624346b92ff4b446627a76a92e3797253dc5521cbf39/invenio_records_permissions-4.0.1.tar.gz", hash = "sha256:76ed98fff58698fc9334e12497253f4a47fb44a6cbf2a983c07dba0fdb2b88a2", size = 11327, upload-time = "2026-07-16T13:46:11.095Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/57/ad22510040651d8ad33e7a50dfcf492ce36af07f4adb6208e280603a300e/invenio_records_permissions-4.0.0-py2.py3-none-any.whl", hash = "sha256:2dd3cdbba7002706dfe6811810729ad0d754898c59cd1c48ee89d97d5e28666d", size = 16237, upload-time = "2026-06-17T21:43:59.363Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/53/47b8e1ef34661db1411537a4511727d9e2dd8cb2d7eca895b5d74d535e4d/invenio_records_permissions-4.0.1-py3-none-any.whl", hash = "sha256:06db1aed91ad6e66ade0bfa64cbe6201784bd4e02b2585893ac9aa687f918d4b", size = 15381, upload-time = "2026-07-16T13:46:10.018Z" },
 ]
 
 [[package]]
 name = "invenio-records-resources"
-version = "11.0.0"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel-edtf" },
@@ -1845,9 +1842,9 @@ dependencies = [
     { name = "xmltodict" },
     { name = "zipstream-ng" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/5e/adb93f432939a8df6ac15b35481401dec7e03c56cb0354bffa219881bd93/invenio_records_resources-11.0.0.tar.gz", hash = "sha256:8e2dcebc45c3741c7a1960bdb7d8ea56674cd5e8a5f387af7f1b32eaed1e7d63", size = 145602, upload-time = "2026-06-17T22:15:55.197Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bd/0aeb58f53334823f2e87fae11911c53839fe9d4958929121d74b2b9ee8b2/invenio_records_resources-11.0.1.tar.gz", hash = "sha256:2991bb9aa208bae8efd469f0aff4d57c4076b5b4bbd60b97d70e6923300424ae", size = 115923, upload-time = "2026-07-16T13:47:05.461Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/80/a53c1cba1a040652a2b2b789d133248ca58bd4f57a2862cb6b9f1bebcb97/invenio_records_resources-11.0.0-py2.py3-none-any.whl", hash = "sha256:d048f7d9876920bd2319aeffaa2926d02de3dad32e65d95da81cff21d927d643", size = 266097, upload-time = "2026-06-17T22:15:53.706Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/d4/7cd6c1a90293ab1b2bd0933e2d0f510f6ebac87c0ebfbe361174cd50187e/invenio_records_resources-11.0.1-py3-none-any.whl", hash = "sha256:cf9cdf746b2f392d246c1bb0ed62b802e179502b4a031220ad0b8505eba04b3a", size = 225173, upload-time = "2026-07-16T13:47:04.176Z" },
 ]
 
 [[package]]
@@ -1877,7 +1874,7 @@ dublincore = [
 
 [[package]]
 name = "invenio-records-ui"
-version = "5.0.0"
+version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "invenio-base" },
@@ -1885,14 +1882,14 @@ dependencies = [
     { name = "invenio-pidstore" },
     { name = "invenio-records" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/80/e05c11b35047855578b9e94a5dea9b75fb61d7a5b335e0d9bdb64f9ca27f/invenio_records_ui-5.0.0.tar.gz", hash = "sha256:82548ab0bc805d636fc3094d5e9502eaf2997f2e8f86f4d86463edce13042801", size = 25755, upload-time = "2026-06-17T21:38:33.432Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ab/06476ac4e5401e26fdf60c1360b7681e1674c88455db8b2b5875d97f20c0/invenio_records_ui-5.0.1.tar.gz", hash = "sha256:ba761438bb9a9eeb2be96d7ebb9da001d383a8d0583cde1e972eaaa2eda6cb66", size = 14890, upload-time = "2026-07-16T13:42:32.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/e0/0ed54b4a1814e642294ff2ca06a978314a10ceef484b39c2514bb1abd088/invenio_records_ui-5.0.0-py2.py3-none-any.whl", hash = "sha256:0538b8eb35db7a7f700ffa83dae57f54816fa3a50fd585204990b0bce8a8cc81", size = 64910, upload-time = "2026-06-17T21:38:32.339Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/31/93a94f240d8e195fb8f6d2fdd8c6483ceb2eb26cf8badcbdf8d035a8e8af/invenio_records_ui-5.0.1-py3-none-any.whl", hash = "sha256:fab69c202c76a3dea040b67662598a69409f18d75b71f21a6c2768e7aa39f0ac", size = 44431, upload-time = "2026-07-16T13:42:31.544Z" },
 ]
 
 [[package]]
 name = "invenio-rest"
-version = "4.0.0"
+version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask-cors" },
@@ -1903,22 +1900,22 @@ dependencies = [
     { name = "marshmallow-utils" },
     { name = "webargs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/9739dcb963381cc39e3969e8b8c79c349701c83649d177d1e1c3ac1bdae1/invenio_rest-4.0.0.tar.gz", hash = "sha256:1e4814d18b71ed27a788492e8293d0b1de3a16c5e55b5eb45f7ec7e647bfe3b5", size = 22135, upload-time = "2026-06-17T20:56:56.39Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/fb/27a0716a2b8ea96c9202ed57356277da603687670557a20b33f3318f920a/invenio_rest-4.0.1.tar.gz", hash = "sha256:b70facad145e674e60c3aecd74b49663721bdf81951d942cbe668f102a3347ea", size = 15944, upload-time = "2026-07-16T13:38:01.163Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/e6/824024ca26e93dcca70e82310a46d8bbd889b2cdf4543e0ca0ac607ac6d2/invenio_rest-4.0.0-py2.py3-none-any.whl", hash = "sha256:bde127f4ec65e72d2122f02656c463dd6c0d212e29899eeaee9fca7fae7b0152", size = 21505, upload-time = "2026-06-17T20:56:55.419Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/aea2122ae8e67d0c408d5dbaf7a39eecfc2d5cf7eb87347497e4998c8f46/invenio_rest-4.0.1-py3-none-any.whl", hash = "sha256:16cd91cac9dd6d76e5a03443ba0724248804b5efcec79c123b0f3665d6600ab7", size = 19953, upload-time = "2026-07-16T13:38:00.196Z" },
 ]
 
 [[package]]
 name = "invenio-search"
-version = "3.1.2"
+version = "3.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dictdiffer" },
     { name = "invenio-base" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/82/51/fc1108453d09cdc5a2c257624e5d7055090b77d49e63a4f921d6d511120c/invenio_search-3.1.2.tar.gz", hash = "sha256:8edfc9eca1506ed841a861231b29ce374770db0862490346cc3d327b8e6dd440", size = 27992, upload-time = "2025-11-20T13:32:40.309Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/55/d71c905eaa1c3eb67fe442116d6947d89f28d3c8407cfa13ff8d197dbbb0/invenio_search-3.1.3.tar.gz", hash = "sha256:ceb6957d3590d5081a9028901d1335bbbd4eaadc0bbfb66b45715b8a84398f86", size = 19526, upload-time = "2026-07-16T13:31:47.111Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/04/eca8047b8aae592f7e0726debc02bc26ca25b4909c6940b66d2d867957be/invenio_search-3.1.2-py2.py3-none-any.whl", hash = "sha256:5c714fe51d2a103b95725088dad433af6ef531d4a01230d850bfeb50f641ef6c", size = 26272, upload-time = "2025-11-20T13:32:39.319Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/69/51af2cc8fd85204bbf314b925481abde804354adb77ce6ef4b04541ee032/invenio_search-3.1.3-py3-none-any.whl", hash = "sha256:590b2e5be4b664008bde38072e9875eb1ab130539752963f302adfd4deaf782e", size = 23657, upload-time = "2026-07-16T13:31:46.079Z" },
 ]
 
 [package.optional-dependencies]
@@ -1929,7 +1926,7 @@ elasticsearch7 = [
 
 [[package]]
 name = "invenio-search-ui"
-version = "5.0.1"
+version = "5.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -1937,14 +1934,14 @@ dependencies = [
     { name = "invenio-base" },
     { name = "invenio-i18n" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/56/b72c62ee3f2b811083d3ac473800cbccaa5fd0a9a755ccf6130d652602b5/invenio_search_ui-5.0.1.tar.gz", hash = "sha256:20d259df9d9b891285ad94cd329b2d33b0de285575a44c6cc518c5c482f7d733", size = 57519, upload-time = "2026-06-22T15:51:44.46Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/38/138e64ab2b9a4a602a2664f9234bc3d8709aa8bafc7ae09e265680ac974f/invenio_search_ui-5.0.2.tar.gz", hash = "sha256:810964d531792ca3b7825528d4028fbee797bf1b1135fd6efb8e34e7ce76c074", size = 39292, upload-time = "2026-07-16T13:31:35.449Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/c9/8cce950ea6c17f581fde2206ee2282e69153c42aff587b10b7b93517ac68/invenio_search_ui-5.0.1-py2.py3-none-any.whl", hash = "sha256:a430fe6ff8b554cb1ab6e1bf0a0a04808eada16e0dd3d15a64b86bc992e449d1", size = 139796, upload-time = "2026-06-22T15:51:43.287Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/fd/e9aa5bb2d76db79bdeab119708fe7d304967b9e2320864f9c8d9850ad0a9/invenio_search_ui-5.0.2-py3-none-any.whl", hash = "sha256:4e14c3bf36b18d91dc85d14330c8c36ad236e9eea232e57eaaf3ed36c90beeab", size = 116911, upload-time = "2026-07-16T13:31:34.317Z" },
 ]
 
 [[package]]
 name = "invenio-stats"
-version = "7.0.0"
+version = "7.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "counter-robots" },
@@ -1957,9 +1954,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "python-geoip" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/33/239c050c61c8da6eb66d861756a0e69bafaaba24457d166afc4d8bf826c6/invenio_stats-7.0.0.tar.gz", hash = "sha256:649d2d9804d5fe0c8287964e0e7f928c23926ce1c0fb39ab27b6b74e4f228d5e", size = 39596, upload-time = "2026-06-17T21:47:50.131Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/19/591864abc6b8da4f5930600a404041bd95bac5418b7379675fdc2baa5894/invenio_stats-7.0.1.tar.gz", hash = "sha256:43b9fdc1d08f56becd07776400ffc9e99d4b597e3cae40752299f4151f8fdfd1", size = 27931, upload-time = "2026-07-16T13:26:17.28Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/0e/775c35d5b23db3f952b4fa932948dd0ecca99a519c15031b6539041b7b56/invenio_stats-7.0.0-py2.py3-none-any.whl", hash = "sha256:3066520ed5d882618312ada2675d3c21f941e4af1369d830b4e7c472d228f0e1", size = 51065, upload-time = "2026-06-17T21:47:48.922Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3e/5e1c602b0884eee59cbb8b81615153035bfd6046c2533d3aec5f0dbe0b95/invenio_stats-7.0.1-py3-none-any.whl", hash = "sha256:b4ab8d42992bdcfcbb45b3138676f0497161509e656d5cd9f3d4cc8d987514c5", size = 48774, upload-time = "2026-07-16T13:26:16.3Z" },
 ]
 
 [[package]]
@@ -1980,15 +1977,15 @@ wheels = [
 
 [[package]]
 name = "invenio-userprofiles"
-version = "7.0.0"
+version = "7.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "invenio-accounts" },
     { name = "invenio-i18n" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/65/8fa6da49964f2880723794e552fbc926b027e59b0364dd16397c22ce6e87/invenio_userprofiles-7.0.0.tar.gz", hash = "sha256:3f380efd5f2d4aaf088d6fe019e4cbb5beb09b0cbfb43e0423e2924d8b4c3f0a", size = 48969, upload-time = "2026-06-17T21:39:51.469Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/7e/75591c25ed74ce3b4594b476b61ac3c03dda39e4fbbaab82d6c723550dcf/invenio_userprofiles-7.0.1.tar.gz", hash = "sha256:97aae7e2fa466dfd607a4ed228e3ecea308c3acdcfa949349def32081cfdfc0c", size = 28527, upload-time = "2026-07-16T13:24:03.567Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/0b/fdfc080de108161ab26750457b1d42cfb855ff8bae9f0f48aacc4f0740ea/invenio_userprofiles-7.0.0-py2.py3-none-any.whl", hash = "sha256:bdd5ac4b1bf703f4d9a0e27a6ef85d7fcd53df0a2c0cafb0e74dbc96c3cd6c27", size = 123186, upload-time = "2026-06-17T21:39:50.474Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/23/62f5f22ccb2c7ea54e3097a02d9018d39e38f53c17aec13100d812ab43dc/invenio_userprofiles-7.0.1-py3-none-any.whl", hash = "sha256:fab9217dfb00231784046f0b5019119552b1444c8485af0bab7941aaacf612a5", size = 81203, upload-time = "2026-07-16T13:24:02.558Z" },
 ]
 
 [[package]]
@@ -2036,11 +2033,11 @@ wheels = [
 
 [[package]]
 name = "isbnlib2"
-version = "3.11.19"
+version = "3.11.20"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d4/9d/18f104b965db7ee0ac5543d2c6c39cd44b6f4f016484cd57a0b56c1f15c5/isbnlib2-3.11.19.tar.gz", hash = "sha256:37c2833b6feb6b05abfc028134149dffc813def244cd1bdc251ab3a3fabe08dd", size = 56888, upload-time = "2026-06-14T11:13:59.807Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/8c/2b64e22100cd18642450f909c6a9ee43abba5141be958f2e6e0c6dc0810f/isbnlib2-3.11.20.tar.gz", hash = "sha256:cafe3f1116cd78374d463d5323d06b58b98ab624b26c19b2dab202a23116b35c", size = 56938, upload-time = "2026-07-20T11:01:48.828Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/af/bce0a35779136f2301e8442e62094890da8d36504d0ab71b370bfc3631ac/isbnlib2-3.11.19-py3-none-any.whl", hash = "sha256:fec59123b56c4b71ff70ccdfa898a3df2c38618642b2d73650318a7a0b565ec1", size = 67860, upload-time = "2026-06-14T11:13:58.185Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f3/72889557fb99d3b091aa53a515750262eaf230a26de342539433745214b0/isbnlib2-3.11.20-py3-none-any.whl", hash = "sha256:54a8dac35c6c1f520d57b3d8413a5b3a711e36fe021001f0926d7eb7b2e14e4b", size = 67889, upload-time = "2026-07-20T11:01:47.462Z" },
 ]
 
 [[package]]
@@ -2132,16 +2129,16 @@ wheels = [
 
 [[package]]
 name = "jsonresolver"
-version = "0.5.1"
+version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonschema-specifications" },
     { name = "pluggy" },
     { name = "werkzeug" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/c2/5d7ee99eaf8cb1f2b97ef295332921a8dd3903f0eafb15559e04312bc200/jsonresolver-0.5.1.tar.gz", hash = "sha256:dc48f19f3e329af6d30a696c53fb087edf95d97c4615bccd27f517e683503864", size = 13788, upload-time = "2026-03-20T07:27:53.892Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/51/e352275d8f44074ca1d395cb5ebebbf0a85f2ac62bf1de9fd27ccfddbe7e/jsonresolver-0.5.2.tar.gz", hash = "sha256:f98791c636702f6f8ffb644b242103cc2b943b25d56c319a83cf6368ec8dfaa8", size = 8090, upload-time = "2026-07-16T13:08:22.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/57/45bde3c362518fd3a8078a32d704edeb94a61ad814302a246b351016f492/jsonresolver-0.5.1-py2.py3-none-any.whl", hash = "sha256:5736bca6678cde4ef501c09a9b7754467d11863bab89af6d2cee45adc49f689d", size = 13634, upload-time = "2026-03-20T07:27:52.682Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/32/bb67a0598cac4703b27c55379f106266d65f343c406070477d50816971ba/jsonresolver-0.5.2-py3-none-any.whl", hash = "sha256:41d69f88a3d32d3082e22edf2cb225edae79fbb26e04dd4be7ae76ded1673083", size = 11364, upload-time = "2026-07-16T13:08:21.311Z" },
 ]
 
 [[package]]
@@ -2545,11 +2542,11 @@ wheels = [
 
 [[package]]
 name = "mistune"
-version = "3.3.3"
+version = "3.3.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/a5/2dab368d6950e6808904dec98f54c7e726ee7be4a0c6afe00e6e011bd52d/mistune-3.3.3.tar.gz", hash = "sha256:c4c6c0c840b8637a2e9b8b6d607eb7c8f00888bf14c754409bcd339e848c2477", size = 115363, upload-time = "2026-07-09T06:18:05.268Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/92/328a294a6de83bacb95bed01f04e0eaff4e3616ee359fc821a5dfc539b02/mistune-3.3.4.tar.gz", hash = "sha256:58b5c96d6fcb61190dfe5fae498d2b2065f99cf61e9649418fd54cf1ada86dfe", size = 121426, upload-time = "2026-07-22T05:22:30.89Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/70/b1e4737b84163db5bb1dfde6f216dbfbf32783330a9989c965e121172830/mistune-3.3.3-py3-none-any.whl", hash = "sha256:99de1585e42dcbd826faa9e11a202727a5e202e4e4722a4c69ac1ff615793dd7", size = 63569, upload-time = "2026-07-09T06:18:03.839Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e4/288365afae98953bc01de09f686f40d8ee84578135aa7767d5d4e60b5278/mistune-3.3.4-py3-none-any.whl", hash = "sha256:ee015381e955e370962968befe1d729ab60fafb6a715ac6751763fbce38c8d4a", size = 66862, upload-time = "2026-07-22T05:22:29.419Z" },
 ]
 
 [[package]]
@@ -2847,11 +2844,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.10.0"
+version = "4.11.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/9b/560e4be8e26f6fd133a03630a8df0c663b9e8d61b4ade152b72005aec83b/platformdirs-4.11.0.tar.gz", hash = "sha256:0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0", size = 31953, upload-time = "2026-07-21T13:09:36.565Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/68/d8d58938dfb1370b266a1a729e6d77a985be23689a0496498ee17b2cbf90/platformdirs-4.11.0-py3-none-any.whl", hash = "sha256:360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74", size = 23247, upload-time = "2026-07-21T13:09:35.422Z" },
 ]
 
 [[package]]
@@ -2896,14 +2893,14 @@ wheels = [
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.52"
+version = "3.0.53"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ea/39b988c938f75cb75d7045b5c69f8bfed47ee2152c8837fb403de29d6fb8/prompt_toolkit-3.0.53.tar.gz", hash = "sha256:9ec8a0ad96d5c56148b3f914aa79c1564c3fde5d2e6b876e7bc327e353cf8fa6", size = 435492, upload-time = "2026-07-26T20:56:14.758Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/54/6f/84908cad2d6aa5144abcf7b42709fe4fdb459bc640ec7ac5786e7693dabc/prompt_toolkit-3.0.53-py3-none-any.whl", hash = "sha256:01c0891d7f9237d5e339f7d3e42cdae80b7534abb1c7c0e3352efba6231492f2", size = 392288, upload-time = "2026-07-26T20:56:12.512Z" },
 ]
 
 [[package]]
@@ -3693,27 +3690,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.21"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/36/6f65aa9989acdec45d417192d8f4e7921931d8a6cf87ac74bce3eed98a8e/ruff-0.15.21.tar.gz", hash = "sha256:d0cfc841c572283c36548f82664a54ce6565567f1b0d5b4cf2caac693d8b7500", size = 4769401, upload-time = "2026-07-09T20:01:34.005Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/c6/ede15cac6839f3dbce52565c8f5164a8210e669c7bc4decb03e5bdf47d0d/ruff-0.15.21-py3-none-linux_armv6l.whl", hash = "sha256:63ea0e965e5d73c90e95b2434beeafc70820536717f561b32ab6e777cb9bdf5d", size = 10854342, upload-time = "2026-07-09T20:00:53.998Z" },
-    { url = "https://files.pythonhosted.org/packages/28/9d/d825b07ee7ea9e2d61df92a860033c94e06e7300d50a1c2653aac27d24fe/ruff-0.15.21-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0f212c5d7d54c01bbfe6dcab02b724a39300f3e34ed7acbe995ccb320a2c58bd", size = 11139539, upload-time = "2026-07-09T20:00:57.809Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/de/3b107712e642f063c7a9e0887c427b22cb44097de5aab36c05f2e280670c/ruff-0.15.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e6312e41bc96791299614995ea3a977c5857c3b5662b1ecef6755b02b87cb646", size = 10595437, upload-time = "2026-07-09T20:01:00.006Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/6f/b4523cc90ba239ede441447a19d0c968846a3012e5a0b0c5b62831a3d5e3/ruff-0.15.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01d65b4831c6b2a4ba8ee6faa84049d44d982b7a706e622c4094c509e51673be", size = 10990053, upload-time = "2026-07-09T20:01:02.187Z" },
-    { url = "https://files.pythonhosted.org/packages/92/cc/c6a9872a5375f0628875481cf2f66b13d7d865bf3ca2e57f91c7e762d976/ruff-0.15.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c5a913a589120ce67933d5d05fd6ddbcc2481c6a054980ee767f7414c72b4fd", size = 10666096, upload-time = "2026-07-09T20:01:04.299Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/97/c621f7a17e097f1790fa3af6374138823b330b2d03fc38337945daca212c/ruff-0.15.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef04b681d02ad4dc9620f00f83ac5c22f652d0e9a9cfe431d219b16ad5ccc41", size = 11537011, upload-time = "2026-07-09T20:01:06.771Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/51/d928727e476e25ccc57c6f449ffd80241a651a973ad949d39cfb2a771d28/ruff-0.15.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:16d090c0740916594157e75b80d666eab8e78083b39b3b0e1d698f4670a17b86", size = 12347101, upload-time = "2026-07-09T20:01:08.859Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/88/8cd62026802b16018ad06931d87997cf795ba2a6239ab659606c87d96bf0/ruff-0.15.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a10e74757dd65004d779b73e2f3c5210156d9980b41224d50d2ebcf1db51e67", size = 11572001, upload-time = "2026-07-09T20:01:11.092Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/97/f63084cf55444fc110e8cb985ebfcc592af47f597d44453d778cb81bc156/ruff-0.15.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bab0905d2f29e0d9fbc3c373ed23db0095edaa3f71f1f4f519ec15134d9e85c8", size = 11549239, upload-time = "2026-07-09T20:01:13.27Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/77/f107da4a2874b7715914b03f09ba9c54424de3ff8a1cc5d015d3ee2ce0ac/ruff-0.15.21-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:00eca240af5789fec6fe7df74c088cc1f9644ed83027113468efba7c92b94075", size = 11535340, upload-time = "2026-07-09T20:01:15.206Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/e9/601deb322d3303a7bf212b0100ead6f2ee3f6a044d89c30f2f92bf83c731/ruff-0.15.21-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:262ab31557a75141325e32d3357f3597645a7f084e732b6b054dde428ecd9341", size = 10964048, upload-time = "2026-07-09T20:01:17.723Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/2e/0f2176d1e99c15192caea19c8c3a0a955246b4cb4de795042eeb616345cd/ruff-0.15.21-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:659c4e7a4212f83306045ec7c5e5a356d16d9a6ef4ae0c7a4d872914fc655d9d", size = 10667055, upload-time = "2026-07-09T20:01:19.73Z" },
-    { url = "https://files.pythonhosted.org/packages/48/60/abd74a02e0c4214f12a68becfd30af7165cfdcb0e661ecdc60bbb949c09a/ruff-0.15.21-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9e866eab611a5f959d36df2d10e446973a3610bc42b0c15b31dc27977d59c233", size = 11242043, upload-time = "2026-07-09T20:01:21.947Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/c6/583075d8ccabb4b229345edcaf1545eb3d8d6be90f686a479d7e94088bbf/ruff-0.15.21-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e89bc93c0d3803ba870b55c29671bad9dc6d94bb1eb181b056b52eb05b52854f", size = 11648064, upload-time = "2026-07-09T20:01:24.023Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/3c/37d0ecb729a7cc2d393ea7dce316fc585680f35d93b8d62139d7d0a3700c/ruff-0.15.21-py3-none-win32.whl", hash = "sha256:01f8d5be84823c172b389e123174f781f9daf86d6c58719d603f941932195cdd", size = 10896555, upload-time = "2026-07-09T20:01:26.941Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/b8/e43466b2a6067ce91e669068f6e28d6c719a920f014b070d5c8731725de3/ruff-0.15.21-py3-none-win_amd64.whl", hash = "sha256:d4b8d9a2f0f12b816b50447f6eccb9f4bb01a6b82c86b50fb3b5354b458dc6d3", size = 12038772, upload-time = "2026-07-09T20:01:29.497Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/75/e90ab9aeece218a9fc5a5bc3ec97d0ee6bb3c4ff95869463c1de58e29a1c/ruff-0.15.21-py3-none-win_arm64.whl", hash = "sha256:6e83115d4b9377c1cbc13abf0e051f069fab0ef815ea0504a8a008cee24dd0a8", size = 11375265, upload-time = "2026-07-09T20:01:31.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
 ]
 
 [[package]]
@@ -3735,15 +3732,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.65.0"
+version = "2.66.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/1f/ed17a390348156ca99fe622b97cd7d2f1969b5f49df89084b0f28e7953e9/sentry_sdk-2.65.0.tar.gz", hash = "sha256:c94dc945d54bad49d4f20448b1e6b217ca2f92f46d05c3e83d41764af685c3d1", size = 932133, upload-time = "2026-07-13T11:33:19.92Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/6f/d59cad0889d15fde85254cf58e701484de3f3f0406003b3197746910b19b/sentry_sdk-2.66.1.tar.gz", hash = "sha256:f882fb08710c5f8bfc603aafa3e901b384009a19cc3f76a572b863392ee81cdc", size = 940543, upload-time = "2026-07-22T12:26:54.553Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/3b/326ad4c03b5da89b5124c8890af66e8119c4d2e10abc0619e0d67d9f7c7f/sentry_sdk-2.65.0-py3-none-any.whl", hash = "sha256:3595169677a808e4d0e1ea6ffb89443459549c7a98392ed71c77c847182ab6bf", size = 503869, upload-time = "2026-07-13T11:33:17.71Z" },
+    { url = "https://files.pythonhosted.org/packages/89/d3/726bd88f0eece09ddf431bea4c9191c18e7a8d070b854eb0014d447712ee/sentry_sdk-2.66.1-py3-none-any.whl", hash = "sha256:86002793161d9a95ef04bdd8d442e9bfece5d989b755f05d6360215094a7aff6", size = 505555, upload-time = "2026-07-22T12:26:52.71Z" },
 ]
 
 [package.optional-dependencies]
@@ -4034,11 +4031,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.4"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/38/e12680bbe6b4f8f3d17adcaf38d26850aa756c85cf4a80e79fc12a018fe8/soupsieve-2.9.1.tar.gz", hash = "sha256:c33e6605bbc71dd628b00c632d58ae607c22bade247e52553928f83bbb75b4ba", size = 122261, upload-time = "2026-07-21T16:57:17.452Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/2c/437fe806897c2d6cfdc3ee43a18da8bf8e568530a4ae9bac781541ca9896/soupsieve-2.9.1-py3-none-any.whl", hash = "sha256:4f4477399246b7a0c720a88ca2454b11cd6bb9ae4c9d170140786e916776c14c", size = 37404, upload-time = "2026-07-21T16:57:16.421Z" },
 ]
 
 [[package]]
@@ -4242,7 +4239,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.26.8"
+version = "0.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -4250,9 +4247,9 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/f7/68adc395201b20b872d68e975386832e8005ffeacedd43a1d837a32815be/typer-0.26.8.tar.gz", hash = "sha256:c244a6bd558886fe3f8780efb6bdd28bb9aff005a94eedebaa5cb32926fe2f7e", size = 202097, upload-time = "2026-06-26T09:22:45.705Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/78/fda3361b56efc27944f24225f6ecd13d96d6fcfe37bd0eb34e2f4c63f9fc/typer-0.27.0.tar.gz", hash = "sha256:629bd12ea5d13a17148125d9a264f949eb171fb3f120f9b04d85873cab054fa5", size = 203430, upload-time = "2026-07-15T19:21:07.007Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/87/b9fd69c92c6102a066e1b86a35243f53e70bd4c709f2a26d9f4fee4f4dc0/typer-0.26.8-py3-none-any.whl", hash = "sha256:3512ca79ac5c11113414b36e80281b872884477722440691c89d1112e321a49c", size = 122564, upload-time = "2026-06-26T09:22:44.72Z" },
+    { url = "https://files.pythonhosted.org/packages/40/03/26a383c9e58c213199d1aad1c3d353cfc22d4444ec6d2c0bf8ad02523843/typer-0.27.0-py3-none-any.whl", hash = "sha256:6f4b27631e47f077871b7dc30e933ec0131c1390fbe0e387ea5574b5bac9ccf1", size = 122716, upload-time = "2026-07-15T19:21:05.553Z" },
 ]
 
 [[package]]
@@ -4316,11 +4313,11 @@ wheels = [
 
 [[package]]
 name = "uritools"
-version = "6.1.2"
+version = "6.1.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/75/b1f0e26e0c080c2febdd3a98a752c9fbcf078778f60fe90ea489dc8226ed/uritools-6.1.2.tar.gz", hash = "sha256:fa60028843a8be651699a1ee2b399066eeaef349224b32a177efa4aeba463f00", size = 24189, upload-time = "2026-05-21T23:11:11.258Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/0d/20d02264b6682f07e92cbf7ee43e5e803670d101a03ef204ba18368c321f/uritools-6.1.3.tar.gz", hash = "sha256:3a498e7e85ef3249343d5710618d641a414da0fbae6d23053ada7976ee83ea5f", size = 23909, upload-time = "2026-07-23T23:17:44.612Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/3f/44a8c5de526ad21bd540015fd44987da69469ea9f51b7c9ac6a8b475a4a8/uritools-6.1.2-py3-none-any.whl", hash = "sha256:5682f8c58e96e379224fd72aec227a45432740c1fa860a06b3024d47c2968601", size = 11991, upload-time = "2026-05-21T23:11:10.002Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/76/e9bb35862bcc5b82218d2c017b1eacdcfeb3ba46ce0c0ca8ffc4db80ddbe/uritools-6.1.3-py3-none-any.whl", hash = "sha256:136f113e76e53f85bf2d9cce0c3d40ceec775d0409e7d6de9b28f046a7d42838", size = 11981, upload-time = "2026-07-23T23:17:43.275Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adapt the configuration and the code to the new ruff default rule selection.

* Drops the `D100`, `D200`, `D205` and `PERF203` ignores, without any violation left in the code base.
* Fixes the violations behind the `D101`, `D103`, `D202`, `D400`, `F403`, `F405` and `F841` ignores and drops them as well.
* Scopes `N815` to the marshmallow and serializer schemas, which mirror the camelCase fields of the JSON schemas.
* Keeps `BLE001`, `D401`, `DTZ`, `RUF012` and `TRY002` ignored, as they cover deliberate patterns, and documents the reason of each ignore.
* Removes dead variables in the DNB service, the documents serializer, the documents permissions and the suggestions REST module.
* Replaces the star import of the utils tests by explicit imports.
* Raises `TypeError` for an invalid argument type and catches only the netaddr errors in `is_ip_in_list()` and `get_ips_list()`.
* Raises `RuntimeError` in the view generating an error for test purposes.
* Renames the loop variables shadowing a fixture or an argument in the stats permissions tests and in the fixtures CLI.

Updated dependencies (54 packages).