### PR TITLE
fix(api): unregister the Flask-Security views from the API

### DIFF
--- a/sonar/config.py
+++ b/sonar/config.py
@@ -121,8 +121,6 @@ ACCOUNTS_SESSION_REDIS_URL = "redis://localhost:6379/1"
 #: proxies) removes these headers again before sending the response to the
 #: client. Set to False, in case of doubt.
 ACCOUNTS_USERINFO_HEADERS = True
-# make security blueprints available to the REST API
-ACCOUNTS_REGISTER_BLUEPRINT = True
 
 # Celery configuration
 # ====================

--- a/sonar/modules/users/templates/users/email/welcome/en.html
+++ b/sonar/modules/users/templates/users/email/welcome/en.html
@@ -3,7 +3,7 @@
 
 <p>Dear {{ user.first_name }},</p>
 <p>An account has been created for you on {{ platform_name }}.</p>
-<p>To access it, please <a href="{{ reset_link.replace('/api', '') }}">reset your password.</a></p>
+<p>To access it, please <a href="{{ reset_link }}">reset your password.</a></p>
 <p>Your login e-mail: {{ user.email }}</p>
 {% if user.is_submitter %}
 <p>You will then be able to:</p>

--- a/sonar/modules/users/utils.py
+++ b/sonar/modules/users/utils.py
@@ -3,9 +3,10 @@
 
 """Utils functions for user module."""
 
+from urllib.parse import urlencode
+
 from flask_babel import _
-from flask_security import url_for_security
-from flask_security.recoverable import generate_reset_password_token
+from invenio_accounts.utils import default_reset_password_link_func
 
 from sonar.modules.organisations.utils import platform_name
 from sonar.modules.utils import send_email
@@ -24,8 +25,10 @@ def send_welcome_email(user_record, user):
     if pname:
         plain_platform_name = pname
 
-    token = generate_reset_password_token(user)
-    reset_link = url_for_security("reset_password", token=token, next=f"/{code}", _external=True)
+    # The link points to the UI application, as the Flask-Security views are
+    # not registered on the API application.
+    _token, reset_link = default_reset_password_link_func(user)
+    reset_link = f"{reset_link}?{urlencode({'next': f'/{code}'})}"
 
     send_email(
         [user_record["email"]],

--- a/sonar/templates/security/email/reset_instructions.html
+++ b/sonar/templates/security/email/reset_instructions.html
@@ -8,7 +8,7 @@
 {%- endif %}
 <p>{{ _('Someone requested that the password for your SONAR account be reset.') }}</p>
 <p>
-  <a href="{{ reset_link.replace('/api', '') }}">{{ _('Reset my password') }}</a>
+  <a href="{{ reset_link }}">{{ _('Reset my password') }}</a>
 </p>
 <p>{{ _('If you didn\'t request this, you can ignore this e-mail. Your password won\'t change until you create a new
   password.') }}</p>

--- a/sonar/templates/security/email/reset_instructions.txt
+++ b/sonar/templates/security/email/reset_instructions.txt
@@ -6,7 +6,7 @@
 
 {{ _('Someone requested that the password for your SONAR account be reset.') }}
 
-{{ _('Reset my password') }}: {{ reset_link.replace('/api', '') }}
+{{ _('Reset my password') }}: {{ reset_link }}
 
 {{ _('If you didn\'t request this, you can ignore this e-mail. Your password won\'t change until you create a new
   password.') }}

--- a/tests/api/collections/test_collections_files_permissions.py
+++ b/tests/api/collections/test_collections_files_permissions.py
@@ -4,7 +4,6 @@
 """Test collections files permissions."""
 
 from flask import url_for
-from flask_security import url_for_security
 from invenio_accounts.testutils import login_user_via_session
 
 
@@ -23,7 +22,7 @@ def test_update_delete(client, superuser, admin, moderator, submitter, user, col
         if u:
             login_user_via_session(client, email=u["email"])
         else:
-            client.get(url_for_security("logout"))
+            client.get(url_for("invenio_accounts_rest_auth.logout"))
         with open(pdf_file, "rb") as f:
             res = client.put(url_file_content, input_stream=f)
             assert res.status_code == status
@@ -45,7 +44,7 @@ def test_read_metadata(client, superuser, admin, moderator, submitter, user, col
         if u:
             login_user_via_session(client, email=u["email"])
         else:
-            client.get(url_for_security("logout"))
+            client.get(url_for("invenio_accounts_rest_auth.logout"))
         res = client.get(url_files)
         assert res.status_code == status
 
@@ -63,6 +62,6 @@ def test_read_content(client, superuser, admin, moderator, submitter, user, coll
         if u:
             login_user_via_session(client, email=u["email"])
         else:
-            client.get(url_for_security("logout"))
+            client.get(url_for("invenio_accounts_rest_auth.logout"))
         res = client.get(url_file_content)
         assert res.status_code == status

--- a/tests/api/deposits/test_deposits_files_permissions.py
+++ b/tests/api/deposits/test_deposits_files_permissions.py
@@ -4,7 +4,6 @@
 """Test deposits files permissions."""
 
 from flask import url_for
-from flask_security import url_for_security
 from invenio_accounts.testutils import login_user_via_session
 
 
@@ -23,7 +22,7 @@ def test_update_delete(client, superuser, admin, moderator, submitter, user, dep
         if u:
             login_user_via_session(client, email=u["email"])
         else:
-            client.get(url_for_security("logout"))
+            client.get(url_for("invenio_accounts_rest_auth.logout"))
         with open(pdf_file, "rb") as f:
             res = client.put(url_file_content, input_stream=f)
             assert res.status_code == status
@@ -42,7 +41,7 @@ def test_read_metadata(client, superuser, admin, moderator, submitter, user, dep
         if u:
             login_user_via_session(client, email=u["email"])
         else:
-            client.get(url_for_security("logout"))
+            client.get(url_for("invenio_accounts_rest_auth.logout"))
         res = client.get(url_files)
         assert res.status_code == status
 
@@ -60,6 +59,6 @@ def test_read_content(client, superuser, admin, moderator, submitter, user, depo
         if u:
             login_user_via_session(client, email=u["email"])
         else:
-            client.get(url_for_security("logout"))
+            client.get(url_for("invenio_accounts_rest_auth.logout"))
         res = client.get(url_file_content)
         assert res.status_code == status

--- a/tests/api/deposits/test_deposits_rest.py
+++ b/tests/api/deposits/test_deposits_rest.py
@@ -6,7 +6,7 @@
 import json
 
 from flask import url_for
-from invenio_accounts.testutils import login_user_via_view
+from invenio_accounts.testutils import login_user_via_session
 
 from sonar.modules.deposits.rest import FilesResource
 from sonar.modules.users.api import UserRecord
@@ -122,7 +122,7 @@ def test_publish(client, db, user, moderator, subdivision, deposit):
     response = client.post(url, data={})
     assert response.status_code == 400
 
-    login_user_via_view(client, email=moderator["email"], password="123456")
+    login_user_via_session(client, email=moderator["email"])
 
     # Test the publication by a moderator
     deposit["status"] = "in_progress"
@@ -171,7 +171,7 @@ def test_review(client, db, user, moderator, deposit):
     )
     assert response.status_code == 403
 
-    login_user_via_view(client, email=moderator["email"], password="123456")
+    login_user_via_session(client, email=moderator["email"])
 
     # Valid approval request
     response = client.post(

--- a/tests/api/documents/test_documents_files_permissions.py
+++ b/tests/api/documents/test_documents_files_permissions.py
@@ -6,7 +6,6 @@
 from io import BytesIO
 
 from flask import url_for
-from flask_security import url_for_security
 from invenio_accounts.testutils import login_user_via_session
 
 
@@ -25,7 +24,7 @@ def test_update_delete(client, superuser, admin, moderator, submitter, user, doc
         if u:
             login_user_via_session(client, email=u["email"])
         else:
-            client.get(url_for_security("logout"))
+            client.get(url_for("invenio_accounts_rest_auth.logout"))
         with open(pdf_file, "rb") as f:
             res = client.put(url_file_content, input_stream=f)
             assert res.status_code == status
@@ -44,7 +43,7 @@ def test_read_metadata(client, superuser, admin, moderator, submitter, user, doc
         if u:
             login_user_via_session(client, email=u["email"])
         else:
-            client.get(url_for_security("logout"))
+            client.get(url_for("invenio_accounts_rest_auth.logout"))
         res = client.get(url_files)
         assert res.status_code == status
 
@@ -55,7 +54,7 @@ def test_read_metadata(client, superuser, admin, moderator, submitter, user, doc
         if u:
             login_user_via_session(client, email=u["email"])
         else:
-            client.get(url_for_security("logout"))
+            client.get(url_for("invenio_accounts_rest_auth.logout"))
         res = client.get(url_files)
         assert res.status_code == status
 
@@ -85,7 +84,7 @@ def test_read_content(
         if u:
             login_user_via_session(client, email=u["email"])
         else:
-            client.get(url_for_security("logout"))
+            client.get(url_for("invenio_accounts_rest_auth.logout"))
         res = client.get(url_file_content)
         assert res.status_code == status
     # Masked document
@@ -95,7 +94,7 @@ def test_read_content(
         if u:
             login_user_via_session(client, email=u["email"])
         else:
-            client.get(url_for_security("logout"))
+            client.get(url_for("invenio_accounts_rest_auth.logout"))
         res = client.get(url_file_content)
         assert res.status_code == status
 
@@ -110,7 +109,7 @@ def test_read_content(
         if u:
             login_user_via_session(client, email=u["email"])
         else:
-            client.get(url_for_security("logout"))
+            client.get(url_for("invenio_accounts_rest_auth.logout"))
         res = client.get(url_file_content)
         assert res.status_code == status
 

--- a/tests/api/organisations/test_organisations_files_permissions.py
+++ b/tests/api/organisations/test_organisations_files_permissions.py
@@ -4,7 +4,6 @@
 """Test organisations files permissions."""
 
 from flask import url_for
-from flask_security import url_for_security
 from invenio_accounts.testutils import login_user_via_session
 
 
@@ -23,7 +22,7 @@ def test_update_delete(client, superuser, admin, moderator, submitter, user, org
         if u:
             login_user_via_session(client, email=u["email"])
         else:
-            client.get(url_for_security("logout"))
+            client.get(url_for("invenio_accounts_rest_auth.logout"))
         with open(pdf_file, "rb") as f:
             res = client.put(url_file_content, input_stream=f)
             assert res.status_code == status
@@ -45,7 +44,7 @@ def test_read_metadata(client, superuser, admin, moderator, submitter, user, org
         if u:
             login_user_via_session(client, email=u["email"])
         else:
-            client.get(url_for_security("logout"))
+            client.get(url_for("invenio_accounts_rest_auth.logout"))
         res = client.get(url_files)
         assert res.status_code == status
 
@@ -63,6 +62,6 @@ def test_read_content(client, superuser, admin, moderator, submitter, user, orga
         if u:
             login_user_via_session(client, email=u["email"])
         else:
-            client.get(url_for_security("logout"))
+            client.get(url_for("invenio_accounts_rest_auth.logout"))
         res = client.get(url_file_content)
         assert res.status_code == status

--- a/tests/api/test_security_views.py
+++ b/tests/api/test_security_views.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Test Flask-Security views on the API application."""
+
+
+def test_security_ui_views_not_registered(app):
+    """Test that the Flask-Security views are not registered on the API.
+
+    They render SONAR templates, which are only available on the UI
+    application, so requesting them through `/api` raised a `TemplateNotFound`
+    error.
+    """
+    assert not [rule for rule in app.url_map.iter_rules() if rule.endpoint.startswith("security.")]
+
+
+def test_security_ui_view_not_found(client):
+    """Test that a Flask-Security URL is not served by the API."""
+    res = client.get("/login/")
+    assert res.status_code == 404

--- a/tests/api/users/test_users_utils.py
+++ b/tests/api/users/test_users_utils.py
@@ -8,6 +8,18 @@ from flask_mail import Mail
 from sonar.modules.users.utils import send_welcome_email
 
 
+def test_send_welcome_email_reset_link(app, user):
+    """Test that the reset password link points to the UI application."""
+    account = app.extensions["security"].datastore.find_user(email=user["email"])
+
+    # The API application is mounted on `/api` by the WSGI dispatcher.
+    with app.test_request_context(environ_overrides={"SCRIPT_NAME": "/api"}), Mail().record_messages() as outbox:
+        send_welcome_email(user, account)
+
+    assert 'href="http://localhost/lost-password/' in outbox[0].html
+    assert "next=%2Forg" in outbox[0].html
+
+
 def test_send_welcome_email(app, user, submitter, moderator, admin):
     """Test send welcome email."""
     datastore = app.extensions["security"].datastore


### PR DESCRIPTION
The Flask-Security blueprint was registered on both applications (ACCOUNTS_REGISTER_BLUEPRINT) so that `url_for_security` could build the reset password links sent by email. Its views render SONAR templates, which are only registered on the UI application, so requesting them through `/api` raised a `TemplateNotFound` error (500), e.g. on `/api/login/`. The links themselves had to be patched in the email templates, as they carried the `/api` prefix of the request they were built in.

* Removes `ACCOUNTS_REGISTER_BLUEPRINT` to restore the invenio defaults: the views are registered on the UI application only, and the API application keeps the blueprints needed to render the Flask-Security emails.
* Builds the reset password link with `default_reset_password_link_func`, which points to the UI application through `ACCOUNTS_REST_RESET_PASSWORD_ENDPOINT`, whichever application generates it.
* Removes the `/api` substitution from the email templates.
* Logs out through the REST endpoint in the API tests, as the Flask-Security views are no longer available there.