### PR TITLE
fix(stat-events): ignore forged IP addresses

### DIFF
--- a/sonar/config.py
+++ b/sonar/config.py
@@ -879,6 +879,8 @@ STATS_EVENTS = {
         "params": {
             "preprocessors": [
                 "invenio_stats.processors:flag_robots",
+                # An event with a forged IP address is not a real visit
+                "sonar.stats_event_builders:flag_invalid_ip_as_robot",
                 # Don't index robot events
                 lambda doc: doc if not doc["is_robot"] else None,
                 "invenio_stats.processors:flag_machines",
@@ -899,6 +901,8 @@ STATS_EVENTS = {
         "params": {
             "preprocessors": [
                 "invenio_stats.processors:flag_robots",
+                # An event with a forged IP address is not a real visit
+                "sonar.stats_event_builders:flag_invalid_ip_as_robot",
                 # Don't index robot events
                 lambda doc: doc if not doc["is_robot"] else None,
                 "invenio_stats.processors:flag_machines",

--- a/sonar/stats_event_builders.py
+++ b/sonar/stats_event_builders.py
@@ -4,6 +4,7 @@
 """Inveio stats signal receivers for record-view events."""
 
 from datetime import UTC, datetime
+from ipaddress import ip_address
 
 from flask import request
 from invenio_stats.utils import format_datetime_iso, get_user
@@ -29,3 +30,20 @@ def record_view_event_builder(event, sender_app, pid=None, record=None, **kwargs
         }
     )
     return event
+
+
+def flag_invalid_ip_as_robot(doc):
+    """Flag an event as a robot event when its IP address is not a valid IP.
+
+    The address comes from the `X-Forwarded-For` header, so an unparsable value
+    means that the client forged the header, which is not a real visit.
+
+    :param doc: The event to process.
+    :returns: The event, flagged as a robot if its IP address is invalid.
+    """
+    if ip := doc.get("ip_address"):
+        try:
+            ip_address(ip)
+        except ValueError:
+            doc["is_robot"] = True
+    return doc

--- a/tests/unit/test_stats_event_builders.py
+++ b/tests/unit/test_stats_event_builders.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Test stats event builders."""
+
+from sonar.stats_event_builders import flag_invalid_ip_as_robot
+
+
+def test_flag_invalid_ip_as_robot():
+    """Test that an event with a forged IP address is flagged as a robot."""
+    assert flag_invalid_ip_as_robot({"ip_address": "'", "is_robot": False})["is_robot"]
+    assert not flag_invalid_ip_as_robot({"ip_address": "93.184.216.34", "is_robot": False})["is_robot"]


### PR DESCRIPTION
Avoid `ValueError` in monitoring when crawlers, bots, etc. use an invalid IP address.

Addresses Sentry issue SONAR-QC.