### PR TITLE
fix(projects): accept the quoted ETag in the `If-Match` header

### DIFF
--- a/sonar/ext.py
+++ b/sonar/ext.py
@@ -13,7 +13,6 @@ from flask_security import current_user, user_registered
 from flask_wiki import Wiki
 from invenio_files_rest.signals import file_deleted, file_downloaded, file_uploaded
 from invenio_indexer.signals import before_record_index
-from invenio_records_resources.resources import RecordResource
 from werkzeug.datastructures import MIMEAccept
 
 from sonar.filters import (
@@ -42,6 +41,7 @@ from sonar.modules.utils import (
 )
 from sonar.modules.validation.views import blueprint as validation_blueprint
 from sonar.resources.projects.resource import (
+    ProjectsRecordResource,
     ProjectsRecordResourceConfig,
 )
 from sonar.resources.projects.service import (
@@ -142,7 +142,7 @@ class SonarBase:
         """Create resources."""
         # Initialize the project resource with the corresponding service.
         project_service = ProjectsRecordService(ProjectsRecordServiceConfig())
-        projects_resource = RecordResource(service=project_service, config=ProjectsRecordResourceConfig)
+        projects_resource = ProjectsRecordResource(service=project_service, config=ProjectsRecordResourceConfig)
         self.resources["projects"] = projects_resource
 
     def get_endpoints(self):

--- a/sonar/resources/projects/resource.py
+++ b/sonar/resources/projects/resource.py
@@ -3,10 +3,12 @@
 
 """Projects resource."""
 
+from flask import request
 from flask_resources import ResponseHandler
 from flask_resources.serializers import JSONSerializer
-from invenio_records_resources.resources import RecordResourceConfig
+from invenio_records_resources.resources import RecordResource, RecordResourceConfig
 from invenio_records_resources.resources.records.headers import etag_headers
+from werkzeug.http import parse_etags
 
 from sonar.dedicated.hepvs.projects.serializers.csv import (
     CSVSerializer as HepvsCSVSerializer,
@@ -21,6 +23,39 @@ def csv_serializer_factory():
     if current_organisation and current_organisation["code"] == "hepvs":
         return HepvsCSVSerializer()
     return BaseCSVSerializer()
+
+
+# TODO: Remove once invenio-records-resources parses the `If-Match` header as an
+# entity-tag instead of a plain integer.
+def unquote_if_match():
+    """Replace the `If-Match` header value by the bare revision number it holds.
+
+    Invenio exposes the revision id as a quoted ETag but parses `If-Match` as an
+    integer, so the ETag sent back by the clients has to be unquoted first. Weak
+    tags are unquoted too, as `invenio-records-rest` also compares them to the
+    revision, and `*` drops the precondition, the service then matching any
+    revision of the existing record. A multi-tag header is left as it is: the
+    service only ever compares one revision, so invenio rejects it as before.
+    """
+    if_match = parse_etags(request.headers.get("If-Match"))
+    if if_match.star_tag:
+        del request.environ["HTTP_IF_MATCH"]
+    elif len(tags := if_match.as_set(include_weak=True)) == 1:
+        request.environ["HTTP_IF_MATCH"] = tags.pop()
+
+
+class ProjectsRecordResource(RecordResource):
+    """Projects resource accepting quoted ETags in the `If-Match` header."""
+
+    def update(self):
+        """Update a project."""
+        unquote_if_match()
+        return super().update()
+
+    def delete(self):
+        """Delete a project."""
+        unquote_if_match()
+        return super().delete()
 
 
 class ProjectsRecordResourceConfig(RecordResourceConfig):

--- a/tests/api/projects/test_projects_rest.py
+++ b/tests/api/projects/test_projects_rest.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Test projects rest API."""
+
+import json
+
+import pytest
+from flask import url_for
+from invenio_accounts.testutils import login_user_via_session
+from werkzeug.http import unquote_etag
+
+HEADERS = {"Content-Type": "application/json", "Accept": "application/json"}
+
+
+def revision(response):
+    """Return the bare revision number held by the ETag of a response."""
+    return unquote_etag(response.headers["ETag"])[0]
+
+
+@pytest.mark.parametrize("if_match", ['"{revision}"', 'W/"{revision}"', "{revision}"], ids=["quoted", "weak", "bare"])
+def test_update_delete_with_etag(client, make_project, admin, project_json, if_match):
+    """Test that every representation of the ETag is accepted in `If-Match`."""
+    # `project.id` and `project_json` are used instead of dumping the record, as a
+    # dump resolves `current_user` outside of a request and voids the login below.
+    project = make_project("submitter", "org")
+    login_user_via_session(client, email=admin["email"])
+    url = url_for("projects.read", pid_value=project.id)
+    data = json.dumps(project_json)
+
+    res = client.get(url)
+    assert res.status_code == 200
+    assert res.headers["ETag"].startswith('"')
+    stale = if_match.format(revision=revision(res))
+
+    # The revision is accepted whichever representation carries it.
+    res = client.put(url, data=data, headers=HEADERS | {"If-Match": stale})
+    assert res.status_code == 200
+    current = if_match.format(revision=revision(res))
+    assert current != stale
+
+    # An outdated revision is still rejected.
+    res = client.put(url, data=data, headers=HEADERS | {"If-Match": stale})
+    assert res.status_code == 412
+
+    res = client.delete(url, headers=HEADERS | {"If-Match": current})
+    assert res.status_code == 204
+
+
+def test_update_delete_with_etag_wildcard(client, make_project, admin, project_json):
+    """Test that a wildcard `If-Match` matches any revision of the record."""
+    project = make_project("submitter", "org")
+    login_user_via_session(client, email=admin["email"])
+    url = url_for("projects.read", pid_value=project.id)
+    data = json.dumps(project_json)
+
+    res = client.put(url, data=data, headers=HEADERS | {"If-Match": "*"})
+    assert res.status_code == 200
+
+    res = client.delete(url, headers=HEADERS | {"If-Match": "*"})
+    assert res.status_code == 204
+
+
+def test_update_with_several_etags(client, make_project, admin, project_json):
+    """Test that an `If-Match` listing several tags is rejected."""
+    project = make_project("submitter", "org")
+    login_user_via_session(client, email=admin["email"])
+    url = url_for("projects.read", pid_value=project.id)
+
+    res = client.get(url)
+    res = client.put(
+        url,
+        data=json.dumps(project_json),
+        headers=HEADERS | {"If-Match": f'{res.headers["ETag"]}, "42"'},
+    )
+    assert res.status_code == 400


### PR DESCRIPTION
Saving a project from the editor always failed with a 400 and `{'if_match': ['Not a valid integer.']}`. `invenio-records-resources` exposes the revision id as a quoted ETag but parses `If-Match` with `ma.fields.Int()` on the raw header, so the API rejects the very ETag it emitted. `invenio-records-rest` is unaffected: it delegates to werkzeug's `request.if_match`, which handles entity-tags. Projects being our only resource on `invenio-records-resources`, the mismatch surfaced there alone, once the ng-core editor started sending back the ETag it reads on load.

* Unquote the header in `ProjectsRecordResource` before invenio's parser reads it; `unquote_etag` also covers weak tags and leaves a bare revision number untouched, so the workaround stays harmless once fixed upstream (still open in `invenio-records-resources` master, hence the TODO)
* Cover `delete` too: no client sends `If-Match` on a deletion today, but the endpoint carries the same defect
* Test the round trip end to end — the ETag from a `GET` is accepted, a stale revision still yields a 412