### PR TITLE
fix(search): author facet counts

### DIFF
--- a/sonar/config.py
+++ b/sonar/config.py
@@ -580,41 +580,58 @@ RECORDS_REST_ENDPOINTS["subd"] = SubdivisionConfiguration.rest_endpoint
 RECORDS_REST_ENDPOINTS["stat"] = StatConfiguration.rest_endpoint
 """REST endpoints for statistics."""
 
-DEFAULT_AGGREGATION_SIZE = 50
+SONAR_APP_AGGREGATION_SIZE = 50
 """Default size for aggregations."""
+
+SONAR_APP_AGGREGATION_SHARD_SIZE = 1000
+"""Default shard size for terms aggregations."""
 
 RECORDS_REST_FACETS = {
     "documents": dict(
         aggs=dict(
-            masked=dict(terms=dict(field="masked", size=DEFAULT_AGGREGATION_SIZE)),
+            masked=dict(
+                terms=dict(
+                    field="masked",
+                )
+            ),
             subdivision=dict(
-                terms=dict(field="subdivisions.pid", size=DEFAULT_AGGREGATION_SIZE)
+                terms=dict(
+                    field="subdivisions.pid",
+                )
             ),
             organisation=dict(
-                terms=dict(field="organisation.pid", size=DEFAULT_AGGREGATION_SIZE)
+                terms=dict(
+                    field="organisation.pid",
+                )
             ),
             language=dict(
-                terms=dict(field="language.value", size=DEFAULT_AGGREGATION_SIZE)
+                terms=dict(
+                    field="language.value",
+                )
             ),
             subject=dict(
-                terms=dict(field="facet_subjects", size=DEFAULT_AGGREGATION_SIZE)
+                terms=dict(
+                    field="facet_subjects",
+                )
             ),
             collection=dict(
-                terms=dict(field="collections.pid", size=DEFAULT_AGGREGATION_SIZE)
+                terms=dict(
+                    field="collections.pid",
+                )
             ),
             document_type=dict(
-                terms=dict(field="documentType", size=DEFAULT_AGGREGATION_SIZE)
+                terms=dict(
+                    field="documentType",
+                )
             ),
             controlled_affiliation=dict(
                 terms=dict(
                     field="contribution.controlledAffiliation.raw",
-                    size=DEFAULT_AGGREGATION_SIZE,
                 )
             ),
             author=dict(
                 terms=dict(
                     field="contribution.agent.preferred_name.raw",
-                    size=DEFAULT_AGGREGATION_SIZE,
                 )
             ),
             year=dict(
@@ -625,13 +642,19 @@ RECORDS_REST_FACETS = {
                 )
             ),
             customField1=dict(
-                terms=dict(field="customField1.raw", size=DEFAULT_AGGREGATION_SIZE)
+                terms=dict(
+                    field="customField1.raw",
+                )
             ),
             customField2=dict(
-                terms=dict(field="customField2.raw", size=DEFAULT_AGGREGATION_SIZE)
+                terms=dict(
+                    field="customField2.raw",
+                )
             ),
             customField3=dict(
-                terms=dict(field="customField3.raw", size=DEFAULT_AGGREGATION_SIZE)
+                terms=dict(
+                    field="customField3.raw",
+                )
             ),
         ),
         filters={
@@ -659,13 +682,23 @@ RECORDS_REST_FACETS = {
         aggs=dict(
             subdivision=dict(
                 terms=dict(
-                    field="diffusion.subdivisions.pid", size=DEFAULT_AGGREGATION_SIZE
+                    field="diffusion.subdivisions.pid",
                 )
             ),
-            status=dict(terms=dict(field="status", size=DEFAULT_AGGREGATION_SIZE)),
-            user=dict(terms=dict(field="user.pid", size=DEFAULT_AGGREGATION_SIZE)),
+            status=dict(
+                terms=dict(
+                    field="status",
+                )
+            ),
+            user=dict(
+                terms=dict(
+                    field="user.pid",
+                )
+            ),
             contributor=dict(
-                terms=dict(field="facet_contributors", size=DEFAULT_AGGREGATION_SIZE)
+                terms=dict(
+                    field="facet_contributors",
+                )
             ),
         ),
         filters={
@@ -682,7 +715,9 @@ RECORDS_REST_FACETS = {
                 "filter": {"bool": {"must_not": {"exists": {"field": "organisation"}}}}
             },
             "subdivision": {
-                "terms": {"field": "subdivision.pid", "size": DEFAULT_AGGREGATION_SIZE}
+                "terms": {
+                    "field": "subdivision.pid",
+                }
             },
         },
         "filters": {

--- a/sonar/ext.py
+++ b/sonar/ext.py
@@ -4,6 +4,7 @@
 """Document extension."""
 
 import os
+from copy import deepcopy
 
 import jinja2
 from flask import current_app, redirect, render_template, request, url_for
@@ -73,6 +74,35 @@ def utility_processor():
     }
 
 
+def _set_default_terms_aggregation_sizes(aggregation, size, shard_size):
+    """Set the default sizes recursively on terms aggregations."""
+    terms = aggregation.get("terms")
+    if isinstance(terms, dict):
+        terms.setdefault("size", size)
+        terms.setdefault("shard_size", shard_size)
+
+    # Recursively apply to nested aggregations
+    for key in ("aggs", "aggregations"):
+        nested_aggregations = aggregation.get(key)
+        if isinstance(nested_aggregations, dict):
+            for nested_aggregation in nested_aggregations.values():
+                if isinstance(nested_aggregation, dict):
+                    _set_default_terms_aggregation_sizes(nested_aggregation, size, shard_size)
+
+
+def _configure_default_terms_aggregation_sizes(app):
+    """Apply the default sizes to configured terms aggregations."""
+    facets = deepcopy(app.config["RECORDS_REST_FACETS"])
+    shard_size = app.config["SONAR_APP_AGGREGATION_SHARD_SIZE"]
+    size = app.config["SONAR_APP_AGGREGATION_SIZE"]
+
+    for facet in facets.values():
+        if isinstance(facet, dict):
+            _set_default_terms_aggregation_sizes(facet, size, shard_size)
+
+    app.config["RECORDS_REST_FACETS"] = facets
+
+
 class SonarBase:
     """SONAR BASE extension."""
 
@@ -94,6 +124,7 @@ class SonarBase:
     def init_app(self, app):
         """Flask application initialization."""
         self.init_config(app)
+        _configure_default_terms_aggregation_sizes(app)
         self.create_resources()
 
         app.extensions["sonar"] = self

--- a/sonar/resources/projects/service.py
+++ b/sonar/resources/projects/service.py
@@ -5,6 +5,7 @@
 
 import contextlib
 
+from flask import current_app
 from invenio_records_resources.services import SearchOptions as BaseSearchOptions
 from invenio_records_resources.services.records.facets import TermsFacet
 from invenio_records_resources.services.records.params import (
@@ -51,6 +52,28 @@ class PreFacetsParam(FacetsParam):
         return search.filter(post_filter)
 
 
+class ConfiguredFacets:
+    """Provide dynamically configured facets as a class property.
+
+    Invenio accesses facets directly from the SearchOptions class. This
+    descriptor builds them on access using the current application
+    configuration.
+    """
+
+    def __get__(self, obj, objtype=None):
+        """Build facets using the current application configuration."""
+        sizes = {
+            "size": current_app.config["SONAR_APP_AGGREGATION_SIZE"],
+            "shard_size": current_app.config["SONAR_APP_AGGREGATION_SHARD_SIZE"],
+        }
+
+        return {
+            "user": TermsFacet(field="metadata.user.pid", **sizes),
+            "organisation": TermsFacet(field="metadata.organisation.pid", **sizes),
+            "status": TermsFacet(field="metadata.validation.status", **sizes),
+        }
+
+
 class SearchOptions(BaseSearchOptions):
     """Search options."""
 
@@ -74,11 +97,7 @@ class SearchOptions(BaseSearchOptions):
         PreFacetsParam,
     ]
 
-    facets = {
-        "user": TermsFacet(field="metadata.user.pid"),
-        "organisation": TermsFacet(field="metadata.organisation.pid"),
-        "status": TermsFacet(field="metadata.validation.status"),
-    }
+    facets = ConfiguredFacets()
 
     suggest_parser_cls = SuggestQueryParser.factory(
         fields=[

--- a/tests/unit/elasticsearch/test_config.py
+++ b/tests/unit/elasticsearch/test_config.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Test Elasticsearch configuration."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from sonar.config import (
+    RECORDS_REST_FACETS,
+    SONAR_APP_AGGREGATION_SHARD_SIZE,
+    SONAR_APP_AGGREGATION_SIZE,
+)
+from sonar.ext import (
+    _configure_default_terms_aggregation_sizes,
+    _set_default_terms_aggregation_sizes,
+)
+
+
+def _find_terms_aggregations(value):
+    """Find terms aggregations recursively in a configuration value."""
+    if isinstance(value, dict):
+        terms = value.get("terms")
+        if isinstance(terms, dict):
+            yield terms
+        for nested_value in value.values():
+            yield from _find_terms_aggregations(nested_value)
+    elif isinstance(value, (list, tuple)):
+        for nested_value in value:
+            yield from _find_terms_aggregations(nested_value)
+
+
+@pytest.mark.parametrize(
+    ("configured_size", "configured_shard_size"),
+    [
+        (SONAR_APP_AGGREGATION_SIZE, SONAR_APP_AGGREGATION_SHARD_SIZE),
+        (75, 2000),
+    ],
+)
+def test_terms_aggregations_use_configured_sizes(configured_size, configured_shard_size):
+    """Test that terms aggregations receive the configured size settings."""
+    app = SimpleNamespace(
+        config={
+            "RECORDS_REST_FACETS": RECORDS_REST_FACETS,
+            "SONAR_APP_AGGREGATION_SIZE": configured_size,
+            "SONAR_APP_AGGREGATION_SHARD_SIZE": configured_shard_size,
+        },
+    )
+
+    _configure_default_terms_aggregation_sizes(app)
+
+    configured_terms = list(_find_terms_aggregations(app.config["RECORDS_REST_FACETS"]))
+    default_terms = list(_find_terms_aggregations(RECORDS_REST_FACETS))
+
+    assert configured_terms
+    assert len(configured_terms) == len(default_terms)
+    assert all("size" not in terms for terms in default_terms)
+    assert all("shard_size" not in terms for terms in default_terms)
+    for terms in configured_terms:
+        assert terms["size"] == configured_size
+        assert terms["shard_size"] == configured_shard_size
+
+
+def test_default_terms_sizes_are_recursive_and_preserve_explicit_values():
+    """Test nested terms and explicitly configured sizes."""
+    aggregation = {
+        "filters": {"query": {"terms": {"status": ["published"]}}},
+        "aggs": {
+            "default": {"terms": {"field": "author"}},
+            "explicit_size": {"terms": {"field": "subject", "size": 25}},
+            "explicit_shard_size": {"terms": {"field": "language", "shard_size": 250}},
+            "histogram": {"date_histogram": {"field": "year"}},
+            "filtered": {
+                "filter": {"match_all": {}},
+                "aggs": {"nested": {"terms": {"field": "collection"}}},
+            },
+        },
+    }
+
+    _set_default_terms_aggregation_sizes(aggregation, 50, 1000)
+
+    aggregations = aggregation["aggs"]
+    assert aggregations["default"]["terms"]["size"] == 50
+    assert aggregations["default"]["terms"]["shard_size"] == 1000
+    assert aggregations["explicit_size"]["terms"]["size"] == 25
+    assert aggregations["explicit_size"]["terms"]["shard_size"] == 1000
+    assert aggregations["explicit_shard_size"]["terms"]["size"] == 50
+    assert aggregations["explicit_shard_size"]["terms"]["shard_size"] == 250
+    assert "size" not in aggregations["histogram"]["date_histogram"]
+    assert "shard_size" not in aggregations["histogram"]["date_histogram"]
+    assert aggregations["filtered"]["aggs"]["nested"]["terms"]["size"] == 50
+    assert aggregations["filtered"]["aggs"]["nested"]["terms"]["shard_size"] == 1000
+    assert "size" not in aggregation["filters"]["query"]["terms"]
+    assert "shard_size" not in aggregation["filters"]["query"]["terms"]


### PR DESCRIPTION
`fix(search): author facet counts`

Elasticsearch builds terms facet counts by merging candidate terms returned
by each shard. With a facet size of 50 and no explicit `shard_size`, each
shard returns only 85 candidates. Globally relevant terms can therefore be
omitted on some shards, causing their final counts to be underestimated.

Project facets use `TermsFacet` objects from `invenio-records-resources`
instead of the dictionaries defined in `RECORDS_REST_FACETS`. They therefore
cannot be configured by the recursive records-rest implementation.

* Add configurable size and shard size defaults for terms aggregations.
* Apply them recursively to RECORDS_REST_FACETS while preserving explicit
  values.
* Build project TermsFacet definitions from the application configuration.
* Allow deployments to override both values without redefining the facets.
* Add tests for the records-rest aggregation configuration.ored.


Closes #926

> [!WARNING]
> Should be tested on the production data as well 
