### PR TITLE
feat(deposits): add doc link to email approval

### DIFF
--- a/sonar/modules/deposits/rest.py
+++ b/sonar/modules/deposits/rest.py
@@ -7,17 +7,39 @@ import re
 from datetime import datetime
 from io import BytesIO
 
-from flask import Blueprint, abort, current_app, jsonify, make_response, request
+from flask import Blueprint, abort, current_app, jsonify, make_response, request, url_for
 from flask_babel import _
 from invenio_db import db
 from invenio_rest import ContentNegotiatedMethodView
+from werkzeug.routing import BuildError
 
 from sonar.modules.deposits.api import DepositRecord
 from sonar.modules.pdf_extractor.pdf_extractor import PDFExtractor
 from sonar.modules.pdf_extractor.utils import format_extracted_data
 from sonar.modules.subdivisions.api import Record as SubdivisionRecord
 from sonar.modules.users.api import UserRecord
-from sonar.modules.utils import get_language_value, send_email
+from sonar.modules.utils import get_language_value, get_pid_from_ref_or_data, send_email
+
+
+def _get_published_document_url(deposit, deposit_user):
+    """Build the public URL of the document created from a deposit."""
+    document_pid = DepositRecord.get_pid_by_ref_link(deposit["document"]["$ref"])
+    view = current_app.config.get("SONAR_APP_DEFAULT_ORGANISATION")
+
+    if organisation_data := deposit_user.get("organisation"):
+        view = get_pid_from_ref_or_data(organisation_data) or view
+
+    try:
+        return url_for(
+            "invenio_records_ui.doc",
+            view=view,
+            pid_value=document_pid,
+            _external=True,
+        )
+    except BuildError:
+        # The API application does not register UI endpoints, but serves under
+        # the same public host and uses the UI route configured for documents.
+        return f"{request.host_url.rstrip('/')}/{view}/documents/{document_pid}"
 
 
 class FilesResource(ContentNegotiatedMethodView):
@@ -206,18 +228,22 @@ def review(pid=None):
     # Load user who creates the deposit
     deposit_user = UserRecord.get_record_by_ref_link(deposit["user"]["$ref"])
 
+    email_context = {
+        "deposit": deposit,
+        "deposit_user": deposit_user,
+        "user": user,
+        "date": datetime.now().strftime("%d.%m.%Y %H:%M:%S"),
+        "comment": payload["comment"],
+        "link": current_app.config.get("SONAR_APP_ANGULAR_URL"),
+    }
+    if payload["action"] == DepositRecord.REVIEW_ACTION_APPROVE:
+        email_context["document_url"] = _get_published_document_url(deposit, deposit_user)
+
     send_email(
         [deposit_user["email"]],
         subject,
         f"deposits/email/{payload['action']}",
-        {
-            "deposit": deposit,
-            "deposit_user": deposit_user,
-            "user": user,
-            "date": datetime.now().strftime("%d.%m.%Y %H:%M:%S"),
-            "comment": payload["comment"],
-            "link": current_app.config.get("SONAR_APP_ANGULAR_URL"),
-        },
+        email_context,
         False,
     )
 

--- a/sonar/modules/deposits/templates/deposits/email/approve/en.txt
+++ b/sonar/modules/deposits/templates/deposits/email/approve/en.txt
@@ -12,6 +12,8 @@ Your institution approved your deposit "{{ deposit.metadata.title }}".
 ==================
 {% endif %}
 
-The deposit will be published shortly on SONAR application.
+The deposit has been published on SONAR application:
+
+{{ document_url }}
 
 Thank you for your submission!

--- a/tests/api/deposits/test_deposits_rest.py
+++ b/tests/api/deposits/test_deposits_rest.py
@@ -6,10 +6,26 @@
 import json
 
 from flask import url_for
+from flask_mail import Mail
 from invenio_accounts.testutils import login_user_via_session
 
-from sonar.modules.deposits.rest import FilesResource
+from sonar.modules.deposits.rest import FilesResource, _get_published_document_url
 from sonar.modules.users.api import UserRecord
+
+
+def test_get_published_document_url(app):
+    """Test published document URLs with organisation and global views."""
+    deposit = {"document": {"$ref": "https://sonar.ch/api/documents/123"}}
+
+    with app.test_request_context(base_url="https://sonar.ch"):
+        assert (
+            _get_published_document_url(
+                deposit,
+                {"organisation": {"$ref": "https://sonar.ch/api/organisations/org"}},
+            )
+            == "https://sonar.ch/org/documents/123"
+        )
+        assert _get_published_document_url(deposit, {}) == "https://sonar.ch/global/documents/123"
 
 
 def test_get(app, deposit):
@@ -174,18 +190,23 @@ def test_review(client, db, user, moderator, deposit):
     login_user_via_session(client, email=moderator["email"])
 
     # Valid approval request
-    response = client.post(
-        url,
-        data=json.dumps(
-            {
-                "action": "approve",
-                "comment": None,
-                "user": {"$ref": UserRecord.get_ref_link("users", moderator["pid"])},
-            }
-        ),
-        headers=headers,
-    )
-    assert response.status_code == 200
+    with Mail().record_messages() as outbox:
+        response = client.post(
+            url,
+            data=json.dumps(
+                {
+                    "action": "approve",
+                    "comment": None,
+                    "user": {"$ref": UserRecord.get_ref_link("users", moderator["pid"])},
+                }
+            ),
+            headers=headers,
+        )
+        assert response.status_code == 200
+        document_pid = response.json["document"]["$ref"].rsplit("/", 1)[-1]
+        document_url = f"http://localhost/org/documents/{document_pid}"
+        assert len(outbox) == 1
+        assert document_url in outbox[0].body
 
     # Valid refusal request
     deposit["status"] = "to_validate"


### PR DESCRIPTION
* Adds the published document URL to deposit approval emails.
* Uses the submitter organisation view or global fallback.
* Keeps rejections and change-request emails unchanged.
* Closes #186