### PR TITLE
fix: remove the error generation route

### DIFF
--- a/sonar/theme/views.py
+++ b/sonar/theme/views.py
@@ -105,12 +105,6 @@ def profile(pid=None):
     return render_template("sonar/accounts/profile.html")
 
 
-@blueprint.route("/error")
-def error():
-    """Error to generate exception for test purposes."""
-    raise RuntimeError("this is an error for test purposes")
-
-
 @blueprint.route("/manage/")
 @blueprint.route("/manage/<path:path>")
 @can_access_manage_view

--- a/tests/ui/test_views.py
+++ b/tests/ui/test_views.py
@@ -6,18 +6,11 @@
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
-import pytest
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session, login_user_via_view
 
 from sonar.help.views import process_link
 from sonar.theme.views import format_date, record_image_url
-
-
-def test_error(client):
-    """Test error page."""
-    with pytest.raises(RuntimeError):
-        assert client.get(url_for("sonar.error"))
 
 
 def test_robots_txt(app):


### PR DESCRIPTION
The `/error` route raised an exception on purpose to check the Sentry reporting. This creates noise in Sentry. Sentry can be verified from a shell on the instance when needed.