### PR TITLE
feat(documents): add citation modal to document detail page

### DIFF
--- a/sonar/modules/documents/static/js/citation.js
+++ b/sonar/modules/documents/static/js/citation.js
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+$(document).ready(function () {
+  const $citationModal = $('#citationModal');
+  if ($citationModal.length === 0) {
+    return;
+  }
+
+  const stylesUrl = $citationModal.data('styles-url');
+  const citationUrl = $citationModal.data('citation-url');
+  const i18n = {
+    loading: $citationModal.data('i18n-loading'),
+    selectStyle: $citationModal.data('i18n-select-style'),
+    errorStyles: $citationModal.data('i18n-error-styles'),
+    errorCitation: $citationModal.data('i18n-error-citation'),
+  };
+
+  const $citationStyles = $('#citation-styles');
+  const $citationText = $('#citation-text');
+  const $citationCopy = $('#citation-copy');
+  const $citationMessage = $('#citation-message');
+  const $citationToast = $('#citation-toast');
+  let citationStylesLoaded = false;
+  let citationStylesLoading = false;
+  let citationRequestId = 0;
+
+  const showCopiedToast = function () {
+    $citationToast.toast('show');
+  };
+
+  const showCitationMessage = function (message) {
+    $citationMessage.text(message).removeClass('d-none alert-danger').addClass('alert-danger');
+  };
+
+  const clearCitationMessage = function () {
+    $citationMessage.addClass('d-none').text('');
+  };
+
+  const loadCitation = function (styleId) {
+    citationRequestId += 1;
+    const requestId = citationRequestId;
+
+    $citationStyles.find('button').removeClass('font-weight-bold');
+    $citationStyles.find('button[data-style="' + styleId + '"]').addClass('font-weight-bold');
+    $citationText.text(i18n.loading);
+    $citationCopy.addClass('d-none');
+
+    fetch(citationUrl + '?style=' + encodeURIComponent(styleId))
+      .then(function (response) {
+        if (!response.ok) {
+          throw new Error('citation request failed');
+        }
+        return response.json();
+      })
+      .then(function (data) {
+        if (requestId !== citationRequestId) {
+          return;
+        }
+        $citationText.html(data.citation);
+        $citationCopy.removeClass('d-none');
+        clearCitationMessage();
+      })
+      .catch(function () {
+        if (requestId !== citationRequestId) {
+          return;
+        }
+        $citationText.text(i18n.selectStyle);
+        showCitationMessage(i18n.errorCitation);
+      });
+  };
+
+  $citationCopy.click(function () {
+    const html = $citationText.html();
+    const text = $citationText.text();
+
+    if (!navigator.clipboard) {
+      return;
+    }
+
+    if (window.ClipboardItem) {
+      const item = new ClipboardItem({
+        'text/plain': new Blob([text], { type: 'text/plain' }),
+        'text/html': new Blob([html], { type: 'text/html' }),
+      });
+      navigator.clipboard
+        .write([item])
+        .then(showCopiedToast)
+        .catch(function () {
+          navigator.clipboard.writeText(text).then(showCopiedToast);
+        });
+    } else {
+      navigator.clipboard.writeText(text).then(showCopiedToast);
+    }
+  });
+
+  $citationModal.on('show.bs.modal', function () {
+    if (citationStylesLoaded || citationStylesLoading) {
+      return;
+    }
+    citationStylesLoading = true;
+
+    fetch(stylesUrl)
+      .then(function (response) {
+        if (!response.ok) {
+          throw new Error('citation styles request failed');
+        }
+        return response.json();
+      })
+      .then(function (styles) {
+        citationStylesLoaded = true;
+        styles.forEach(function (style) {
+          const $li = $('<li>');
+          const $button = $(
+            '<button type="button" class="btn btn-link p-0 d-block text-left" data-style="' + style.id + '">' + style.label + '</button>'
+          );
+          $button.click(function () {
+            loadCitation(style.id);
+          });
+          $li.append($button);
+          $citationStyles.append($li);
+        });
+      })
+      .catch(function () {
+        showCitationMessage(i18n.errorStyles);
+      })
+      .finally(function () {
+        citationStylesLoading = false;
+      });
+  });
+});

--- a/sonar/modules/documents/templates/documents/_citation.html
+++ b/sonar/modules/documents/templates/documents/_citation.html
@@ -1,0 +1,64 @@
+{# SPDX-FileCopyrightText: Fondation RERO+ #}
+{# SPDX-License-Identifier: AGPL-3.0-or-later #}
+
+<button type="button" class="btn btn-outline-secondary btn-sm" data-toggle="modal" data-target="#citationModal">
+  <i class="fa-solid fa-quote-right mr-1"></i> {{ _('Cite') }}
+</button>
+
+<!-- Citation modal -->
+<div
+  class="modal fade"
+  id="citationModal"
+  tabindex="-1"
+  role="dialog"
+  aria-hidden="true"
+  aria-labelledby="citationModalLabel"
+  data-pid="{{ record.pid }}"
+  data-styles-url="/api/documents/citation-styles"
+  data-citation-url="/api/documents/{{ record.pid }}/citation"
+  data-i18n-loading="{{ _('Loading…') }}"
+  data-i18n-select-style="{{ _('Select a style on the left') }}"
+  data-i18n-error-styles="{{ _('An error occurred while loading citation styles') }}"
+  data-i18n-error-citation="{{ _('An error occurred while loading the citation') }}"
+>
+  <div class="modal-dialog modal-lg" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="citationModalLabel">{{ _('Citation') }}</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{ _('Close') }}">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <div id="citation-message" class="alert d-none" role="alert"></div>
+        <div class="row">
+          <div class="col-4">
+            <ul id="citation-styles" class="list-unstyled mb-0 text-left"></ul>
+          </div>
+          <div class="col-8 border-left d-flex flex-column">
+            <div id="citation-text" class="flex-grow-1 text-left">{{ _('Select a style on the left') }}</div>
+            <button type="button" id="citation-copy" class="btn btn-outline-secondary btn-sm align-self-start mt-2 d-none">
+              <i class="fa-solid fa-clipboard mr-1"></i> {{ _('Copy to the clipboard') }}
+            </button>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <strong>{{ _('Be sure to check the citation before using it') }}</strong>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div aria-live="polite" aria-atomic="true" style="position: relative;">
+  <div class="toast text-white bg-success" id="citation-toast" style="position: fixed; top: 1rem; right: 1rem; z-index: 1080;" role="status" data-delay="3000">
+    <div class="toast-header text-white bg-success">
+      <i class="fa-solid fa-check mr-2"></i>
+      <strong class="mr-auto">{{ _('Citation') }}</strong>
+      <button type="button" class="ml-2 mb-1 close text-white" data-dismiss="toast" aria-label="{{ _('Close') }}">
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </div>
+    <div class="toast-body">{{ _('The text has been copied to the clipboard') }}</div>
+  </div>
+</div>

--- a/sonar/modules/documents/templates/documents/record.html
+++ b/sonar/modules/documents/templates/documents/record.html
@@ -45,7 +45,7 @@
   <div class="row">
     <div class="col-lg-3 text-center">
       {% if files and files | length > 0 %}
-      <div class="mb-4">
+      <div class="mb-3">
         {{ thumbnail(record, first_file,
         stats['file-download'][first_file['key']]['count'] or 0) }}
       </div>
@@ -55,8 +55,13 @@
 
       <!-- DOCUMENT TYPE -->
       {% if record.documentType %}
-      <h5 class="my-4">{{ _('document_type_' + record.documentType) }}</h5>
+      <h5 class="my-3">{{ _('document_type_' + record.documentType) }}</h5>
       {% endif %}
+
+      <!-- Citation -->
+      <div class="mb-3">
+        {% include 'documents/_citation.html' %}
+      </div>
 
       {% if files and files | length > 1 %}
       <p>
@@ -558,4 +563,5 @@
     });
   });
 </script>
+<script src="/static/js/citation.js"></script>
 {% endblock javascript %}

--- a/sonar/theme/assets/scss/common/_theme.scss
+++ b/sonar/theme/assets/scss/common/_theme.scss
@@ -35,3 +35,14 @@ div.wiki-page div.sticky-top {
 .export-item {
   width: 110px;
 }
+
+// Only show the focus ring for keyboard navigation, not on a mouse click.
+.btn:focus:not(:focus-visible),
+.btn.focus:not(:focus-visible),
+.btn:active:not(:focus-visible) {
+  outline: 0 !important;
+  outline-style: none !important;
+  outline-width: 0 !important;
+  box-shadow: none !important;
+  -moz-outline-style: none !important;
+}

--- a/tests/ui/documents/test_documents_views.py
+++ b/tests/ui/documents/test_documents_views.py
@@ -162,6 +162,12 @@ def test_detail(app, client, organisation, document_with_file):
 
     assert res.status_code == 200
 
+    # Citation button and modal
+    assert soup.find(id="citationModal")
+    assert soup.find("button", attrs={"data-target": "#citationModal"})
+    assert soup.find(id="citation-styles")
+    assert soup.find(id="citation-toast")
+
     assert client.get(url_for("invenio_records_ui.doc", view="global", pid_value="not-existing")).status_code == 404
 
 


### PR DESCRIPTION
* Add a "Cite" button below the document image, opening a Bootstrap
  modal listing all supported citation styles (from GET
  /documents/citation-styles) and rendering the formatted citation
  for the selected style (GET /documents/<pid>/citation?style=<id>).
* Extract the modal's behavior into a standalone citation.js, loaded
  only on the document detail view, reading its config (API URLs,
  translated strings) from data-* attributes since static JS files
  are not processed by Jinja.
* Copy to clipboard writes both text/plain and text/html via
  ClipboardItem, so pasting into a rich text editor keeps the
  citation's formatting, with a writeText() fallback.
* Remove Bootstrap's focus outline/box-shadow on the citation style
  buttons and the copy button in _theme.scss.
* Add test coverage for the citation modal markup in test_detail.