### PR TITLE
feat(theme): keep the search bar visible on small screens

### DIFF
--- a/sonar/theme/static/js/app.js
+++ b/sonar/theme/static/js/app.js
@@ -1,43 +1,40 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-document.addEventListener("DOMContentLoaded", function () {
-  document.addEventListener('click', function (event) {
-    let link = event.target;
+// Minimal replacement for the bootstrap dropdown and collapse plugins, which are
+// only loaded on the few pages needing jQuery.
 
-    const dropdowns = document.getElementsByClassName('dropdown-menu show');
+// Reflect the visibility of a menu on the toggle controlling it.
+function setExpanded(toggle, expanded) {
+  if (toggle && toggle.dataset.toggle) {
+    toggle.setAttribute("aria-expanded", expanded);
+  }
+}
 
-    // If the clicked element doesn't have the right selector, bail
-    if (!link.matches('.dropdown-toggle')) {
-      link = link.parentNode
+document.addEventListener("click", function (event) {
+  // Some pages load the bootstrap plugins, which then handle the menus themselves.
+  if (window.jQuery && window.jQuery.fn.collapse) {
+    return;
+  }
 
-      // This can maybe be a span inside link
-      if (!link.matches('.dropdown-toggle')) {
-        Array.prototype.forEach.call(dropdowns, function (el, i) {
-          el.classList.remove('show');
-        });
-        return;
-      }
-    };
+  const toggle = event.target.closest('[data-toggle="dropdown"], [data-toggle="collapse"]');
 
-    // Don't follow the link
-    event.preventDefault();
+  // The controlled element is either referenced by `data-target` or placed right after the toggle.
+  const target =
+    toggle && (toggle.dataset.target ? document.querySelector(toggle.dataset.target) : toggle.nextElementSibling);
 
-    // Dropdown corresponding to link
-    const dropdown = link.nextElementSibling;
-
-    // Hide all dropdowns
-    Array.prototype.forEach.call(dropdowns, function (el, i) {
-      if (el.isEqualNode(dropdown) === false) {
-        el.classList.remove('show');
-      }
-    });
-
-    // Already shown
-    if (dropdown.className.search('show') !== -1) {
-      dropdown.classList.remove('show')
-    } else {
-      dropdown.classList.add('show')
+  // Any click outside of an open dropdown closes it.
+  document.querySelectorAll(".dropdown-menu.show").forEach(function (menu) {
+    if (menu !== target) {
+      menu.classList.remove("show");
+      setExpanded(menu.previousElementSibling, false);
     }
-  }, false);
+  });
+
+  if (!target) {
+    return;
+  }
+
+  event.preventDefault();
+  setExpanded(toggle, target.classList.toggle("show"));
 });

--- a/sonar/theme/templates/sonar/page.html
+++ b/sonar/theme/templates/sonar/page.html
@@ -142,69 +142,11 @@
   {%- endblock page_body %}
 
   {% include 'sonar/footer.html' %}
+  {# Outside of the javascript block, as templates overriding it would drop the menus behaviour. #}
+  <script src="{{ url_for('static', filename='js/app.js') }}"></script>
   {%- endblock body_inner %}
 
-  {%- block javascript %}
-  <script>
-    document.addEventListener("DOMContentLoaded", function () {
-      // Toggle display
-      const toggleDisplay = document.getElementsByClassName('toggle-display');
-      Array.prototype.forEach.call(toggleDisplay, function (el, i) {
-        el.addEventListener('click', function (event) {
-          const targetElement = document.getElementById(el.dataset.target);
-          if (targetElement) {
-            if (targetElement.className.search('d-none') !== -1) {
-              targetElement.classList.remove('d-none')
-            } else {
-              targetElement.classList.add('d-none')
-            }
-          }
-          event.preventDefault();
-        });
-      });
-
-      document.addEventListener('click', function (event) {
-        let link = event.target;
-
-        const dropdowns = document.getElementsByClassName('dropdown-menu show');
-
-        // If the clicked element doesn't have the right selector, bail
-        if (!link.matches('.dropdown-toggle') && !link.matches('.navbar-toggler')) {
-          link = link.parentNode
-
-          // This can maybe be a span inside link
-          if (!link.matches('.dropdown-toggle') && !link.matches('.navbar-toggler')) {
-            Array.prototype.forEach.call(dropdowns, function (el, i) {
-              el.classList.remove('show');
-            });
-            return;
-          }
-        };
-
-        // Don't follow the link
-        event.preventDefault();
-
-        // Dropdown corresponding to link
-        const dropdown = link.nextElementSibling;
-
-        // Hide all dropdowns
-        Array.prototype.forEach.call(dropdowns, function (el, i) {
-          if (el.isEqualNode(dropdown) === false) {
-            el.classList.remove('show');
-          }
-        });
-
-        // Already shown
-        if (dropdown.className.search('show') !== -1) {
-          dropdown.classList.remove('show')
-        } else {
-          dropdown.classList.add('show')
-        }
-      }, false);
-    });
-  </script>
-
-  {%- endblock javascript %}
+  {%- block javascript %}{%- endblock javascript %}
   {%- endblock outer_body %}
 </body>
 

--- a/sonar/theme/templates/sonar/partial/navbar.html
+++ b/sonar/theme/templates/sonar/partial/navbar.html
@@ -21,26 +21,29 @@
       {% endif %}
     </a>
     {% endif %}
-    <button class="ml-auto navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
-      aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-      <i class="fa-solid fa-bars p-1"></i>
-    </button>
-    <div class="collapse navbar-collapse" id="navbarSupportedContent">
-      {% if not admin %}
-      {% if page != 'home' %}
+    <div class="d-flex align-items-center flex-grow-1 flex-lg-grow-0 justify-content-end my-2 my-lg-0 ml-lg-3">
+      {% if not admin and page != 'home' %}
       <form
         action="{{ url_for('documents.search', view=view_code if g.get('organisation', {}).get('isDedicated') else config.SONAR_APP_DEFAULT_ORGANISATION) }}"
-        class="form-inline my-2 my-lg-0 ml-lg-3">
-        <input name="q" class="form-control {{ 'form-control-sm' if g.get('organisation') and page == 'home' else '' }} mr-sm-2"
-          type="search" placeholder="{{ _('Search') }}" aria-label="{{ _('Search') }}"
-          value="{{ request.args.get('q', '') }}">
-        <button class="btn btn-outline-light {{ 'btn-sm' if g.get('organisation') else '' }} my-2 my-sm-0" type="submit"
-          aria-label="{{ _('Search') }}">
-          <i class="fa-solid fa-magnifying-glass"></i>
-        </button>
+        class="flex-grow-1 flex-lg-grow-0">
+        <div class="input-group">
+          <input name="q" class="form-control" type="search" placeholder="{{ _('Search') }}"
+            aria-label="{{ _('Search') }}" value="{{ request.args.get('q', '') }}">
+          <div class="input-group-append">
+            <button class="btn btn-outline-light" type="submit" aria-label="{{ _('Search') }}">
+              <i class="fa-solid fa-magnifying-glass"></i>
+            </button>
+          </div>
+        </div>
       </form>
       {% endif %}
-      {% else %}
+      <button class="navbar-toggler ml-2" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
+        aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <i class="fa-solid fa-bars p-1"></i>
+      </button>
+    </div>
+    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+      {% if admin %}
       <span class="navbar-text text-secondary">{{ _('Administration')|upper }}</span>
       {% endif %}
       <ul class="navbar-nav ml-auto">

--- a/tests/ui/test_views.py
+++ b/tests/ui/test_views.py
@@ -20,6 +20,18 @@ def test_index_trailing_slash(client, organisation):
     assert res.location == url_for("index", view=organisation["code"])
 
 
+def test_navbar_search_outside_collapsible_menu(client):
+    """Test that the navbar search field is not hidden behind the hamburger menu."""
+    res = client.get(url_for("documents.search", view="global"))
+    assert res.status_code == 200
+
+    html = res.get_data(as_text=True)
+    search_field = html.find('<input name="q"')
+    collapsible_menu = html.find('id="navbarSupportedContent"')
+    assert search_field != -1
+    assert search_field < collapsible_menu
+
+
 def test_robots_txt(app):
     """Test le robots.txt file."""
     with app.test_client() as client:
@@ -277,6 +289,8 @@ def test_profile(client, user):
     # Logged
     res = client.get(url_for("sonar.profile", pid=user["pid"]))
     assert res.status_code == 200
+    # The page specific javascript block must not drop the menus behaviour.
+    assert "/static/js/app.js" in res.get_data(as_text=True)
 
     # Wrong PID
     res = client.get(url_for("sonar.profile", pid="wrong"))


### PR DESCRIPTION
- Move the search bar out of the collapsible navbar, so the search stays reachable without opening the hamburger menu, same as ILS.
- Merge the two diverging copies of the dropdown and collapse implementation into a single `app.js`, matching the toggles on their `data-toggle` attribute and resolving the controlled element through `data-target`.
- FIX: Load `app.js` outside of the `javascript` block, as the templates overriding that block without calling `super()` (user profile, document detail) were left without any menu behaviour.
- Stand down when the bootstrap plugins are loaded, as both implementations were fighting over the same clicks on the document detail page.