### PR TITLE
fix(api): avoid TemplateNotFound errors on the security API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,9 @@ documents = "sonar.modules.documents:Documents"
 organisations = "sonar.modules.organisations:Organisations"
 invenio_i18n = "invenio_i18n:InvenioI18N"
 
+[project.entry-points."invenio_base.api_finalize_app"]
+sonar = "sonar.ext:api_finalize_app"
+
 [project.entry-points."invenio_base.converters"]
 org_code = "sonar.route_converters:OrganisationCodeConverter"
 

--- a/sonar/ext.py
+++ b/sonar/ext.py
@@ -6,7 +6,7 @@
 import os
 
 import jinja2
-from flask import current_app, render_template, request
+from flask import abort, current_app, render_template, request
 from flask_bootstrap import Bootstrap4
 from flask_principal import RoleNeed, identity_loaded
 from flask_security import current_user, user_registered
@@ -255,3 +255,31 @@ class SonarAPI(SonarBase):
             """
             if request.args.get("format"):
                 request.accept_mimetypes = MIMEAccept([(request.args["format"], 1)])
+
+
+def api_finalize_app(app):
+    """Finalize the API application.
+
+    The Flask-Security blueprint is registered on the API application (see
+    ``ACCOUNTS_REGISTER_BLUEPRINT``) to let ``url_for_security`` build links
+    pointing to the UI application. Its views rendering a template cannot work
+    here, as the SONAR templates are only registered on the UI application, so
+    they are disabled. Their REST counterparts are provided by
+    ``invenio-accounts``.
+
+    :param app: The Flask application.
+    """
+
+    def view_not_found(*args, **kwargs):
+        """Abort with a not found error."""
+        abort(404)
+
+    for endpoint in [
+        "security.change_password",
+        "security.forgot_password",
+        "security.login",
+        "security.register",
+        "security.reset_password",
+        "security.send_confirmation",
+    ]:
+        app.view_functions[endpoint] = view_not_found

--- a/tests/api/test_ext_security_views.py
+++ b/tests/api/test_ext_security_views.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Test Flask-Security views on the API application."""
+
+import pytest
+from flask import url_for
+from flask_security import url_for_security
+
+
+@pytest.mark.parametrize(
+    "endpoint, kwargs",
+    [
+        ("security.change_password", {}),
+        ("security.forgot_password", {}),
+        ("security.login", {}),
+        ("security.register", {}),
+        ("security.reset_password", {"token": "token"}),
+        ("security.send_confirmation", {}),
+    ],
+)
+def test_security_ui_views_disabled(client, endpoint, kwargs):
+    """Test that views rendering a template are not served by the API."""
+    res = client.get(url_for(endpoint, **kwargs))
+    assert res.status_code == 404
+
+
+def test_security_ui_views_url_still_available(app):
+    """Test that links to the UI application can still be generated."""
+    assert url_for_security("reset_password", token="token")
+
+
+def test_security_logout_view_available(client):
+    """Test that logout is still served, as it does not render a template."""
+    res = client.get(url_for_security("logout"))
+    assert res.status_code == 302


### PR DESCRIPTION
The Flask-Security blueprint is registered on the API application (ACCOUNTS_REGISTER_BLUEPRINT) so that `url_for_security` can build the reset password links sent by email. Its views render SONAR templates, which are only registered on the UI application, so requesting them through `/api` raised a `TemplateNotFound` error (500), e.g. on `/api/login/`.

* Aborts with a 404 on the six views rendering a template, in a new API finalize hook, keeping the URL rules registered for `url_for_security`.
* Leaves `security.logout` and `security.confirm_email` untouched, as they only redirect.