### PR TITLE
fix(suggestions): suggest values, not records

### DIFF
--- a/sonar/config.py
+++ b/sonar/config.py
@@ -171,6 +171,16 @@ CELERY_BROKER_HEARTBEAT = 0
 #: Bulk index request timeout
 INDEXER_BULK_REQUEST_TIMEOUT = 60
 
+# Suggestions
+# ===========
+#: Suggestions returned, ie. size of the terms aggregation.
+SONAR_APP_SUGGESTIONS_MAX_RESULTS = 20
+#: Values each shard returns before the merge. The indices have several shards
+#: and most values appear in a single record, so the default
+#: (`SONAR_APP_SUGGESTIONS_MAX_RESULTS * 1.5 + 10`) would leave out matching
+#: values.
+SONAR_APP_SUGGESTIONS_SHARD_SIZE = 200
+
 # Database
 # ========
 #: Database URI including user and password

--- a/sonar/es_templates/v7/record.json
+++ b/sonar/es_templates/v7/record.json
@@ -3,10 +3,14 @@
   "settings": {
     "analysis": {
       "filter": {
-        "autocomplete_filter": {
+        "edge_ngram_filter": {
           "type": "edge_ngram",
           "min_gram": 1,
-          "max_gram": 20
+          "max_gram": 30
+        },
+        "truncate_filter": {
+          "type": "truncate",
+          "length": 30
         }
       },
       "tokenizer": {
@@ -51,7 +55,19 @@
           "tokenizer": "standard",
           "filter": [
             "lowercase",
-            "autocomplete_filter"
+            "icu_folding",
+            "german_normalization",
+            "edge_ngram_filter"
+          ]
+        },
+        "search_autocomplete": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "filter": [
+            "lowercase",
+            "icu_folding",
+            "german_normalization",
+            "truncate_filter"
           ]
         }
       }

--- a/sonar/modules/collections/mappings/v7/collections/collection-v1.0.0.json
+++ b/sonar/modules/collections/mappings/v7/collections/collection-v1.0.0.json
@@ -29,7 +29,7 @@
               "suggest": {
                 "type": "text",
                 "analyzer": "autocomplete",
-                "search_analyzer": "standard"
+                "search_analyzer": "search_autocomplete"
               },
               "raw": {
                 "type": "keyword",

--- a/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0.json
+++ b/sonar/modules/deposits/jsonschemas/deposits/deposit-v1.0.0.json
@@ -800,7 +800,7 @@
                     "props": {
                       "queryOptions": {
                         "type": "collections",
-                        "field": "name.value",
+                        "field": "name.value.suggest",
                         "label": "label"
                       }
                     }
@@ -1303,7 +1303,7 @@
                     "props": {
                       "queryOptions": {
                         "type": "projects",
-                        "field": "metadata.name",
+                        "field": "metadata.name.suggest",
                         "label": "name"
                       }
                     }
@@ -1418,7 +1418,7 @@
                     "props": {
                       "queryOptions": {
                         "type": "subdivisions",
-                        "field": "name.value",
+                        "field": "name.value.suggest",
                         "label": "label"
                       }
                     }

--- a/sonar/modules/documents/dumpers.py
+++ b/sonar/modules/documents/dumpers.py
@@ -9,6 +9,15 @@ from invenio_records.api import _records_state
 from invenio_records.dumpers import Dumper
 
 from sonar.modules.utils import get_ips_list
+from sonar.suggestions.dumpers import SuggestionsDumperExt
+
+# Fields the editor autocompletes through `/api/suggestions/completion`.
+SUGGESTION_FIELDS = [
+    "contribution.agent.preferred_name",
+    "customField1",
+    "customField2",
+    "customField3",
+]
 
 
 class ReplaceRefsDumper(Dumper):
@@ -29,6 +38,8 @@ class ReplaceRefsDumper(Dumper):
 
 class IndexerDumper(Dumper):
     """Document indexer dumper."""
+
+    _suggestions = SuggestionsDumperExt(SUGGESTION_FIELDS)
 
     @staticmethod
     def _add_dates(record, data):
@@ -93,6 +104,7 @@ class IndexerDumper(Dumper):
         self._process_organisation_ips(record, data)
         self._process_fulltext(record, data)
         self._process_identifiers(record, data)
+        self._suggestions.dump(record, data)
 
         return data
 

--- a/sonar/modules/documents/jsonschemas/documents/document-v1.0.0.json
+++ b/sonar/modules/documents/jsonschemas/documents/document-v1.0.0.json
@@ -1204,7 +1204,7 @@
                 "props": {
                   "queryOptions": {
                     "type": "collections",
-                    "field": "name.value",
+                    "field": "name.value.suggest",
                     "label": "label"
                   }
                 }
@@ -2169,7 +2169,7 @@
                   "queryOptions": {
                     "type": "projects",
                     "label": "name",
-                    "field": "metadata.name"
+                    "field": "metadata.name.suggest"
                   }
                 }
               }
@@ -2302,7 +2302,7 @@
                 "props": {
                   "queryOptions": {
                     "type": "subdivisions",
-                    "field": "name.value",
+                    "field": "name.value.suggest",
                     "label": "label"
                   }
                 }

--- a/sonar/modules/documents/mappings/v7/documents/document-v1.0.0.json
+++ b/sonar/modules/documents/mappings/v7/documents/document-v1.0.0.json
@@ -7,7 +7,8 @@
   "mappings": {
     "_source": {
       "excludes": [
-        "fulltext"
+        "fulltext",
+        "suggestions"
       ]
     },
     "date_detection": false,
@@ -15,6 +16,25 @@
     "properties": {
       "fulltext": {
         "type": "text"
+      },
+      "suggestions": {
+        "type": "nested",
+        "properties": {
+          "field": {
+            "type": "keyword"
+          },
+          "value": {
+            "type": "text",
+            "analyzer": "autocomplete",
+            "search_analyzer": "search_autocomplete",
+            "norms": false,
+            "fields": {
+              "raw": {
+                "type": "keyword"
+              }
+            }
+          }
+        }
       },
       "$schema": {
         "type": "keyword"

--- a/sonar/modules/documents/oaipmh_utils.py
+++ b/sonar/modules/documents/oaipmh_utils.py
@@ -7,6 +7,8 @@ from invenio_oaiserver import current_oaiserver
 from invenio_pidstore.errors import PIDDoesNotExistError
 from sqlalchemy.exc import NoResultFound
 
+from sonar.suggestions.dumpers import FIELD as SUGGESTIONS_FIELD
+
 from .dumpers import IndexerDumper
 
 
@@ -23,5 +25,8 @@ def getrecord_fetcher(record_uuid):
         raise PIDDoesNotExistError("oai", None) from None
 
     record_dict = record.dumps(IndexerDumper())
+    # The indexer dumper denormalizes the suggestable values, which are of no
+    # use outside of the index.
+    record_dict.pop(SUGGESTIONS_FIELD, None)
     record_dict["updated"] = record.updated
     return record_dict

--- a/sonar/modules/subdivisions/mappings/v7/subdivisions/subdivision-v1.0.0.json
+++ b/sonar/modules/subdivisions/mappings/v7/subdivisions/subdivision-v1.0.0.json
@@ -29,7 +29,7 @@
               "suggest": {
                 "type": "text",
                 "analyzer": "autocomplete",
-                "search_analyzer": "standard"
+                "search_analyzer": "search_autocomplete"
               },
               "raw": {
                 "type": "keyword",

--- a/sonar/modules/users/jsonschemas/users/user-v1.0.0.json
+++ b/sonar/modules/users/jsonschemas/users/user-v1.0.0.json
@@ -170,7 +170,7 @@
               "props": {
                 "queryOptions": {
                   "type": "subdivisions",
-                  "field": "name.value",
+                  "field": "name.value.suggest",
                   "label": "label"
                 }
               }

--- a/sonar/resources/projects/api.py
+++ b/sonar/resources/projects/api.py
@@ -16,11 +16,15 @@ from sonar.modules.users.api import UserRecord
 from sonar.modules.utils import get_pid_from_ref_or_data
 from sonar.modules.validation.extensions.validation import ValidationExtension
 from sonar.resources.api import Record as BaseRecord
+from sonar.suggestions.dumpers import SuggestionsDumperExt
 
 from . import models
 
 # Custom provider to set the PID type
 RecordIdProvider = type("RecordIdProvider", (BaseRecordIdProvider,), {"pid_type": "proj"})
+
+# Fields the editor autocompletes through `/api/suggestions/completion`.
+SUGGESTION_FIELDS = ["metadata.projectSponsor", "metadata.innerSearcher", "metadata.keywords"]
 
 
 class SearchDumperObjectsExt(SearchDumperExt):
@@ -73,7 +77,7 @@ class Record(BaseRecord):
     # PID type retrieved from provider
     pid_type = RecordIdProvider.pid_type
 
-    dumper = SearchDumper(extensions=[SearchDumperObjectsExt()])
+    dumper = SearchDumper(extensions=[SearchDumperObjectsExt(), SuggestionsDumperExt(SUGGESTION_FIELDS)])
 
     _extensions = [ValidationExtension()]
 

--- a/sonar/resources/projects/mappings/v7/projects/project-v1.0.0.json
+++ b/sonar/resources/projects/mappings/v7/projects/project-v1.0.0.json
@@ -5,11 +5,35 @@
     "max_result_window": 20000
   },
   "mappings": {
+    "_source": {
+      "excludes": [
+        "suggestions"
+      ]
+    },
     "date_detection": false,
     "numeric_detection": false,
     "properties": {
       "id": {
         "type": "keyword"
+      },
+      "suggestions": {
+        "type": "nested",
+        "properties": {
+          "field": {
+            "type": "keyword"
+          },
+          "value": {
+            "type": "text",
+            "analyzer": "autocomplete",
+            "search_analyzer": "search_autocomplete",
+            "norms": false,
+            "fields": {
+              "raw": {
+                "type": "keyword"
+              }
+            }
+          }
+        }
       },
       "metadata": {
         "type": "object",
@@ -20,7 +44,7 @@
               "suggest": {
                 "type": "text",
                 "analyzer": "autocomplete",
-                "search_analyzer": "standard"
+                "search_analyzer": "search_autocomplete"
               },
               "raw": {
                 "type": "keyword",

--- a/sonar/suggestions/dumpers.py
+++ b/sonar/suggestions/dumpers.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Suggestions dumpers."""
+
+from invenio_records.dumpers import SearchDumperExt
+
+# Nested field added to the indexed data, see the `autocomplete` analyzer in the
+# `record.json` ES template and the `suggestions` property of the mappings.
+FIELD = "suggestions"
+
+
+class SuggestionsDumperExt(SearchDumperExt):
+    """Denormalize the suggestable values of a record.
+
+    Each value gets its own sub-document, so that Elasticsearch matches and
+    aggregates the values individually instead of matching the record as a
+    whole. Any resource can reuse it with the paths of its own fields.
+    """
+
+    def __init__(self, fields):
+        """Initialize the extension.
+
+        :param fields: paths of the suggestable fields in the dumped data.
+        """
+        self.fields = fields
+
+    @classmethod
+    def _extract_values(cls, data, parts):
+        """Collect the string values reachable through a field path.
+
+        Lists are walked at any level, as arrays of objects are common in the
+        schemas, ie. `contribution.agent.preferred_name`.
+
+        :param data: portion of the data to walk.
+        :param parts: remaining parts of the field path.
+        :returns: generator over the string values found.
+        """
+        if isinstance(data, list):
+            for item in data:
+                yield from cls._extract_values(item, parts)
+        elif not parts:
+            if isinstance(data, str):
+                yield data
+        elif isinstance(data, dict):
+            yield from cls._extract_values(data.get(parts[0]), parts[1:])
+
+    def dump(self, record, data):
+        """Add the nested suggestions to the data to index.
+
+        :param record: the record to dump.
+        :param data: the data to index.
+        """
+        data[FIELD] = [
+            {"field": field, "value": value}
+            for field in self.fields
+            for value in dict.fromkeys(self._extract_values(data, field.split(".")))
+        ]
+
+    def load(self, data, record_cls):
+        """Remove the nested suggestions from the indexed data.
+
+        The mappings already exclude them from the stored source, this keeps
+        them out of the record should an index escape the reindex.
+
+        :param data: the indexed data.
+        :param record_cls: the record class.
+        """
+        data.pop(FIELD, None)

--- a/sonar/suggestions/rest.py
+++ b/sonar/suggestions/rest.py
@@ -3,11 +3,13 @@
 
 """Suggestions rest views."""
 
+from elasticsearch_dsl.query import Q
 from flask import Blueprint, current_app, jsonify, request
 
 from sonar.modules.organisations.api import current_organisation
 from sonar.modules.permissions import has_superuser_access, is_user_logged_and_submitter
 from sonar.proxies import sonar
+from sonar.suggestions.dumpers import FIELD
 
 api_blueprint = Blueprint("suggestions", __name__, url_prefix="/suggestions")
 
@@ -35,8 +37,6 @@ def completion():
     if not resource:
         return jsonify({"error": "No resource parameter given"}), 400
 
-    fields = field.split(",")
-
     search = None
     try:
         service = sonar.service(resource)
@@ -52,37 +52,32 @@ def completion():
     if not search:
         return jsonify({"error": "Search class not found"}), 404
 
-    results = []
+    # Organisation filter for non-superusers
+    if not has_superuser_access() and current_organisation and (org_field := _ORG_FIELDS.get(resource)):
+        search = search.filter("term", **{org_field: current_organisation["pid"]})
 
-    try:
-        # Organisation filter for non-superusers
-        if not has_superuser_access() and current_organisation:
-            org_field = _ORG_FIELDS.get(resource)
-            if org_field:
-                search = search.filter("term", **{org_field: current_organisation["pid"]})
+    # The dumper indexes each suggestable value as its own nested object, so the
+    # aggregation returns the matching values only, ordered by the number of
+    # records they appear in. Each typed word must be an indexed n-gram of the
+    # same value, so partial words match without the term expansion a prefix
+    # query would need.
+    matching = Q("terms", **{f"{FIELD}.field": field.split(",")}) & Q(
+        "match", **{f"{FIELD}.value": {"query": query, "operator": "and"}}
+    )
 
-        for field_name in fields:
-            field_search = search.query("match_phrase_prefix", **{field_name: query}).source(includes=[field_name])[:20]
+    # The same query selects the records first, so the aggregation walks the
+    # values of the matching records instead of the whole index. A resource
+    # without suggestable values has no `suggestions` mapping and, thanks to
+    # `ignore_unmapped`, returns no suggestion instead of an error.
+    search = search.filter("nested", path=FIELD, query=matching, ignore_unmapped=True).extra(size=0)
+    search.aggs.bucket(FIELD, "nested", path=FIELD).bucket("matching", "filter", filter=matching).bucket(
+        "values",
+        "terms",
+        field=f"{FIELD}.value.raw",
+        size=current_app.config["SONAR_APP_SUGGESTIONS_MAX_RESULTS"],
+        shard_size=current_app.config["SONAR_APP_SUGGESTIONS_SHARD_SIZE"],
+    )
 
-            for hit in field_search.execute():
-                value = hit.to_dict()
-                for part in field_name.split("."):
-                    if not isinstance(value, dict):
-                        value = None
-                        break
-                    value = value.get(part)
-                if isinstance(value, str):
-                    results.append(value)
-                elif isinstance(value, list):
-                    results.extend(v for v in value if isinstance(v, str))
+    results = search.execute()
 
-    except Exception:
-        return jsonify({"error": "Bad request"}), 400
-
-    # Remove duplicates
-    results = list(dict.fromkeys(results))
-
-    # Sort items
-    results.sort()
-
-    return jsonify(results)
+    return jsonify([bucket.key for bucket in results.aggregations[FIELD].matching.values.buckets])

--- a/tests/api/suggestions/test_suggestions_rest.py
+++ b/tests/api/suggestions/test_suggestions_rest.py
@@ -7,52 +7,46 @@ import json
 
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
-from invenio_search import current_search
+from invenio_search import current_search, current_search_client
 
 
-def test_completion(client, project_hepvs_json, make_user, user_without_role):
-    """Test completion suggestions with access control and organisation filter."""
+def completion(client, query, field, resource="documents"):
+    """Call the completion endpoint and return the suggestions.
+
+    :param client: test client.
+    :param query: query typed by the user.
+    :param field: field, or comma separated list of fields, to suggest from.
+    :param resource: resource to search in.
+    :returns: the suggested values.
+    """
+    res = client.get(url_for("suggestions.completion", q=query, field=field, resource=resource))
+    assert res.status_code == 200
+
+    return res.json
+
+
+def contributions(*names):
+    """Build contributions for the given preferred names.
+
+    :param names: preferred names of the contributors.
+    :returns: list of contributions.
+    """
+    return [{"agent": {"type": "bf:Person", "preferred_name": name}, "role": ["cre"]} for name in names]
+
+
+def test_completion_params(client, make_user, user_without_role):
+    """Test access control and parameters validation."""
     # 401: unauthenticated request blocked before parameter validation
     res = client.get(url_for("suggestions.completion"))
     assert res.status_code == 401
 
     # 403: authenticated but no submitter role
     login_user_via_session(client, email=user_without_role.email)
-    res = client.get(url_for("suggestions.completion", q="test", field="metadata.name", resource="projects"))
+    res = client.get(url_for("suggestions.completion", q="test", field="customField1", resource="documents"))
     assert res.status_code == 403
 
-    headers = {"Content-Type": "application/json"}
-
-    # Setup: hepvs admin (dedicated org with hepvs schema) + project
-    user_hepvs = make_user("admin", organisation="hepvs", organisation_is_shared=False, access="admin-access")
-    login_user_via_session(client, email=user_hepvs["email"])
-
-    hepvs_project = project_hepvs_json
-    hepvs_project["metadata"]["name"] = "HEPVS Research Project"
-    hepvs_project["metadata"]["organisation"] = {"$ref": "https://sonar.ch/api/organisations/hepvs"}
-    hepvs_project["metadata"]["user"] = {"$ref": f"https://sonar.ch/api/users/{user_hepvs['pid']}"}
-    res = client.post(url_for("projects.search"), data=json.dumps(hepvs_project), headers=headers)
-    assert res.status_code == 201
-
-    # Setup: usi admin (shared org, default schema) + project
-    user_usi = make_user("admin", organisation="usi", access="admin-access")
-    login_user_via_session(client, email=user_usi["email"])
-
-    usi_project = {
-        "metadata": {
-            "name": "USI Research Project",
-            "startDate": "2021-01-01",
-            "organisation": {"$ref": "https://sonar.ch/api/organisations/usi"},
-            "user": {"$ref": f"https://sonar.ch/api/users/{user_usi['pid']}"},
-        }
-    }
-    res = client.post(url_for("projects.search"), data=json.dumps(usi_project), headers=headers)
-    assert res.status_code == 201
-
-    current_search.flush_and_refresh(index="projects")
-
-    # Switch back to hepvs admin for parameter validation tests
-    login_user_via_session(client, email=user_hepvs["email"])
+    user = make_user("admin", organisation="org")
+    login_user_via_session(client, email=user["email"])
 
     # No query parameter
     res = client.get(url_for("suggestions.completion"))
@@ -65,55 +59,183 @@ def test_completion(client, project_hepvs_json, make_user, user_without_role):
     assert res.json == {"error": "No field parameter given"}
 
     # No resource parameter
-    res = client.get(url_for("suggestions.completion", q="Research", field="metadata.name"))
+    res = client.get(url_for("suggestions.completion", q="test", field="customField1"))
     assert res.status_code == 400
     assert res.json == {"error": "No resource parameter given"}
 
     # Non-existent resource
-    res = client.get(
-        url_for(
-            "suggestions.completion",
-            q="Research",
-            field="metadata.name",
-            resource="unknown",
-        )
-    )
+    res = client.get(url_for("suggestions.completion", q="test", field="customField1", resource="unknown"))
     assert res.status_code == 404
     assert res.json == {"error": "Search class not found"}
 
-    # Unknown field returns empty results (match_phrase_prefix silently ignores unmapped fields)
-    res = client.get(url_for("suggestions.completion", q="Research", field="unknown", resource="projects"))
-    assert res.status_code == 200
-    assert res.json == []
 
-    # Organisation filter: hepvs admin searching "Research" sees only the hepvs project
-    res = client.get(
-        url_for(
-            "suggestions.completion",
-            q="Research",
-            field="metadata.name",
-            resource="projects",
-        )
-    )
-    assert res.status_code == 200
-    assert res.json == ["HEPVS Research Project"]
-
-    # Organisation filter: usi admin searching "Research" sees only the usi project
-    login_user_via_session(client, email=user_usi["email"])
-    res = client.get(
-        url_for(
-            "suggestions.completion",
-            q="Research",
-            field="metadata.name",
-            resource="projects",
-        )
-    )
-    assert res.status_code == 200
-    assert res.json == ["USI Research Project"]
-
-    # Users resource has no organisation filter — query by name prefix
+def test_completion_resource_without_suggestions(client, make_user, search_clear):
+    """Test a resource that does not index suggestable values."""
+    user = make_user("admin", organisation="org")
+    login_user_via_session(client, email=user["email"])
     current_search.flush_and_refresh(index="users")
+
+    # The record is indexed, but only the denormalized values can be suggested
+    assert completion(client, user["email"], "email", "users") == []
+
+
+def test_completion_documents(client, document_json, make_document, make_user, search_clear):
+    """Test completion suggestions on documents."""
+    # `customField1` is `["Test"]` in the fixture
+    document_json["contribution"] = contributions("Dupont, Jean", "Zimmermann, Ada", "Testeur, Léa")
+    make_document(organisation="org")
+    current_search.flush_and_refresh(index="documents")
+
+    user = make_user("admin", organisation="org")
+    login_user_via_session(client, email=user["email"])
+
+    field = "contribution.agent.preferred_name"
+
+    # A partial word is enough, the whole word is not required
+    for query in ["D", "Dup", "dupont", "Dupont, Jean"]:
+        assert completion(client, query, field) == ["Dupont, Jean"]
+
+    # A matching record does not suggest the other values of its field
+    assert completion(client, "Zim", field) == ["Zimmermann, Ada"]
+
+    # Each typed word must match the same value, not the same record
+    assert completion(client, "Dupont Ada", field) == []
+
+    # Values of several fields in a single request
+    assert completion(client, "te", f"{field},customField1") == ["Test", "Testeur, Léa"]
+
+    # Unknown value and unknown field
+    assert completion(client, "Nobody", field) == []
+    assert completion(client, "Dupont", "unknown") == []
+
+
+def test_completion_documents_diacritics(client, document_json, make_document, make_user, search_clear):
+    """Test completion suggestions with folded values and queries."""
+    document_json["contribution"] = contributions("Délèze, Sébastien", "Müller, Anaïs")
+    make_document(organisation="org")
+    current_search.flush_and_refresh(index="documents")
+
+    user = make_user("admin", organisation="org")
+    login_user_via_session(client, email=user["email"])
+
+    field = "contribution.agent.preferred_name"
+
+    # Diacritics are folded on both sides
+    assert completion(client, "dele", field) == ["Délèze, Sébastien"]
+    assert completion(client, "Délè", field) == ["Délèze, Sébastien"]
+
+    # The German transliteration is folded too
+    assert completion(client, "mueller", field) == ["Müller, Anaïs"]
+    assert completion(client, "Müll", field) == ["Müller, Anaïs"]
+
+
+def test_completion_documents_long_words(client, document_json, make_document, make_user, search_clear):
+    """Test completion suggestions on words longer than the indexed n-grams."""
+    name = "Rechtsschutzversicherungsgesellschaft, Anna"
+    document_json["contribution"] = contributions(name)
+    make_document(organisation="org")
+    current_search.flush_and_refresh(index="documents")
+
+    user = make_user("admin", organisation="org")
+    login_user_via_session(client, email=user["email"])
+
+    field = "contribution.agent.preferred_name"
+
+    # The `autocomplete` analyzer only indexes the 30 first characters of a
+    # word, the query is truncated to match them
+    assert completion(client, "Rechtsschutzversicherungsgesel", field) == [name]
+    assert completion(client, "Rechtsschutzversicherungsgesellschaft", field) == [name]
+
+
+def test_completion_documents_frequency(client, document_json, make_document, make_user, search_clear):
+    """Test that a frequent value does not hide the rare ones."""
+    # More records than the 20 the previous implementation looked at
+    document_json["contribution"] = contributions("Common, Value")
+    for _ in range(21):
+        make_document(organisation="org")
+
+    document_json["contribution"] = contributions("Comte, Rare")
+    make_document(organisation="org")
+    current_search.flush_and_refresh(index="documents")
+
+    user = make_user("admin", organisation="org")
+    login_user_via_session(client, email=user["email"])
+
+    # Values are ordered by the number of records they appear in
+    assert completion(client, "co", "contribution.agent.preferred_name") == ["Common, Value", "Comte, Rare"]
+
+
+def test_completion_documents_max_results(client, document_json, make_document, make_user, search_clear):
+    """Test that the suggestions of a single record are limited."""
+    document_json["contribution"] = contributions(*[f"Auteur {index:02d}" for index in range(25)])
+    make_document(organisation="org")
+    current_search.flush_and_refresh(index="documents")
+
+    user = make_user("admin", organisation="org")
+    login_user_via_session(client, email=user["email"])
+
+    assert len(completion(client, "auteur", "contribution.agent.preferred_name")) == 20
+
+
+def test_completion_documents_organisation(
+    client, document_json, make_document, make_organisation, make_user, superuser, search_clear
+):
+    """Test the organisation filter on documents."""
+    document_json["contribution"] = contributions("Dupont, Jean")
+    make_document(organisation="org")
+
+    # The factory forces the `org` reference, set the second organisation by hand
+    make_organisation("org2")
+    document_json["contribution"] = contributions("Duvernay, Claire")
+    document_json["organisation"] = [{"$ref": "https://sonar.ch/api/organisations/org2"}]
+    make_document(organisation=None)
+
+    current_search.flush_and_refresh(index="documents")
+
+    field = "contribution.agent.preferred_name"
+
+    user = make_user("admin", organisation="org")
+    login_user_via_session(client, email=user["email"])
+    assert completion(client, "du", field) == ["Dupont, Jean"]
+
+    user_org2 = make_user("admin", organisation="org2")
+    login_user_via_session(client, email=user_org2["email"])
+    assert completion(client, "du", field) == ["Duvernay, Claire"]
+
+    # Superusers are not restricted to their organisation
+    login_user_via_session(client, email=superuser["email"])
+    assert completion(client, "du", field) == ["Dupont, Jean", "Duvernay, Claire"]
+
+
+def test_completion_projects(client, project_hepvs_json, make_user, search_clear):
+    """Test completion suggestions on projects."""
+    # `projectSponsor` is "Sébastien Délèze" and `innerSearcher` ["John Doe"]
+    user_hepvs = make_user("admin", organisation="hepvs", organisation_is_shared=False, access="admin-access")
     login_user_via_session(client, email=user_hepvs["email"])
-    res = client.get(url_for("suggestions.completion", q="Hepvs", field="full_name", resource="users"))
-    assert res.status_code == 200
-    assert res.json == ["Hepvsadmin Doe"]
+
+    project_hepvs_json["metadata"]["organisation"] = {"$ref": "https://sonar.ch/api/organisations/hepvs"}
+    project_hepvs_json["metadata"]["user"] = {"$ref": f"https://sonar.ch/api/users/{user_hepvs['pid']}"}
+    res = client.post(
+        url_for("projects.search"),
+        data=json.dumps(project_hepvs_json),
+        headers={"Content-Type": "application/json"},
+    )
+    assert res.status_code == 201
+
+    current_search.flush_and_refresh(index="projects")
+
+    fields = "metadata.projectSponsor,metadata.innerSearcher"
+
+    # A single request covers each of the requested fields
+    assert completion(client, "dele", fields, "projects") == ["Sébastien Délèze"]
+    assert completion(client, "doe", fields, "projects") == ["John Doe"]
+    assert completion(client, "te", "metadata.keywords", "projects") == ["Test"]
+
+    # The suggestions are not part of the stored source
+    hit = current_search_client.search(index="projects")["hits"]["hits"][0]
+    assert "suggestions" not in hit["_source"]
+
+    # Organisation filter: another organisation gets no suggestion
+    user_usi = make_user("admin", organisation="usi", access="admin-access")
+    login_user_via_session(client, email=user_usi["email"])
+    assert completion(client, "dele", fields, "projects") == []

--- a/tests/ui/documents/test_documents_dumpers.py
+++ b/tests/ui/documents/test_documents_dumpers.py
@@ -26,6 +26,7 @@ def test_document_indexer_dumper(document, pdf_file):
     assert "ips" in data["organisation"][0]
     assert "isOpenAccess" in data
     assert "identifiers" in data
+    assert {"field": "customField1", "value": "Test"} in data["suggestions"]
 
 
 def test_document_indexer_dumper_identifiers(document):

--- a/tests/ui/documents/test_oaipmh.py
+++ b/tests/ui/documents/test_oaipmh.py
@@ -3,6 +3,10 @@
 
 """Test OAIPMH URLS."""
 
+from sonar.modules.documents.dumpers import IndexerDumper
+from sonar.modules.documents.oaipmh_utils import getrecord_fetcher
+from sonar.suggestions.dumpers import FIELD as SUGGESTIONS_FIELD
+
 
 def test_oaipmh_get(client, org_oaiset, document):
     """Test OAIPMH API."""
@@ -17,6 +21,12 @@ def test_oaipmh_get(client, org_oaiset, document):
     res = client.get("/oai2d?verb=GetRecord&metadataPrefix=oai_dc&identifier=oai:sonar.ch:1")
     assert res.status_code == 200
     assert "<setSpec>org</setSpec>" in res.text
+
+
+def test_oaipmh_getrecord_fetcher(app, document):
+    """Test that the fetched record drops the values denormalized for the index."""
+    assert SUGGESTIONS_FIELD in document.dumps(IndexerDumper())
+    assert SUGGESTIONS_FIELD not in getrecord_fetcher(document.id)
 
 
 def test_oaipmh_get_deleted_document(client, document):

--- a/tests/unit/suggestions/__init__.py
+++ b/tests/unit/suggestions/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests unit suggestions."""

--- a/tests/unit/suggestions/test_suggestions_dumpers.py
+++ b/tests/unit/suggestions/test_suggestions_dumpers.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Test suggestions dumpers."""
+
+from sonar.suggestions.dumpers import SuggestionsDumperExt
+
+
+def test_extract_values():
+    """Test collecting the values reachable through a field path."""
+    data = {
+        "contribution": [
+            {"agent": {"preferred_name": "Dupont, Jean"}},
+            {"agent": {"preferred_name": "Zimmermann, Ada"}},
+            {"role": ["cre"]},
+        ],
+        "customField1": ["Test", "Other"],
+        "isOpenAccess": True,
+    }
+
+    assert list(SuggestionsDumperExt._extract_values(data, ["contribution", "agent", "preferred_name"])) == [
+        "Dupont, Jean",
+        "Zimmermann, Ada",
+    ]
+    assert list(SuggestionsDumperExt._extract_values(data, ["customField1"])) == ["Test", "Other"]
+
+    # Unknown path and non string value
+    assert not list(SuggestionsDumperExt._extract_values(data, ["unknown"]))
+    assert not list(SuggestionsDumperExt._extract_values(data, ["isOpenAccess"]))
+
+
+def test_suggestions_dumper_ext():
+    """Test dumping the suggestable values as nested objects."""
+    data = {
+        "contribution": [
+            {"agent": {"preferred_name": "Dupont, Jean"}},
+            {"agent": {"preferred_name": "Dupont, Jean"}},
+        ],
+        "customField1": ["Test"],
+    }
+
+    dumper = SuggestionsDumperExt(["contribution.agent.preferred_name", "customField1", "customField2"])
+    dumper.dump(None, data)
+
+    # One object per value, duplicates removed, declaration order kept
+    assert data["suggestions"] == [
+        {"field": "contribution.agent.preferred_name", "value": "Dupont, Jean"},
+        {"field": "customField1", "value": "Test"},
+    ]
+
+    # The values are dropped again when the indexed data is loaded back
+    dumper.load(data, None)
+    assert "suggestions" not in data


### PR DESCRIPTION
The completion endpoint matched *records*, so a hit carried every value of
its field and Python had to re-extract and re-filter them. Worse, it only
looked at the first 50 scored documents.

A value can only be matched on its own if it is indexed on its own, which
only a dumper can do — `copy_to` copies values, not structure.

* Add `SuggestionsDumperExt`, which denormalizes the suggestable values
  into a `nested` field, one sub-document per value. It takes the field
  paths as argument, so any resource can reuse it: documents wire it into
  `IndexerDumper`, projects into their `SearchDumper` extensions.
* Read the values from a nested aggregation: no document cap, ordering by
  frequency, one request for all the requested fields, and `operator: and`
  applied per value.
* Align the analyzers on rero-ils: `autocomplete` / `search_autocomplete`
  pair, `edge_ngram` up to 30. The remaining `.suggest`
  sub-fields follow, which also lets the `$ref` pickers find `Zürich` with
  `zurich`.
* Query the real field paths again and drop the orphan `.suggest`
  sub-fields.

⚠ v1.13.0 migration will require a full `documents`, `projects`, `collections`,
`subdivisions` and `users` (6dfd183c) reindex!