### PR TITLE
fix(oaipmh): return idDoesNotExist for deleted documents

### DIFF
--- a/sonar/modules/documents/oaipmh_utils.py
+++ b/sonar/modules/documents/oaipmh_utils.py
@@ -4,13 +4,24 @@
 """Invenio OAIPMH server utils."""
 
 from invenio_oaiserver import current_oaiserver
+from invenio_pidstore.errors import PIDDoesNotExistError
+from sqlalchemy.exc import NoResultFound
 
 from .dumpers import IndexerDumper
 
 
 def getrecord_fetcher(record_uuid):
-    """Fetch record data as dict for serialization."""
-    record = current_oaiserver.record_cls.get_record(record_uuid)
+    """Fetch record data as dict for serialization.
+
+    The OAI persistent identifier survives the deletion of its record, so it
+    still resolves and points to a record that cannot be loaded anymore. As the
+    repository declares `deletedRecord=no`, answer with `idDoesNotExist`.
+    """
+    try:
+        record = current_oaiserver.record_cls.get_record(record_uuid)
+    except NoResultFound:
+        raise PIDDoesNotExistError("oai", None) from None
+
     record_dict = record.dumps(IndexerDumper())
     record_dict["updated"] = record.updated
     return record_dict

--- a/tests/ui/documents/test_oaipmh.py
+++ b/tests/ui/documents/test_oaipmh.py
@@ -17,3 +17,13 @@ def test_oaipmh_get(client, org_oaiset, document):
     res = client.get("/oai2d?verb=GetRecord&metadataPrefix=oai_dc&identifier=oai:sonar.ch:1")
     assert res.status_code == 200
     assert "<setSpec>org</setSpec>" in res.text
+
+
+def test_oaipmh_get_deleted_document(client, document):
+    """Test OAIPMH GetRecord on a deleted document."""
+    identifier = f"oai:sonar.ch:{document['pid']}"
+    document.delete(dbcommit=True, delindex=True)
+
+    res = client.get(f"/oai2d?verb=GetRecord&metadataPrefix=oai_dc&identifier={identifier}")
+    assert res.status_code == 422
+    assert '<error code="idDoesNotExist">' in res.text


### PR DESCRIPTION
Resolves Sentry error `SONAR-WS`.