### PR TITLE
ci: skip location-only changes in the template

### DIFF
--- a/.github/workflows/extract-translations.yml
+++ b/.github/workflows/extract-translations.yml
@@ -66,8 +66,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           POT='sonar/translations/messages.pot'
-          # Ignore POT-Creation-Date (rewritten every run) to skip content-free commits.
-          if git diff --quiet -I '^"POT-Creation-Date:' -- "$POT"; then
+          # Ignore POT-Creation-Date (rewritten every run) and the #: source locations
+          # (they churn on any line shift) to skip content-free commits.
+          if git diff --quiet -I '^"POT-Creation-Date:' -I '^#:' -- "$POT"; then
             echo "No template changes."; exit 0
           fi
           git add "$POT"


### PR DESCRIPTION
The diff guard of `extract-translations.yml` now also ignores the `#:` source
locations, so a run whose only delta is shifted line numbers no longer produces
a `chore(i18n): extract messages` commit.

Weblate matches units by msgid, so stale locations in the template cost nothing.
A noise commit, on the other hand, is not free: it pushes the buffer, which wakes
the webhook, which makes msgmerge rewrite every `.po` file. Three such Weblate
commits are already in the buffer, each touching all nine language files for
zero translated string:

| Weblate commit | `.po` rewritten | `msgstr` changed | `#:` lines |
| --- | --- | --- | --- |
| `e51238a` | 9 | 0 | 207 |
| `4805eee` | 9 | 0 | 108 |
| `8d218ea` | 9 | 0 | 144 |

Replayed on the nine extraction commits so far, the new guard skips exactly the
three that change no msgid and keeps the six that carry a real change:

| commit | msgid changed | old guard | new guard |
| --- | --- | --- | --- |
| `c4a2a91` | 0 | committed | **skipped** |
| `e3a75c3` | 0 | committed | **skipped** |
| `676eb3d` | 2 | committed | committed |
| `c8f39bf` | 10 | committed | committed |
| `f3f52ca` | 5 | committed | committed |
| `b15471b` | 0 | committed | **skipped** |
| `507c9cc` | 4 | committed | committed |
| `e85d9e5` | 2 | committed | committed |
| `123151a` | 1 | committed | committed |

`-I` ignores a hunk only when every changed line in it matches, so an added or
removed msgid is still committed even when surrounded by location churn. On a
whole-file renumbering the guard can still fire, because git sometimes aligns an
identical line inside a block of changed locations -- the failure mode is one
harmless extra commit, never a missed change.

Same change as on rero-ils ([rero/rero-ils#4221](https://github.com/rero/rero-ils/pull/4221)),
so the two workflows stay identical apart from the repository name and the
template path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)