### PR TITLE
fix(views): serve the organisation homepage with a trailing slash

### DIFF
--- a/sonar/ext.py
+++ b/sonar/ext.py
@@ -6,7 +6,7 @@
 import os
 
 import jinja2
-from flask import current_app, render_template, request
+from flask import current_app, redirect, render_template, request, url_for
 from flask_bootstrap import Bootstrap4
 from flask_principal import RoleNeed, identity_loaded
 from flask_security import current_user, user_registered
@@ -228,6 +228,16 @@ class Sonar(SonarBase):
         def index(view):
             """Homepage."""
             return render_template("sonar/frontpage.html", view=view)
+
+        @app.route("/<org_code:view>/")
+        def index_trailing_slash(view):
+            """Redirect to the canonical homepage, without the trailing slash.
+
+            Werkzeug only redirects a URL missing a trailing slash to the rule
+            declaring one, not the other way around, so the trailing slash form
+            has to be handled explicitly.
+            """
+            return redirect(url_for("index", view=view), code=301)
 
 
 class SonarAPI(SonarBase):

--- a/tests/ui/test_views.py
+++ b/tests/ui/test_views.py
@@ -13,6 +13,13 @@ from sonar.help.views import process_link
 from sonar.theme.views import format_date, record_image_url
 
 
+def test_index_trailing_slash(client, organisation):
+    """Test that the homepage with a trailing slash redirects to the canonical URL."""
+    res = client.get(f"/{organisation['code']}/")
+    assert res.status_code == 301
+    assert res.location == url_for("index", view=organisation["code"])
+
+
 def test_robots_txt(app):
     """Test le robots.txt file."""
     with app.test_client() as client:


### PR DESCRIPTION
Werkzeug redirects a URL missing a trailing slash to the rule declaring one, but not the other way around. The organisation homepage rule is declared without it, so `sonar.ch/<code>/` raised a 404 while `sonar.ch/<code>` was served.