### PR TITLE
fix(documents): correct RIS/BibTeX export

### DIFF
--- a/sonar/modules/documents/serializers/bibtex.py
+++ b/sonar/modules/documents/serializers/bibtex.py
@@ -4,15 +4,16 @@
 """BibTeX serializer."""
 
 import re
-import string
 
 from invenio_records_rest.serializers.base import SerializerMixinInterface
 
 from .common import (
+    THESIS_DOCUMENT_TYPES,
     extract_abstract,
     extract_authors,
     extract_dissertation,
     extract_editors,
+    extract_host_publication,
     extract_identifiers,
     extract_journal_info,
     extract_publication_info,
@@ -67,13 +68,15 @@ _COAR_TO_BIBTEX = {
     "coar:c_18hj": "techreport",
     "coar:c_18ws": "techreport",
     "coar:c_18gh": "techreport",
-    "coar:c_46ec": "phdthesis",
+    # Only PHD thesis has a matching entry type. Every other level
+    # rides on "mastersthesis", whose "type" field replaces the printed label.
+    "coar:c_46ec": "mastersthesis",
     "coar:c_7a1f": "mastersthesis",
     "coar:c_db06": "phdthesis",
     "coar:c_bdcc": "mastersthesis",
-    "habilitation_thesis": "phdthesis",
+    "habilitation_thesis": "mastersthesis",
     "advanced_studies_thesis": "mastersthesis",
-    "other_thesis": "phdthesis",
+    "other_thesis": "mastersthesis",
     "coar:c_8042": "techreport",
     "coar:c_1843": "misc",
     "coar:R60J-J5BD": "misc",
@@ -87,13 +90,19 @@ def _bibtex_entry_type(doc_type):
 
 
 def _bibtex_key(metadata):
-    """Generate a BibTeX cite key from first author and year."""
-    authors = extract_authors(metadata)
-    last_name = authors[0].split(",")[0].strip() if authors else "unknown"
+    """Generate a BibTeX cite key from first author (or editor), year and pid.
+
+    The pid keeps keys unique across independent calls (e.g. paginated
+    exports), which share no collision state.
+    """
+    names = extract_authors(metadata) or extract_editors(metadata)
+    last_name = names[0].split(",")[0].strip() if names else "unknown"
     # BibTeX keys cannot contain whitespace: collapse multi-word last names
     # like "van der Berg" into a single token.
     name = re.sub(r"\s+", "", last_name)
-    return f"{name}{extract_year(metadata) or ''}"
+    base = f"{name}{extract_year(metadata) or ''}"
+    pid = metadata.get("pid")
+    return f"{base}-{pid}" if pid else base
 
 
 _BIBTEX_ESCAPE = {
@@ -127,26 +136,12 @@ def _bibtex_field(name, value, escape=True):
     return f"  {name:<12} = {{{text}}}"
 
 
-def serialize_record_to_bibtex(metadata, used_keys=None):
-    """Serialize a document metadata dict to a BibTeX entry string.
-
-    :param used_keys: Optional set of cite keys already emitted in the same
-        export (e.g. a search result with several entries). When the
-        generated key collides with one already in the set, a letter suffix
-        ("a", "b", ...) is appended to keep cite keys unique, as BibTeX
-        consumers can otherwise reject or silently overwrite one entry.
-    """
+def serialize_record_to_bibtex(metadata):
+    """Serialize a document metadata dict to a BibTeX entry string."""
     doc_type = metadata.get("documentType", "")
     entry_type = _bibtex_entry_type(doc_type)
+    is_thesis = doc_type in THESIS_DOCUMENT_TYPES
     key = _bibtex_key(metadata)
-
-    if used_keys is not None:
-        base_key = key
-        suffix_index = 0
-        while key in used_keys:
-            key = f"{base_key}{string.ascii_lowercase[suffix_index]}"
-            suffix_index += 1
-        used_keys.add(key)
 
     fields = []
 
@@ -163,20 +158,27 @@ def serialize_record_to_bibtex(metadata, used_keys=None):
     if title := extract_title(metadata):
         fields.append(_bibtex_field("title", title))
 
-    # Publication info
     _, place, publisher = extract_publication_info(metadata)
+    # A hosted item's publisher/address are those of its container, which does
+    # not always state its place: the record's own is then kept.
+    host_place, host_publisher = extract_host_publication(metadata)
+    if host_publisher:
+        place, publisher = host_place or place, host_publisher
     if year := extract_year(metadata):
         fields.append(_bibtex_field("year", year))
     if place:
         fields.append(_bibtex_field("address", place))
-    if publisher:
-        fields.append(_bibtex_field("publisher", publisher))
 
-    # Thesis: granting institution -> school
-    if entry_type in ("phdthesis", "mastersthesis"):
-        _, school, _ = extract_dissertation(metadata)
-        if school:
+    # Thesis: "school" is the publisher slot of a thesis entry.
+    # "type" states the precise degree.
+    if is_thesis:
+        degree, institution, _ = extract_dissertation(metadata)
+        if school := institution or publisher:
             fields.append(_bibtex_field("school", school))
+        if degree:
+            fields.append(_bibtex_field("type", degree))
+    elif publisher:
+        fields.append(_bibtex_field("publisher", publisher))
 
     # Host document: journal for articles, book/proceedings title otherwise
     journal, volume, issue, pages = extract_journal_info(metadata)
@@ -191,13 +193,20 @@ def serialize_record_to_bibtex(metadata, used_keys=None):
         fields.append(_bibtex_field("pages", pages))
 
     # Identifiers
-    doi, isbn, issn = extract_identifiers(metadata)
+    doi, isbn, issn, other_identifiers = extract_identifiers(metadata)
     if doi:
         fields.append(_bibtex_field("doi", doi, escape=False))
     if isbn:
         fields.append(_bibtex_field("isbn", isbn, escape=False))
     if issn:
         fields.append(_bibtex_field("issn", issn, escape=False))
+    # BibTeX field names must be unique within an entry: number repeated
+    # "other" identifier labels instead of overwriting the earlier field.
+    label_counts = {}
+    for label, value in other_identifiers:
+        label_counts[label] = label_counts.get(label, 0) + 1
+        field_name = label if label_counts[label] == 1 else f"{label}{label_counts[label]}"
+        fields.append(_bibtex_field(field_name, value, escape=False))
 
     # Abstract
     if abstract := extract_abstract(metadata):
@@ -222,9 +231,5 @@ class BibTeXSerializer(SerializerMixinInterface):
 
     def serialize_search(self, pid_fetcher, search_result, links=None, item_links_factory=None):
         """Serialize search results to BibTeX (one entry per hit)."""
-        used_keys = set()
-        entries = [
-            serialize_record_to_bibtex(unwrap_metadata(hit["_source"]), used_keys=used_keys)
-            for hit in search_result["hits"]["hits"]
-        ]
+        entries = [serialize_record_to_bibtex(unwrap_metadata(hit["_source"])) for hit in search_result["hits"]["hits"]]
         return "\n\n".join(entries)

--- a/sonar/modules/documents/serializers/common.py
+++ b/sonar/modules/documents/serializers/common.py
@@ -3,6 +3,12 @@
 
 """Shared metadata extraction helpers for citation serializers (BibTeX, RIS)."""
 
+from sonar.modules.documents.citations.type_mapping import TYPE_MAPPING
+
+#: Document types the exporters handle as a thesis, derived from the CSL type
+#: mapping so a new thesis type is classified in a single place.
+THESIS_DOCUMENT_TYPES = frozenset(doc_type for doc_type, csl_type in TYPE_MAPPING.items() if csl_type == "thesis")
+
 
 def unwrap_metadata(record):
     """Return a record's metadata dict, keeping "pid"/"permalink" reachable.
@@ -92,6 +98,27 @@ def extract_journal_info(metadata):
     return journal, part.get("numberingVolume"), part.get("numberingIssue"), part.get("numberingPages")
 
 
+def extract_host_publication(metadata):
+    """Return (place, publisher) parsed from the host document's publication statement.
+
+    A hosted item's publisher and place are those of its container in
+    BibTeX, RIS and CSL alike. The host holds them as a single ISBD-shaped
+    statement ("Paris : PUF, 2016"), which both formats want split and
+    without the date. The date closes the statement, so whatever follows the last
+    comma is dropped. Entries carrying no statement are skipped; a statement
+    that does not split becomes the publisher alone.
+    """
+    for part in metadata.get("partOf", []):
+        statement = part.get("document", {}).get("publication", {}).get("statement")
+        if not statement:
+            continue
+        place, _, publisher = statement.partition(":")
+        if publisher.strip():
+            return place.strip() or None, publisher.rsplit(",", 1)[0].strip() or None
+        return None, place.rsplit(",", 1)[0].strip() or None
+    return None, None
+
+
 def extract_abstract(metadata):
     """Return the first non-empty abstract value."""
     for abstract in metadata.get("abstracts", []):
@@ -123,21 +150,30 @@ def extract_dissertation(metadata):
 
 
 def extract_identifiers(metadata):
-    """Return DOI, ISBN and ISSN, falling back to the host document (partOf).
+    """Return (doi, isbn, issn, other_identifiers).
 
-    A journal's ISSN or a host book's ISBN is stored in partOf for articles
-    and book chapters, not at the top level. The top level wins when present.
+    other_identifiers lists every non-DOI/ISBN/ISSN identifier as
+    (label, value) pairs, in encounter order, including repeats of the
+    same type.
     """
     result = {}
+    other_identifiers = []
     sources = [metadata.get("identifiedBy", [])]
     sources += [p.get("document", {}).get("identifiedBy", []) for p in metadata.get("partOf", [])]
     type_map = {"bf:Doi": "doi", "bf:Isbn": "isbn", "bf:Issn": "issn", "bf:IssnL": "issn"}
     for identifiers in sources:
         for identifier in identifiers:
-            key = type_map.get(identifier.get("type"))
-            if key and identifier.get("value") and key not in result:
-                result[key] = identifier["value"]
-    return result.get("doi"), result.get("isbn"), result.get("issn")
+            value = identifier.get("value")
+            if not value:
+                continue
+            id_type = identifier.get("type")
+            key = type_map.get(id_type)
+            if key:
+                if key not in result:
+                    result[key] = value
+            else:
+                other_identifiers.append(((id_type or "bf:Identifier").removeprefix("bf:").lower(), value))
+    return result.get("doi"), result.get("isbn"), result.get("issn"), other_identifiers
 
 
 def extract_url(metadata):

--- a/sonar/modules/documents/serializers/ris.py
+++ b/sonar/modules/documents/serializers/ris.py
@@ -8,10 +8,12 @@ import re
 from invenio_records_rest.serializers.base import SerializerMixinInterface
 
 from .common import (
+    THESIS_DOCUMENT_TYPES,
     extract_abstract,
     extract_authors,
     extract_dissertation,
     extract_editors,
+    extract_host_publication,
     extract_identifiers,
     extract_journal_info,
     extract_publication_info,
@@ -111,21 +113,27 @@ def serialize_record_to_ris(metadata):
     if title := extract_title(metadata):
         lines.append(_ris_line("TI", title))
 
-    # Publication info
+    # Publication info: a hosted item's place/publisher are those of its
+    # container, which does not always state its place: the record's own is
+    # then kept.
     _, place, publisher = extract_publication_info(metadata)
+    host_place, host_publisher = extract_host_publication(metadata)
+    if host_publisher:
+        place, publisher = host_place or place, host_publisher
     if year := extract_year(metadata):
         lines.append(_ris_line("PY", year))
     if place:
         lines.append(_ris_line("CY", place))
 
-    # Thesis: institution -> PB (if not already set), degree -> M3
-    if doc_type == "THES":
+    # Thesis: PB is a single slot, so the granting institution overrides the
+    # generic publisher there; M3 states the degree.
+    if metadata.get("documentType") in THESIS_DOCUMENT_TYPES:
         degree, institution, _ = extract_dissertation(metadata)
-        if institution and not publisher:
-            lines.append(_ris_line("PB", institution))
+        if issuer := institution or publisher:
+            lines.append(_ris_line("PB", issuer))
         if degree:
             lines.append(_ris_line("M3", degree))
-    if publisher:
+    elif publisher:
         lines.append(_ris_line("PB", publisher))
 
     # Host document: JO for journals, T2 (secondary title) for chapters/proceedings
@@ -137,21 +145,22 @@ def serialize_record_to_ris(metadata):
         lines.append(_ris_line("VL", volume))
     if issue:
         lines.append(_ris_line("IS", issue))
-    if pages:
-        page_numbers = re.findall(r"\d+", pages)
-        if page_numbers:
-            lines.append(_ris_line("SP", page_numbers[0]))
-            if len(page_numbers) > 1:
-                lines.append(_ris_line("EP", page_numbers[1]))
+    if pages and (page_numbers := re.findall(r"\d+", pages)):
+        lines.append(_ris_line("SP", page_numbers[0]))
+        if len(page_numbers) > 1:
+            lines.append(_ris_line("EP", page_numbers[1]))
 
     # Identifiers
-    doi, isbn, issn = extract_identifiers(metadata)
+    doi, isbn, issn, other_identifiers = extract_identifiers(metadata)
     if doi:
         lines.append(_ris_line("DO", doi))
     if isbn:
         lines.append(_ris_line("SN", isbn))
     if issn:
         lines.append(_ris_line("SN", issn))
+    # RIS has no dedicated tag for ark/URN/local/report-number-style
+    # identifiers: export them as labeled notes instead of dropping them.
+    lines.extend(_ris_line("N1", f"{label.upper()}: {value}") for label, value in other_identifiers)
 
     # Abstract
     if abstract := extract_abstract(metadata):

--- a/tests/unit/documents/serializers/test_bibtex.py
+++ b/tests/unit/documents/serializers/test_bibtex.py
@@ -13,6 +13,7 @@ from sonar.modules.documents.serializers.bibtex import (
     _bibtex_key,
     serialize_record_to_bibtex,
 )
+from sonar.modules.documents.serializers.common import THESIS_DOCUMENT_TYPES
 
 
 def test_bibtex_coar_mapping_is_complete():
@@ -22,11 +23,16 @@ def test_bibtex_coar_mapping_is_complete():
     assert coar_types <= _COAR_TO_BIBTEX.keys()
 
 
-def test_bibtex_coar_mapping_conference_and_bachelor():
-    """Conference papers, proceedings and bachelor theses map to their dedicated entry types."""
+def test_bibtex_coar_mapping_conference_types():
+    """Conference papers and proceedings map to their dedicated entry types."""
     assert _COAR_TO_BIBTEX["coar:c_5794"] == "inproceedings"
     assert _COAR_TO_BIBTEX["coar:c_f744"] == "proceedings"
-    assert _COAR_TO_BIBTEX["coar:c_7a1f"] == "mastersthesis"
+
+
+def test_bibtex_coar_mapping_thesis_entry_types():
+    """Only a doctoral thesis is a phdthesis; every other level rides on mastersthesis."""
+    assert _COAR_TO_BIBTEX["coar:c_db06"] == "phdthesis"
+    assert {_COAR_TO_BIBTEX[doc_type] for doc_type in THESIS_DOCUMENT_TYPES - {"coar:c_db06"}} == {"mastersthesis"}
 
 
 def test_bibtex_key_multi_word_last_name():
@@ -83,6 +89,169 @@ def test_bibtex_thesis_school():
     assert "school       = {University of Example}," in serialize_record_to_bibtex(metadata)
 
 
+def test_bibtex_thesis_degree_uses_type_field_regardless_of_entry_type():
+    """A thesis states its degree via "type", as the entry type cannot tell a bachelor's from a PhD."""
+    metadata = {
+        "documentType": "coar:c_7a1f",
+        "dissertation": {"grantingInstitution": "Example University", "degree": "Travail de bachelor"},
+    }
+    result = serialize_record_to_bibtex(metadata)
+    assert result.startswith("@mastersthesis{")
+    assert "type         = {Travail de bachelor}," in result
+
+
+def test_bibtex_all_thesis_types_export_school_and_degree():
+    """Every thesis document type exports its school and degree, whatever its entry type."""
+    for doc_type in THESIS_DOCUMENT_TYPES:
+        metadata = {
+            "documentType": doc_type,
+            "dissertation": {"grantingInstitution": "Example University", "degree": "Travail de bachelor"},
+        }
+        result = serialize_record_to_bibtex(metadata)
+        assert "school       = {Example University}," in result
+        assert "type         = {Travail de bachelor}," in result
+
+
+def test_bibtex_thesis_institution_overrides_publisher_but_keeps_place():
+    """A thesis's granting institution takes the publisher slot, its own place is kept."""
+    metadata = {
+        "documentType": "coar:c_7a1f",
+        "provisionActivity": [
+            {
+                "type": "bf:Publication",
+                "startDate": "2017",
+                "statement": [
+                    {"type": "bf:Place", "label": [{"value": "Experimenton"}]},
+                    {"type": "bf:Agent", "label": [{"value": "Mirage Editions"}]},
+                ],
+            }
+        ],
+        "dissertation": {"grantingInstitution": "École des hautes études partagées", "degree": "Travail de bachelor"},
+    }
+    result = serialize_record_to_bibtex(metadata)
+    assert "school       = {École des hautes études partagées}," in result
+    assert "address      = {Experimenton}," in result
+    assert "publisher" not in result
+
+
+def test_bibtex_thesis_school_falls_back_to_own_publisher():
+    """A thesis with no granting institution fills its school with its own publisher."""
+    metadata = {
+        "documentType": "coar:c_db06",
+        "provisionActivity": [
+            {
+                "type": "bf:Publication",
+                "statement": [{"type": "bf:Agent", "label": [{"value": "Université de l'Exemple"}]}],
+            }
+        ],
+    }
+    result = serialize_record_to_bibtex(metadata)
+    assert "school       = {Université de l'Exemple}," in result
+    assert "publisher" not in result
+
+
+def test_bibtex_hosted_item_keeps_its_own_place_and_publisher():
+    """A hosted item keeps its own place/publisher, which the host does not provide."""
+    metadata = {
+        "documentType": "coar:c_6501",
+        "provisionActivity": [
+            {
+                "type": "bf:Publication",
+                "startDate": "2021",
+                "statement": [
+                    {"type": "bf:Place", "label": [{"value": "Hypothetica"}]},
+                    {"type": "bf:Agent", "label": [{"value": "Conceptual Press"}]},
+                ],
+            }
+        ],
+        "partOf": [{"document": {"title": "Transactions on Conceptual Systems"}, "numberingYear": "2007"}],
+    }
+    result = serialize_record_to_bibtex(metadata)
+    assert "address      = {Hypothetica}," in result
+    assert "publisher    = {Conceptual Press}," in result
+    assert "journal      = {Transactions on Conceptual Systems}," in result
+
+
+def test_bibtex_host_publication_statement_fills_publisher_and_address():
+    """A chapter's publisher/address come from the host publication statement."""
+    metadata = {
+        "documentType": "coar:c_3248",
+        "provisionActivity": [
+            {
+                "type": "bf:Publication",
+                "startDate": "2016",
+                "statement": [{"type": "bf:Agent", "label": [{"value": "Imported Press"}]}],
+            }
+        ],
+        "partOf": [{"document": {"title": "Le livre hôte", "publication": {"statement": "Paris : PUF, 2016"}}}],
+    }
+    result = serialize_record_to_bibtex(metadata)
+    assert "address      = {Paris}," in result
+    assert "publisher    = {PUF}," in result
+    assert "Imported Press" not in result
+
+
+def test_bibtex_host_statement_without_place_keeps_the_record_place():
+    """A host statement stating only its publisher leaves the record's own address in place."""
+    metadata = {
+        "documentType": "coar:c_3248",
+        "provisionActivity": [
+            {
+                "type": "bf:Publication",
+                "startDate": "2016",
+                "statement": [
+                    {"type": "bf:Place", "label": [{"value": "Genève"}]},
+                    {"type": "bf:Agent", "label": [{"value": "Droz"}]},
+                ],
+            }
+        ],
+        "partOf": [{"document": {"title": "Le livre hôte", "publication": {"statement": "PUF"}}}],
+    }
+    result = serialize_record_to_bibtex(metadata)
+    assert "address      = {Genève}," in result
+    assert "publisher    = {PUF}," in result
+
+
+def test_bibtex_series_entry_does_not_replace_own_publisher():
+    """A monograph in a series keeps its own place/publisher, as a series carries no statement."""
+    metadata = {
+        "documentType": "coar:c_2f33",
+        "provisionActivity": [
+            {
+                "type": "bf:Publication",
+                "startDate": "2019",
+                "statement": [
+                    {"type": "bf:Place", "label": [{"value": "Bern"}]},
+                    {"type": "bf:Agent", "label": [{"value": "Peter Lang"}]},
+                ],
+            }
+        ],
+        "partOf": [{"document": {"title": "Studien zur Germanistik"}, "numberingVolume": "12"}],
+    }
+    result = serialize_record_to_bibtex(metadata)
+    assert "address      = {Bern}," in result
+    assert "publisher    = {Peter Lang}," in result
+
+
+def test_bibtex_other_identifiers_get_their_own_field():
+    """Identifiers with no dedicated BibTeX field (ark, URN...) are kept, not dropped."""
+    metadata = {"identifiedBy": [{"type": "bf:Urn", "value": "Urn-000307"}]}
+    assert "urn          = {Urn-000307}," in serialize_record_to_bibtex(metadata)
+
+
+def test_bibtex_duplicate_identifier_types_get_numbered_fields():
+    """Two identifiers of the same "other" type produce distinct field names, as BibTeX requires unique names."""
+    metadata = {
+        "identifiedBy": [
+            {"type": "ark", "value": "ark-000279"},
+            {"type": "ark", "value": "ark:/99999/ffk3312"},
+        ]
+    }
+    result = serialize_record_to_bibtex(metadata)
+    assert "ark          = {ark-000279}," in result
+    assert "ark2         = {ark:/99999/ffk3312}," in result
+
+
 def test_bibtex_escapes_special_characters():
     """LaTeX special characters are escaped in free-text fields."""
     metadata = {"title": [{"mainTitle": [{"value": "100% AT&T's Report_v2"}]}]}
@@ -123,20 +292,35 @@ def test_bibtex_escapes_backslash_in_single_pass():
     assert r"\{\}" not in result
 
 
-def test_bibtex_serialize_search_deduplicates_cite_keys():
-    """Two records with the same author surname and year get distinct cite keys."""
+def test_bibtex_key_uses_pid_for_uniqueness_across_independent_calls():
+    """Cite keys stay unique across independent calls, which share no collision state."""
     metadata1 = {
-        "contribution": [{"agent": {"type": "bf:Person", "preferred_name": "Smith, John"}, "role": ["cre"]}],
-        "provisionActivity": [{"type": "bf:Publication", "startDate": "2020", "statement": []}],
+        "pid": "161",
+        "permalink": "https://sonar.example/documents/161",
+        "contribution": [{"agent": {"type": "bf:Person", "preferred_name": "Huang, Mei"}, "role": ["cre"]}],
+        "provisionActivity": [{"type": "bf:Publication", "startDate": "2024", "statement": []}],
     }
     metadata2 = {
-        "contribution": [{"agent": {"type": "bf:Person", "preferred_name": "Smith, Jane"}, "role": ["cre"]}],
-        "provisionActivity": [{"type": "bf:Publication", "startDate": "2020", "statement": []}],
+        "pid": "75",
+        "permalink": "https://sonar.example/documents/75",
+        "contribution": [{"agent": {"type": "bf:Person", "preferred_name": "Huang, Wei"}, "role": ["cre"]}],
+        "provisionActivity": [{"type": "bf:Publication", "startDate": "2024", "statement": []}],
     }
-    search_result = {"hits": {"hits": [{"_source": {"metadata": metadata1}}, {"_source": {"metadata": metadata2}}]}}
-    result = BibTeXSerializer().serialize_search(None, search_result)
-    assert "@misc{Smith2020," in result
-    assert "@misc{Smith2020a," in result
+    # Each call is independent, exactly like two separate pages of a
+    # paginated bulk export.
+    result1 = serialize_record_to_bibtex(metadata1)
+    result2 = serialize_record_to_bibtex(metadata2)
+    assert "@misc{Huang2024-161," in result1
+    assert "@misc{Huang2024-75," in result2
+
+
+def test_bibtex_key_falls_back_to_editor_when_no_author():
+    """The cite key uses the first editor's surname when there is no author."""
+    metadata = {
+        "contribution": [{"agent": {"type": "bf:Person", "preferred_name": "Bonnet, Lars"}, "role": ["edt"]}],
+        "provisionActivity": [{"type": "bf:Publication", "startDate": "2021", "statement": []}],
+    }
+    assert _bibtex_key(metadata) == "Bonnet2021"
 
 
 def test_bibtex_serialize_search_unwraps_sibling_permalink():

--- a/tests/unit/documents/serializers/test_common_serializer_helpers.py
+++ b/tests/unit/documents/serializers/test_common_serializer_helpers.py
@@ -8,6 +8,7 @@ from sonar.modules.documents.serializers.common import (
     extract_authors,
     extract_dissertation,
     extract_editors,
+    extract_host_publication,
     extract_identifiers,
     extract_journal_info,
     extract_publication_info,
@@ -146,6 +147,36 @@ def test_extract_journal_info_missing():
     assert extract_journal_info({}) == (None, None, None, None)
 
 
+def test_extract_host_publication_splits_the_isbd_statement():
+    """An ISBD-shaped host statement yields the place and the publisher, whatever date closes it."""
+    for statement in ("Paris : PUF", "Paris : PUF, 2016", "Paris : PUF, cop. 2016", "Paris : PUF, [2016-2018]"):
+        metadata = {"partOf": [{"document": {"publication": {"statement": statement}}}]}
+        assert extract_host_publication(metadata) == ("Paris", "PUF")
+
+
+def test_extract_host_publication_without_place():
+    """A statement with no separator is the publisher alone, never a place."""
+    for statement in ("PUF", "PUF, 2016"):
+        metadata = {"partOf": [{"document": {"publication": {"statement": statement}}}]}
+        assert extract_host_publication(metadata) == (None, "PUF")
+
+
+def test_extract_host_publication_skips_entries_without_statement():
+    """A series entry (no statement) is skipped in favour of the host that has one."""
+    metadata = {
+        "partOf": [
+            {"document": {"title": "Studien zur Germanistik"}, "numberingVolume": "12"},
+            {"document": {"publication": {"statement": "Bern : Peter Lang, 2019"}}},
+        ]
+    }
+    assert extract_host_publication(metadata) == ("Bern", "Peter Lang")
+
+
+def test_extract_host_publication_missing():
+    """No partOf statement at all returns a tuple of None."""
+    assert extract_host_publication({"partOf": [{"numberingYear": "2019"}]}) == (None, None)
+
+
 def test_extract_abstract():
     """The first non-empty abstract value is returned."""
     metadata = {"abstracts": [{"value": ""}, {"value": "Real abstract"}, {"value": "Second abstract"}]}
@@ -200,13 +231,13 @@ def test_extract_identifiers_top_level():
             {"type": "bf:Issn", "value": "1234-5678"},
         ]
     }
-    assert extract_identifiers(metadata) == ("10.1000/abc", "978-3-16-148410-0", "1234-5678")
+    assert extract_identifiers(metadata) == ("10.1000/abc", "978-3-16-148410-0", "1234-5678", [])
 
 
 def test_extract_identifiers_falls_back_to_part_of():
     """The host document's ISSN is used when there is none at the top level."""
     metadata = {"partOf": [{"document": {"identifiedBy": [{"type": "bf:Issn", "value": "1234-5678"}]}}]}
-    assert extract_identifiers(metadata) == (None, None, "1234-5678")
+    assert extract_identifiers(metadata) == (None, None, "1234-5678", [])
 
 
 def test_extract_identifiers_top_level_wins_over_part_of():
@@ -215,12 +246,43 @@ def test_extract_identifiers_top_level_wins_over_part_of():
         "identifiedBy": [{"type": "bf:Issn", "value": "1111-1111"}],
         "partOf": [{"document": {"identifiedBy": [{"type": "bf:Issn", "value": "2222-2222"}]}}],
     }
-    assert extract_identifiers(metadata) == (None, None, "1111-1111")
+    assert extract_identifiers(metadata) == (None, None, "1111-1111", [])
 
 
 def test_extract_identifiers_missing():
-    """No identifiedBy nor partOf field returns a tuple of None."""
-    assert extract_identifiers({}) == (None, None, None)
+    """No identifiedBy nor partOf field returns a tuple of None and an empty list."""
+    assert extract_identifiers({}) == (None, None, None, [])
+
+
+def test_extract_identifiers_other_types_are_all_preserved():
+    """Non-DOI/ISBN/ISSN identifiers are all returned, including repeats of the same type."""
+    metadata = {
+        "identifiedBy": [
+            {"type": "ark", "value": "ark-000279"},
+            {"type": "ark", "value": "ark:/99999/ffk3312"},
+            {"type": "bf:Urn", "value": "Urn-000307"},
+            {"type": "bf:Local", "value": "LOCAL-1"},
+        ]
+    }
+    _, _, _, other = extract_identifiers(metadata)
+    assert other == [
+        ("ark", "ark-000279"),
+        ("ark", "ark:/99999/ffk3312"),
+        ("urn", "Urn-000307"),
+        ("local", "LOCAL-1"),
+    ]
+
+
+def test_extract_identifiers_label_comes_from_the_type():
+    """Any identifier type is labeled from its own name, including one added later."""
+    metadata = {
+        "identifiedBy": [
+            {"type": "bf:ReportNumber", "value": "R-1"},
+            {"type": "bf:SomeFutureType", "value": "X"},
+        ]
+    }
+    _, _, _, other = extract_identifiers(metadata)
+    assert other == [("reportnumber", "R-1"), ("somefuturetype", "X")]
 
 
 def test_extract_url_uses_permalink_when_present():

--- a/tests/unit/documents/serializers/test_ris.py
+++ b/tests/unit/documents/serializers/test_ris.py
@@ -78,6 +78,140 @@ def test_ris_thesis_institution_and_degree():
     assert "M3  - PhD" in result
 
 
+def test_ris_thesis_institution_overrides_publisher_but_keeps_place():
+    """A thesis's granting institution takes the PB slot, its own place is kept."""
+    metadata = {
+        "documentType": "coar:c_7a1f",
+        "provisionActivity": [
+            {
+                "type": "bf:Publication",
+                "startDate": "2017",
+                "statement": [
+                    {"type": "bf:Place", "label": [{"value": "Experimenton"}]},
+                    {"type": "bf:Agent", "label": [{"value": "Mirage Editions"}]},
+                ],
+            }
+        ],
+        "dissertation": {"grantingInstitution": "École des hautes études partagées", "degree": "Travail de bachelor"},
+    }
+    result = serialize_record_to_ris(metadata)
+    assert "PB  - École des hautes études partagées" in result
+    assert "CY  - Experimenton" in result
+    assert "Mirage Editions" not in result
+
+
+def test_ris_thesis_publisher_used_without_granting_institution():
+    """A thesis with no granting institution keeps its own publisher as PB."""
+    metadata = {
+        "documentType": "coar:c_db06",
+        "provisionActivity": [
+            {
+                "type": "bf:Publication",
+                "statement": [{"type": "bf:Agent", "label": [{"value": "Université de l'Exemple"}]}],
+            }
+        ],
+    }
+    assert "PB  - Université de l'Exemple" in serialize_record_to_ris(metadata)
+
+
+def test_ris_hosted_item_keeps_its_own_place_and_publisher():
+    """A hosted item keeps its own place/publisher, which the host does not provide."""
+    metadata = {
+        "documentType": "coar:c_6501",
+        "provisionActivity": [
+            {
+                "type": "bf:Publication",
+                "startDate": "2021",
+                "statement": [
+                    {"type": "bf:Place", "label": [{"value": "Hypothetica"}]},
+                    {"type": "bf:Agent", "label": [{"value": "Conceptual Press"}]},
+                ],
+            }
+        ],
+        "partOf": [{"document": {"title": "Transactions on Conceptual Systems"}, "numberingYear": "2007"}],
+    }
+    result = serialize_record_to_ris(metadata)
+    assert "CY  - Hypothetica" in result
+    assert "PB  - Conceptual Press" in result
+    assert "JO  - Transactions on Conceptual Systems" in result
+
+
+def test_ris_host_publication_statement_fills_publisher_and_place():
+    """A chapter's PB/CY come from the host publication statement."""
+    metadata = {
+        "documentType": "coar:c_3248",
+        "provisionActivity": [
+            {
+                "type": "bf:Publication",
+                "startDate": "2016",
+                "statement": [{"type": "bf:Agent", "label": [{"value": "Imported Press"}]}],
+            }
+        ],
+        "partOf": [{"document": {"title": "Le livre hôte", "publication": {"statement": "Paris : PUF, 2016"}}}],
+    }
+    result = serialize_record_to_ris(metadata)
+    assert "CY  - Paris" in result
+    assert "PB  - PUF" in result
+    assert "Imported Press" not in result
+
+
+def test_ris_host_statement_without_place_keeps_the_record_place():
+    """A host statement stating only its publisher leaves the record's own CY in place."""
+    metadata = {
+        "documentType": "coar:c_3248",
+        "provisionActivity": [
+            {
+                "type": "bf:Publication",
+                "startDate": "2016",
+                "statement": [
+                    {"type": "bf:Place", "label": [{"value": "Genève"}]},
+                    {"type": "bf:Agent", "label": [{"value": "Droz"}]},
+                ],
+            }
+        ],
+        "partOf": [{"document": {"title": "Le livre hôte", "publication": {"statement": "PUF"}}}],
+    }
+    result = serialize_record_to_ris(metadata)
+    assert "CY  - Genève" in result
+    assert "PB  - PUF" in result
+
+
+def test_ris_series_entry_does_not_replace_own_publisher():
+    """A monograph in a series keeps its own place/publisher, as a series carries no statement."""
+    metadata = {
+        "documentType": "coar:c_2f33",
+        "provisionActivity": [
+            {
+                "type": "bf:Publication",
+                "startDate": "2019",
+                "statement": [
+                    {"type": "bf:Place", "label": [{"value": "Bern"}]},
+                    {"type": "bf:Agent", "label": [{"value": "Peter Lang"}]},
+                ],
+            }
+        ],
+        "partOf": [{"document": {"title": "Studien zur Germanistik"}, "numberingVolume": "12"}],
+    }
+    result = serialize_record_to_ris(metadata)
+    assert "CY  - Bern" in result
+    assert "PB  - Peter Lang" in result
+
+
+def test_ris_other_identifiers_are_exported_as_notes():
+    """Identifiers with no dedicated RIS tag (ark, URN...) are kept as notes, not dropped."""
+    metadata = {
+        "identifiedBy": [
+            {"type": "ark", "value": "ark-000279"},
+            {"type": "ark", "value": "ark:/99999/ffk3312"},
+            {"type": "bf:Urn", "value": "Urn-000307"},
+        ]
+    }
+    result = serialize_record_to_ris(metadata)
+    assert "N1  - ARK: ark-000279" in result
+    assert "N1  - ARK: ark:/99999/ffk3312" in result
+    assert "N1  - URN: Urn-000307" in result
+
+
 def test_ris_pages_with_double_dash():
     """A page range using a double dash is still parsed correctly."""
     metadata = {"partOf": [{"numberingPages": "135--142"}]}


### PR DESCRIPTION
Follow-up to https://github.com/rero/sonar/pull/1130, from an audit of the export against the source JSON
of a full test corpus.

* Place and publisher now follow what BibTeX, RIS and CSL expect for a
  hosted item: the host publication statement, split from its ISBD form
  ("Paris : PUF, 2016"), takes that slot when present, otherwise the
  record's own provisionActivity keeps it. No exporter read the statement
  until now, leaving @incollection without its required publisher.

* A thesis fills the same slot with its granting institution (BibTeX
  school, RIS PB) and states its degree in BibTeX type. Only a doctoral
  thesis maps to phdthesis; every other level rides on mastersthesis,
  whose printed label type replaces. Thesis detection keys off
  documentType, not off the entry type, which cannot tell the levels
  apart.

* extract_identifiers() dropped every non-DOI/ISBN/ISSN identifier (ark,
  URN, Local, ReportNumber...), about half of the corpus. They are now
  exported as RIS N1 notes and as BibTeX fields named after the type,
  numbered when a type repeats.

* BibTeX cite keys ("{Surname}{Year}") now include the record's pid,
  which makes them unique by construction. The letter-suffix
  disambiguation they relied on could only see the keys of a single
  serialize_search() call: an export assembled from independent calls --
  a paginated search, or repeated single-record exports, which had no
  disambiguation at all -- kept producing collisions, and BibTeX
  consumers either reject or silently merge colliding entries. The
  suffix machinery is dropped with the need for it.