### PR TITLE
fix(suggestions): match partial words in the editor autocomplete fields

### DIFF
--- a/sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0.json
+++ b/sonar/dedicated/hepvs/projects/jsonschemas/hepvs/projects/project-v1.0.0.json
@@ -174,7 +174,7 @@
               "props": {
                 "queryOptions": {
                   "type": "projects",
-                  "field": "metadata.projectSponsor,metadata.innerSearcher",
+                  "field": "metadata.projectSponsor.suggest,metadata.innerSearcher.suggest",
                   "suggest": "/api/suggestions/completion",
                   "allowAdd": true
                 }
@@ -279,7 +279,7 @@
                 "props": {
                   "queryOptions": {
                     "type": "projects",
-                    "field": "metadata.projectSponsor,metadata.innerSearcher",
+                    "field": "metadata.projectSponsor.suggest,metadata.innerSearcher.suggest",
                     "suggest": "/api/suggestions/completion",
                     "allowAdd": true
                   }
@@ -446,7 +446,7 @@
                 "props": {
                   "queryOptions": {
                     "type": "projects",
-                    "field": "metadata.keywords",
+                    "field": "metadata.keywords.suggest",
                     "suggest": "/api/suggestions/completion",
                     "allowAdd": true
                   }

--- a/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0.json
+++ b/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0.json
@@ -800,7 +800,7 @@
                     "props": {
                       "queryOptions": {
                         "type": "collections",
-                        "field": "name.value",
+                        "field": "name.value.suggest",
                         "label": "label"
                       }
                     }
@@ -1059,7 +1059,7 @@
                 "props": {
                   "queryOptions": {
                     "type": "documents",
-                    "field": "customField1",
+                    "field": "customField1.suggest",
                     "suggest": "/api/suggestions/completion",
                     "allowAdd": true
                   }
@@ -1080,7 +1080,7 @@
                 "props": {
                   "queryOptions": {
                     "type": "documents",
-                    "field": "customField2",
+                    "field": "customField2.suggest",
                     "suggest": "/api/suggestions/completion",
                     "allowAdd": true
                   }
@@ -1101,7 +1101,7 @@
                 "props": {
                   "queryOptions": {
                     "type": "documents",
-                    "field": "customField3",
+                    "field": "customField3.suggest",
                     "suggest": "/api/suggestions/completion",
                     "allowAdd": true
                   }
@@ -1195,7 +1195,7 @@
                 "props": {
                     "queryOptions": {
                       "type": "documents",
-                      "field": "contribution.agent.preferred_name",
+                      "field": "contribution.agent.preferred_name.suggest",
                       "suggest": "/api/suggestions/completion",
                       "allowAdd": true
                     }
@@ -1303,7 +1303,7 @@
                     "props": {
                       "queryOptions": {
                         "type": "projects",
-                        "field": "metadata.name",
+                        "field": "metadata.name.suggest",
                         "label": "name"
                       }
                     }
@@ -1418,7 +1418,7 @@
                     "props": {
                       "queryOptions": {
                         "type": "subdivisions",
-                        "field": "name.value",
+                        "field": "name.value.suggest",
                         "label": "label"
                       }
                     }

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0.json
@@ -1204,7 +1204,7 @@
                 "props": {
                   "queryOptions": {
                     "type": "collections",
-                    "field": "name.value",
+                    "field": "name.value.suggest",
                     "label": "label"
                   }
                 }
@@ -1451,7 +1451,7 @@
                         "props": {
                             "queryOptions": {
                               "type": "documents",
-                              "field": "contribution.agent.preferred_name",
+                              "field": "contribution.agent.preferred_name.suggest",
                               "suggest": "/api/suggestions/completion",
                               "allowAdd": true
                             }
@@ -1616,7 +1616,7 @@
                         "props": {
                           "queryOptions": {
                             "type": "documents",
-                            "field": "contribution.agent.preferred_name",
+                            "field": "contribution.agent.preferred_name.suggest",
                             "suggest": "/api/suggestions/completion",
                             "allowAdd": true
                           }
@@ -1683,7 +1683,7 @@
                         "props": {
                           "queryOptions": {
                             "type": "documents",
-                            "field": "contribution.agent.preferred_name",
+                            "field": "contribution.agent.preferred_name.suggest",
                             "suggest": "/api/suggestions/completion",
                             "allowAdd": true
                           }
@@ -2168,7 +2168,7 @@
                   "queryOptions": {
                     "type": "projects",
                     "label": "name",
-                    "field": "metadata.name"
+                    "field": "metadata.name.suggest"
                   }
                 }
               }
@@ -2206,7 +2206,7 @@
             "props": {
               "queryOptions": {
                 "type": "documents",
-                "field": "customField1",
+                "field": "customField1.suggest",
                 "suggest": "/api/suggestions/completion",
                 "allowAdd": true
               }
@@ -2235,7 +2235,7 @@
             "props": {
               "queryOptions": {
                 "type": "documents",
-                "field": "customField2",
+                "field": "customField2.suggest",
                 "suggest": "/api/suggestions/completion",
                 "allowAdd": true
               }
@@ -2264,7 +2264,7 @@
             "props": {
               "queryOptions": {
                 "type": "documents",
-                "field": "customField3",
+                "field": "customField3.suggest",
                 "suggest": "/api/suggestions/completion",
                 "allowAdd": true
               }
@@ -2301,7 +2301,7 @@
                 "props": {
                   "queryOptions": {
                     "type": "subdivisions",
-                    "field": "name.value",
+                    "field": "name.value.suggest",
                     "label": "label"
                   }
                 }

--- a/sonar/modules/documents/mappings/v7/documents/document-v1.0.0.json
+++ b/sonar/modules/documents/mappings/v7/documents/document-v1.0.0.json
@@ -404,6 +404,11 @@
                 "fields": {
                   "raw": {
                     "type": "keyword"
+                  },
+                  "suggest": {
+                    "type": "text",
+                    "analyzer": "autocomplete",
+                    "search_analyzer": "standard"
                   }
                 }
               },
@@ -567,6 +572,11 @@
         "fields": {
           "raw": {
             "type": "keyword"
+          },
+          "suggest": {
+            "type": "text",
+            "analyzer": "autocomplete",
+            "search_analyzer": "standard"
           }
         }
       },
@@ -575,6 +585,11 @@
         "fields": {
           "raw": {
             "type": "keyword"
+          },
+          "suggest": {
+            "type": "text",
+            "analyzer": "autocomplete",
+            "search_analyzer": "standard"
           }
         }
       },
@@ -583,6 +598,11 @@
         "fields": {
           "raw": {
             "type": "keyword"
+          },
+          "suggest": {
+            "type": "text",
+            "analyzer": "autocomplete",
+            "search_analyzer": "standard"
           }
         }
       },

--- a/sonar/modules/users/jsonschemas/users/user-v1.0.0.json
+++ b/sonar/modules/users/jsonschemas/users/user-v1.0.0.json
@@ -170,7 +170,7 @@
               "props": {
                 "queryOptions": {
                   "type": "subdivisions",
-                  "field": "name.value",
+                  "field": "name.value.suggest",
                   "label": "label"
                 }
               }

--- a/sonar/resources/projects/mappings/v7/projects/project-v1.0.0.json
+++ b/sonar/resources/projects/mappings/v7/projects/project-v1.0.0.json
@@ -134,13 +134,34 @@
             }
           },
           "projectSponsor": {
-            "type": "text"
+            "type": "text",
+            "fields": {
+              "suggest": {
+                "type": "text",
+                "analyzer": "autocomplete",
+                "search_analyzer": "standard"
+              }
+            }
           },
           "innerSearcher": {
-            "type": "text"
+            "type": "text",
+            "fields": {
+              "suggest": {
+                "type": "text",
+                "analyzer": "autocomplete",
+                "search_analyzer": "standard"
+              }
+            }
           },
           "keywords": {
-            "type": "text"
+            "type": "text",
+            "fields": {
+              "suggest": {
+                "type": "text",
+                "analyzer": "autocomplete",
+                "search_analyzer": "standard"
+              }
+            }
           },
           "validation": {
             "type": "object",

--- a/sonar/suggestions/rest.py
+++ b/sonar/suggestions/rest.py
@@ -3,6 +3,10 @@
 
 """Suggestions rest views."""
 
+import re
+import unicodedata
+
+from elasticsearch.exceptions import RequestError
 from flask import Blueprint, current_app, jsonify, request
 
 from sonar.modules.organisations.api import current_organisation
@@ -16,6 +20,78 @@ _ORG_FIELDS = {
     "projects": "metadata__organisation__pid",
     "documents": "organisation__pid",
 }
+
+# Sub-field holding the edge n-grams, see the `autocomplete` analyzer in the
+# `record.json` ES template. Queries target it, values are read back from the
+# parent field as sub-fields are not part of the `_source`.
+_SUGGEST_SUFFIX = ".suggest"
+
+# Documents inspected per field, and suggestions finally returned.
+_MAX_HITS = 50
+_MAX_RESULTS = 20
+
+
+def _source_field(field_name):
+    """Return the `_source` path of a queried field.
+
+    :param field_name: queried field, ie. `contribution.agent.preferred_name.suggest`.
+    :returns: the path holding the value, ie. `contribution.agent.preferred_name`.
+    """
+    if field_name.endswith(_SUGGEST_SUFFIX):
+        return field_name[: -len(_SUGGEST_SUFFIX)]
+
+    return field_name
+
+
+def _extract_values(source, parts):
+    """Collect the string values reachable through a field path.
+
+    Lists are walked at any level, as arrays of objects are common in the
+    schemas, ie. `contribution.agent.preferred_name`.
+
+    :param source: portion of the `_source` to walk.
+    :param parts: remaining parts of the field path.
+    :returns: generator over the string values found.
+    """
+    if isinstance(source, list):
+        for item in source:
+            yield from _extract_values(item, parts)
+    elif not parts:
+        if isinstance(source, str):
+            yield source
+    elif isinstance(source, dict):
+        yield from _extract_values(source.get(parts[0]), parts[1:])
+
+
+def _words(value):
+    """Split a value into lowercased words, without diacritics.
+
+    :param value: value to split.
+    :returns: list of words.
+    """
+    decomposed = unicodedata.normalize("NFKD", value.lower())
+    folded = "".join(char for char in decomposed if not unicodedata.combining(char))
+
+    return re.findall(r"\w+", folded)
+
+
+def _matches(value, query):
+    """Check that a value matches the typed query.
+
+    Elasticsearch matches a record as a whole, so a hit carries every value of
+    the field, including those the user did not type. Keep only the values for
+    which each typed word is the prefix of a word.
+
+    Diacritics are ignored, so that a value legitimately matched by Elasticsearch
+    is never discarded here.
+
+    :param value: value to check.
+    :param query: query typed by the user.
+    :returns: True if the value matches the query.
+    """
+    words = _words(value)
+
+    return all(any(word.startswith(term) for word in words) for term in _words(query))
 
 
 @api_blueprint.route("/completion", methods=["GET"])
@@ -56,33 +132,23 @@ def completion():
 
     try:
         # Organisation filter for non-superusers
-        if not has_superuser_access() and current_organisation:
-            org_field = _ORG_FIELDS.get(resource)
-            if org_field:
-                search = search.filter("term", **{org_field: current_organisation["pid"]})
+        if not has_superuser_access() and current_organisation and (org_field := _ORG_FIELDS.get(resource)):
+            search = search.filter("term", **{org_field: current_organisation["pid"]})
 
         for field_name in fields:
-            field_search = search.query("match_phrase_prefix", **{field_name: query}).source(includes=[field_name])[:20]
+            source_field = _source_field(field_name)
+            # Each typed word must be an indexed n-gram, so partial words match
+            # without the term expansion a prefix query would need.
+            field_search = search.query("match", **{field_name: {"query": query, "operator": "and"}})
+            field_search = field_search.source(includes=[source_field])[:_MAX_HITS]
 
             for hit in field_search.execute():
-                value = hit.to_dict()
-                for part in field_name.split("."):
-                    if not isinstance(value, dict):
-                        value = None
-                        break
-                    value = value.get(part)
-                if isinstance(value, str):
-                    results.append(value)
-                elif isinstance(value, list):
-                    results.extend(v for v in value if isinstance(v, str))
+                results.extend(
+                    value for value in _extract_values(hit.to_dict(), source_field.split(".")) if _matches(value, query)
+                )
 
-    except Exception:
+    except RequestError:
         return jsonify({"error": "Bad request"}), 400
 
-    # Remove duplicates
-    results = list(dict.fromkeys(results))
-
-    # Sort items
-    results.sort()
-
-    return jsonify(results)
+    results = sorted(dict.fromkeys(results))
+    return jsonify(results[:_MAX_RESULTS])

--- a/tests/api/suggestions/test_suggestions_rest.py
+++ b/tests/api/suggestions/test_suggestions_rest.py
@@ -111,9 +111,39 @@ def test_completion(client, project_hepvs_json, make_user, user_without_role):
     assert res.status_code == 200
     assert res.json == ["USI Research Project"]
 
-    # Users resource has no organisation filter — query by name prefix
-    current_search.flush_and_refresh(index="users")
-    login_user_via_session(client, email=user_hepvs["email"])
-    res = client.get(url_for("suggestions.completion", q="Hepvs", field="full_name", resource="users"))
+
+def test_completion_array_field(client, document_json, make_document, make_user, search_clear):
+    """Test completion suggestions on a field nested in an array."""
+    document_json["contribution"] = [
+        {
+            "agent": {"type": "bf:Person", "preferred_name": "Dupont, Jean"},
+            "role": ["cre"],
+        },
+        {
+            "agent": {"type": "bf:Person", "preferred_name": "Zimmermann, Ada"},
+            "role": ["cre"],
+        },
+    ]
+    make_document(organisation="org")
+    current_search.flush_and_refresh(index="documents")
+
+    user = make_user("admin", organisation="org")
+    login_user_via_session(client, email=user["email"])
+
+    field = "contribution.agent.preferred_name.suggest"
+
+    # A partial word is enough, the whole word is not required
+    for query in ["D", "Dup", "dupont", "Dupont, Jean"]:
+        res = client.get(url_for("suggestions.completion", q=query, field=field, resource="documents"))
+        assert res.status_code == 200
+        assert res.json == ["Dupont, Jean"]
+
+    # A matching record does not suggest the other values of its field
+    res = client.get(url_for("suggestions.completion", q="Zim", field=field, resource="documents"))
     assert res.status_code == 200
-    assert res.json == ["Hepvsadmin Doe"]
+    assert res.json == ["Zimmermann, Ada"]
+
+    # Unknown value
+    res = client.get(url_for("suggestions.completion", q="Nobody", field=field, resource="documents"))
+    assert res.status_code == 200
+    assert res.json == []


### PR DESCRIPTION
6dfd183c conflated two kinds of `.suggest` sub-field. Dropping the ES completion suggester was right — it ignores `search.filter()`, so the new organisation filter could not work with it — but the same pass also stripped `.suggest` from references to the *edge n-gram* sub-fields, still mapped and serving the search API. Editors were left querying analysed fields, where a term only matches a whole token.

* Restore those 7 references (collections, subdivisions, projects), no reindex needed. Also revives the projects `Read` typeahead branch, which detects autocomplete by `".suggest" in q`: submitters only saw their own projects.
* Add edge n-gram sub-fields for the completion endpoint and query them with `match`. `match_phrase_prefix` expands the last term lexicographically and truncates at `max_expansions`, so short prefixes lose the wanted term; an n-gram is an indexed token, so the lookup is exact and stays filterable.
* Walk lists when reading `_source`: the walk stopped at the first non-dict, so `contribution.agent.preferred_name` — an array — returned nothing at all.
* Keep only the values matching the query; a hit carried every value of its field.
* Test an array-nested field, the existing cases were all scalar. Drop `users.full_name`, unused.

:warning: On migration, `documents` and `projects` should be fully reindexed.