### PR TITLE
fix(projects): avoid KeyError in HEP-VS CSV export

### DIFF
--- a/sonar/dedicated/hepvs/projects/serializers/csv.py
+++ b/sonar/dedicated/hepvs/projects/serializers/csv.py
@@ -74,7 +74,9 @@ class CSVSerializer(CSVSerializerMixin):
             :param actor: Actor dictionary.
             :returns: String representation of the actor.
             """
-            text = actor["choice"] if actor["choice"] != "Other" else actor["other"]
+            text = actor["choice"]
+            if text == "Other":
+                text = actor.get("other", text)
             if actor.get("count"):
                 text = f"{text} ({actor['count']})"
             return text
@@ -85,14 +87,14 @@ class CSVSerializer(CSVSerializerMixin):
 
         # External partners
         if data.get("externalPartners"):
-            if not data["externalPartners"]["choice"]:
+            if not data["externalPartners"].get("choice"):
                 data.pop("externalPartners")
             else:
                 data["externalPartners"] = self.list_separator.join(
                     list(
                         map(
                             transform_external_partners,
-                            data["externalPartners"]["list"],
+                            data["externalPartners"].get("list", []),
                         )
                     )
                 )
@@ -105,10 +107,10 @@ class CSVSerializer(CSVSerializerMixin):
 
         # Educational document
         if data.get("educationalDocument"):
-            if not data["educationalDocument"]["choice"]:
+            if not data["educationalDocument"].get("choice"):
                 data.pop("educationalDocument")
             else:
-                data["educationalDocument"] = data["educationalDocument"]["briefDescription"]
+                data["educationalDocument"] = data["educationalDocument"].get("briefDescription", "")
 
         # Funder
         if not data.get("funding", {}).get("choice"):
@@ -120,7 +122,7 @@ class CSVSerializer(CSVSerializerMixin):
 
         # Promote innovation
         if data.get("promoteInnovation"):
-            if not data["promoteInnovation"]["choice"]:
+            if not data["promoteInnovation"].get("choice"):
                 data.pop("promoteInnovation")
             else:
-                data["promoteInnovation"] = data["promoteInnovation"]["reason"]
+                data["promoteInnovation"] = data["promoteInnovation"].get("reason", "")

--- a/tests/unit/dedicated/hepvs/test_dedicated_projects_hepvs.py
+++ b/tests/unit/dedicated/hepvs/test_dedicated_projects_hepvs.py
@@ -6,6 +6,7 @@
 from invenio_accounts.testutils import login_user_via_view
 
 from sonar.dedicated.hepvs.projects.schema import RecordSchema
+from sonar.dedicated.hepvs.projects.serializers.csv import CSVSerializer
 from sonar.proxies import sonar
 from sonar.resources.projects.api import Record
 from sonar.theme.views import schemas
@@ -46,3 +47,22 @@ def test_api(client, make_user):
     # Access the field class directly from Record class to test _get_schema
     schema_field = Record.schema
     assert schema_field._get_schema(record_data) == "https://sonar.ch/schemas/hepvs/projects/project-v1.0.0.json"
+
+
+def test_csv_format_row_without_conditional_fields():
+    """Test CSV row formatting when conditional sub-fields are not stored."""
+    data = {
+        "externalPartners": {"choice": True},
+        "educationalDocument": {"choice": True},
+        "promoteInnovation": {"choice": True},
+        "actorsInvolved": [{"choice": "Other", "count": 2}],
+    }
+
+    CSVSerializer().format_row(data)
+
+    assert data == {
+        "externalPartners": "",
+        "educationalDocument": "",
+        "promoteInnovation": "",
+        "actorsInvolved": "Other (2)",
+    }


### PR DESCRIPTION
Conditional sub-fields (externalPartners.list, educationalDocument. briefDescription, promoteInnovation.reason, actorsInvolved.other) are only enforced by the Angular form, not by the JSON schema. A record storing `choice` without its sub-field broke the whole CSV export.